### PR TITLE
Add OCI source and license labels to the runtime image

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -144,7 +144,10 @@ jobs:
           --mount type=bind,source="${PWD}",target=/w
           -- actionlint:test -color -verbose
       - name: Lint Dockerfile with hadolint
-        run: docker run --rm -i hadolint/hadolint hadolint --ignore DL3018 --strict-labels - < Dockerfile
+        run: docker run --rm -i hadolint/hadolint hadolint --ignore DL3018 --strict-labels
+          --require-label org.opencontainers.image.source:url
+          --require-label org.opencontainers.image.licenses:spdx
+          - < Dockerfile
       - name: Lint Dockerfile with droast
         uses: immanuwell/dockerfile-roast@50689402f3eced348cf4bd822ffb57871b5c02d0 # 1.6.1
   action:

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,8 @@ RUN go build -v -ldflags "-s -w -X actionlint.kjanat.dev.version=${ACTIONLINT_VE
 FROM koalaman/shellcheck-alpine:stable AS shellcheck
 
 FROM alpine:${ALPINE_VER} AS runtime
+LABEL org.opencontainers.image.source="https://github.com/kjanat/actionlint"
+LABEL org.opencontainers.image.licenses="MIT"
 COPY --from=builder /go/src/app/actionlint /usr/local/bin/
 COPY --from=shellcheck /bin/shellcheck /usr/local/bin/shellcheck
 RUN apk add --no-cache python3 py3-pyflakes


### PR DESCRIPTION
The published container images carry no OCI metadata, so neither `ghcr.io/kjanat/actionlint` nor the action image says where its source lives or what licence it ships under. GitHub's package page cannot link an image back to this repository without `org.opencontainers.image.source`.

## Dockerfile

Both labels go on the `runtime` stage. `action` and `cli` are both `FROM runtime`, so one pair covers both published images — verified by building both targets and reading them back:

```
cli    : {"org.opencontainers.image.licenses":"MIT","org.opencontainers.image.source":"https://github.com/kjanat/actionlint"}
action : {"org.opencontainers.image.licenses":"MIT","org.opencontainers.image.source":"https://github.com/kjanat/actionlint"}
```

Putting them on `cli` instead leaves `runtime` and `action` uncovered and hadolint still reports DL3049, so the stage choice is load-bearing rather than cosmetic.

`LICENSE.txt` is the MIT text, so `MIT` is the correct SPDX identifier.

## CI

The `docker` job runs `hadolint --strict-labels`, and `--strict-labels` without `--require-label` rejects *any* label as superfluous. Adding the labels alone therefore breaks the job:

```
-:15 DL3050 info: Superfluous label(s) present.
-:16 DL3050 info: Superfluous label(s) present.
```

The two `--require-label` flags declare the schema those labels satisfy. This is the half of the change the upstream patch omits — it adds the labels to a Dockerfile whose CI runs the same `--strict-labels` invocation, so it breaks its own build.

One consequence worth knowing: from here the `docker` job also fails on any future label that is not in the schema, and on any stage that does not inherit these two. That is the intended enforcement.

`droast.toml` keeps `strict-labels` and `[required-labels]` commented out, so it is unaffected. `release.yaml` passes only `index:org.opencontainers.image.description` as an OCI index annotation, which is a different layer from image-config labels, and its `docker/metadata-action` output is used for tags only — no duplicate or conflicting `.source`/`.licenses` anywhere.

## Credit

Ported from https://github.com/rhysd/actionlint/pull/653 by `Nozomi Ishii`.

The two `LABEL` lines are theirs. Changed here: the source URL points at this fork rather than `rhysd/actionlint`, the labels sit on `runtime` to serve this fork's multi-stage layout, and the `--require-label` flags were added because without them the change breaks CI.

## Verification

```
$ make build SKIP_GO_GENERATE=true
CGO_ENABLED=0 go build ./cmd/actionlint

$ go test -race -count=1 ./...
ok  	actionlint.kjanat.dev	524s
(all other packages ok)

$ make lint SKIP_GO_GENERATE=true
golangci-lint run
0 issues.
go run golang.org/x/vuln/cmd/govulncheck@latest ./...
No vulnerabilities found.
GOOS=js GOARCH=wasm golangci-lint run ./playground
0 issues.
go run ./scripts/check-checks -quiet ./docs/checks.md

$ dprint check
(no output, exit 0)
```

hadolint 2.15.1, with the exact invocation the changed `ci.yaml` produces after YAML folding:

```
against origin/main's Dockerfile : exit 1, six DL3049 findings
against this branch's Dockerfile : exit 0
```

The folded `run:` scalar has a continuation line beginning `- < Dockerfile`. Four parsers (PyYAML, yq, js-yaml, Ruby Psych) fold it identically to the command above; the leading `-` is not read as a sequence indicator because it is not the first character of the scalar.

`./actionlint -color -shellcheck 'shellcheck -o all'` over this repository's own workflows: `Found 0 errors in 9 files`. `droast` on the changed Dockerfile: zero findings.
