### PR TITLE
List all expected keys of workflow_dispatch input in the error message

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -561,7 +561,7 @@ func (p *parser) parseWorkflowDispatchEventInput(name *String, n *yaml.Node) *Di
 		case "options":
 			ret.Options = p.parseStringSequence("options", e.val, false)
 		default:
-			p.unexpectedKey(e.key, "inputs", []string{"description", "required", "default"})
+			p.unexpectedKey(e.key, "inputs", []string{"description", "required", "default", "type", "options"})
 		}
 	}
 

--- a/testdata/err/case_sensitive_keys.out
+++ b/testdata/err/case_sensitive_keys.out
@@ -1,6 +1,6 @@
 test.yaml:2:1: unexpected key "NAME" for "workflow" section. expected one of "concurrency", "defaults", "env", "jobs", "name", "on", "permissions", "run-name" [syntax-check]
 test.yaml:5:3: unknown Webhook event "SCHEDULE". see https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#webhook-events for list of all Webhook event names [events]
-test.yaml:9:9: unexpected key "DESCRIPTION" for "inputs" section. expected one of "default", "description", "required" [syntax-check]
+test.yaml:9:9: unexpected key "DESCRIPTION" for "inputs" section. expected one of "default", "description", "options", "required", "type" [syntax-check]
 test.yaml:11:5: expected "types" key for "repository_dispatch" section but got "TYPES" [syntax-check]
 test.yaml:15:9: unexpected key "DESCRIPTION" for inputs at workflow_call event. expected one of "default", "description", "required", "type" [syntax-check]
 test.yaml:19:9: unexpected key "DESCRIPTION" for "secrets" section. expected one of "description", "required" [syntax-check]

--- a/testdata/err/unexpected_keys.out
+++ b/testdata/err/unexpected_keys.out
@@ -1,5 +1,5 @@
 test.yaml:3:5: expected "inputs" key for "workflow_dispatch" section but got "invalid_key" [syntax-check]
-test.yaml:6:9: unexpected key "invalid_key" for "inputs" section. expected one of "default", "description", "required" [syntax-check]
+test.yaml:6:9: unexpected key "invalid_key" for "inputs" section. expected one of "default", "description", "options", "required", "type" [syntax-check]
 test.yaml:8:5: expected "types" key for "repository_dispatch" section but got "invalid_key" [syntax-check]
 test.yaml:10:5: unexpected key "invalid_key" for "push" section. expected one of "branches", "branches-ignore", "paths", "paths-ignore", "tags", "tags-ignore", "types", "workflows" [syntax-check]
 test.yaml:15:9: unexpected key "invalid_key" for inputs at workflow_call event. expected one of "default", "description", "required", "type" [syntax-check]


### PR DESCRIPTION
The parser accepts five keys in a `workflow_dispatch` input — `description`, `required`, `default`, `type` and `options` — but the diagnostic for an unexpected key listed only the first three. Anyone who put `type:` or `options:` next to a typo was told those two keys were not expected, while the parser a few lines above was accepting them.

## Parser

`parse.go:564`, in `parseWorkflowDispatchEventInput`, now passes all five keys to `unexpectedKey`. Nothing else changes: the call sits in the `default` arm of the `switch`, so no parse behaviour is affected and no workflow that linted clean before can start failing. `testdata/ok/workflow_dispatch_input_types.yaml` already uses `type` and `options` across ten inputs and has always linted clean — the parser was right, only the message lied about it.

The message is assembled by `unexpectedKey` (`parse.go:259`), which sorts through `sortedQuotes` (`quotes.go:62`), so the order in the literal does not matter and the rendered list is alphabetical:

```
unexpected key "invalid_key" for "inputs" section. expected one of "default", "description", "options", "required", "type" [syntax-check]
```

The `workflow_call` variant of the same diagnostic (`parse.go:690`) is deliberately untouched. Inputs at a `workflow_call` event have no `options` key, so its four-key list stays as it is. Both golden files carry that line unchanged as diff context.

## Sweep

All 28 `unexpectedKey` call sites in `parse.go` were checked against the `case` arms of their own `switch`, including the `container`/`services` pair where the key set grows conditionally and `command`/`entrypoint` fall through to the six-key list outside `services`. This was the only incomplete list.

## Credit

Ported from https://github.com/rhysd/actionlint/pull/715 by `Socialpranker`.

The one-line parser change and both golden updates are theirs. The upstream patch does not apply cleanly here — its context line calls `parseStringSequence` with four arguments where this fork passes three — so it was applied by hand rather than with `git apply`.

## Verification

```
$ make build SKIP_GO_GENERATE=true
CGO_ENABLED=0 go build ./cmd/actionlint

$ make test
go test -race ./...
ok  	actionlint.kjanat.dev	6.168s
ok  	actionlint.kjanat.dev/cmd/actionlint-action	1.053s
ok  	actionlint.kjanat.dev/fuzz	1.021s
ok  	actionlint.kjanat.dev/scripts/bump-version	2.045s
ok  	actionlint.kjanat.dev/scripts/check-checks	1.977s
ok  	actionlint.kjanat.dev/scripts/generate-availability	1.377s
ok  	actionlint.kjanat.dev/scripts/generate-popular-actions	3.339s
ok  	actionlint.kjanat.dev/scripts/generate-webhook-events	1.305s

$ make lint SKIP_GO_GENERATE=true
golangci-lint run
0 issues.
go run golang.org/x/vuln/cmd/govulncheck@latest ./...
No vulnerabilities found.
GOOS=js GOARCH=wasm golangci-lint run ./playground
0 issues.
go run ./scripts/check-checks -quiet ./docs/checks.md

$ dprint check
(no output, exit 0)
```

Both goldens were updated before the parser change, and both tests failed on exactly the missing `"options"` and `"type"` and on nothing else. Reverting `parse.go:564` reproduces that failure.
