### PR TITLE
Accept a plus sign and a leading zero in exponent parts of number literals

### DIFF
--- a/expr_lexer.go
+++ b/expr_lexer.go
@@ -323,18 +323,13 @@ func (lex *ExprLexer) lexNum() *Token {
 			r = lex.eat()
 		}
 
-		if r == '0' {
-			r = lex.eat() // eat the '0'
-		} else {
-			// r is 1..9
+		if !isNum(r) {
+			return lex.unexpected(r, "exponent part of float number", expectedDigitChars)
+		}
+		for {
+			r = lex.eat()
 			if !isNum(r) {
-				return lex.unexpected(r, "exponent part of float number", expectedDigitChars)
-			}
-			for {
-				r = lex.eat()
-				if !isNum(r) {
-					break
-				}
+				break
 			}
 		}
 

--- a/expr_lexer.go
+++ b/expr_lexer.go
@@ -319,7 +319,7 @@ func (lex *ExprLexer) lexNum() *Token {
 
 	if r == 'e' || r == 'E' {
 		r = lex.eat() // eat 'e' or 'E'
-		if r == '-' {
+		if r == '-' || r == '+' {
 			r = lex.eat()
 		}
 

--- a/expr_lexer_test.go
+++ b/expr_lexer_test.go
@@ -179,6 +179,26 @@ func TestLexOneToken(t *testing.T) {
 			kind:  TokenKindFloat,
 		},
 		{
+			what:  "int with zero-padded exp part",
+			input: "1e01",
+			kind:  TokenKindFloat,
+		},
+		{
+			what:  "float with zero-padded exp part",
+			input: "1.0e01",
+			kind:  TokenKindFloat,
+		},
+		{
+			what:  "int with zero-padded positive exp part",
+			input: "1e+01",
+			kind:  TokenKindFloat,
+		},
+		{
+			what:  "int with zero-padded negative exp part",
+			input: "1e-01",
+			kind:  TokenKindFloat,
+		},
+		{
 			what:  "float zero with negative exp part",
 			input: "0.0e-99",
 			kind:  TokenKindFloat,
@@ -803,18 +823,6 @@ func TestLexExprError(t *testing.T) {
 			input: "0x0e1",
 			want:  "unexpected character 'e' while lexing character following hex integer 0x0",
 			col:   4,
-		},
-		{
-			what:  "integer exponent part starts with zero",
-			input: "1e01",
-			want:  "unexpected character '1' while lexing character following number 1e0",
-			col:   4,
-		},
-		{
-			what:  "float number exponent part starts with zero",
-			input: "1.0e01",
-			want:  "unexpected character '1' while lexing character following number 1.0e0",
-			col:   6,
 		},
 		{
 			what:  "integer part lacks in float number",

--- a/expr_lexer_test.go
+++ b/expr_lexer_test.go
@@ -164,6 +164,21 @@ func TestLexOneToken(t *testing.T) {
 			kind:  TokenKindFloat,
 		},
 		{
+			what:  "float positive exp part",
+			input: "1.0e+99",
+			kind:  TokenKindFloat,
+		},
+		{
+			what:  "float positive exp part with upper E",
+			input: "1.0E+99",
+			kind:  TokenKindFloat,
+		},
+		{
+			what:  "int with positive exp part",
+			input: "3e+42",
+			kind:  TokenKindFloat,
+		},
+		{
 			what:  "float zero with negative exp part",
 			input: "0.0e-99",
 			kind:  TokenKindFloat,
@@ -667,6 +682,18 @@ func TestLexExprError(t *testing.T) {
 			what:  "no number after - in exponent part",
 			input: "1.0e-",
 			want:  "unexpected EOF while lexing exponent part of float number",
+			col:   6,
+		},
+		{
+			what:  "no number after + in exponent part",
+			input: "1.0e+",
+			want:  "unexpected EOF while lexing exponent part of float number",
+			col:   6,
+		},
+		{
+			what:  "invalid char in exponent part after +",
+			input: "1.0e+_",
+			want:  "unexpected character '_' while lexing exponent part of float number",
 			col:   6,
 		},
 		{

--- a/expr_parser_test.go
+++ b/expr_parser_test.go
@@ -101,6 +101,16 @@ func TestParseExpressionSyntaxOK(t *testing.T) {
 			expected: &FloatNode{Value: -0.123e-12},
 		},
 		{
+			what:     "float literal with positive exponent part",
+			input:    "99e+1",
+			expected: &FloatNode{Value: 99e+1},
+		},
+		{
+			what:     "float literal with fraction and positive exponent part",
+			input:    "0.123e+12",
+			expected: &FloatNode{Value: 0.123e+12},
+		},
+		{
 			what:     "float zero value with exponent part",
 			input:    "0e3",
 			expected: &FloatNode{Value: 0e3},

--- a/expr_parser_test.go
+++ b/expr_parser_test.go
@@ -111,6 +111,11 @@ func TestParseExpressionSyntaxOK(t *testing.T) {
 			expected: &FloatNode{Value: 0.123e+12},
 		},
 		{
+			what:     "float literal with zero-padded exponent part",
+			input:    "1e01",
+			expected: &FloatNode{Value: 1e01},
+		},
+		{
 			what:     "float zero value with exponent part",
 			input:    "0e3",
 			expected: &FloatNode{Value: 0e3},


### PR DESCRIPTION
`${{ 1e+5 }}` is rejected. `${{ 1e01 }}` is rejected. Both are valid JSON, both [evaluate to `100000` and `10` on GitHub](https://github.com/kjanat/actionlint/pull/35), and [GitHub's expression reference](https://docs.github.com/en/actions/reference/workflows-and-actions/expressions#literals) says a `number` literal is "Any number format supported by JSON". The lexer is stricter than the standard actionlint claims to follow.

## The exponent part

Two changes in `ExprLexer.lexNum`, both inside the exponent block.

**A `+` after `e` or `E` is now consumed.** [RFC 8259 §6](https://www.rfc-editor.org/rfc/rfc8259#section-6) gives `exp = e [ minus / plus ] 1*DIGIT`, and the runner's [`ParseNumber`](https://github.com/actions/runner/blob/258d6c857db3519913f7deb6004b60172f8043ae/src/Sdk/DTExpressions2/Expressions2/Sdk/ExpressionUtility.cs#L193-L258) reaches [`Double.TryParse` with `NumberStyles.AllowExponent`](https://github.com/actions/runner/blob/258d6c857db3519913f7deb6004b60172f8043ae/src/Sdk/DTExpressions2/Expressions2/Sdk/ExpressionUtility.cs#L203-L207), which accepts either sign. Found in 23 workflow files, traceable to one line — `if: ${{ env.PKG_SIZE > 1e+8 }}` in [`makepath/mapshader`](https://github.com/makepath/mapshader/blob/master/.github/workflows/pypi-publish.yml) — copied across some fifteen forks.

**A leading zero in the exponent is now allowed.** That restriction came from [rhysd/actionlint@`d14ac7b`](https://github.com/rhysd/actionlint/commit/d14ac7b2d764ed6d54f12a67e67148952a1d61af) ("fix number after 0 did not cause an error in exponent part and hex number", 2021-08-01). It applies JSON's leading-zero rule from the `int` production to the `exp` production, where RFC 8259 requires only `1*DIGIT`.

That commit has one parent and no linked pull request. Every issue and pull request that existed in [the repository](https://github.com/rhysd/actionlint/issues?q=sort%3Acreated-asc) on that date was checked — numbers 1 through 19; number 20 was opened the following day — and none concerns number literals. Occurrences in the wild, after filtering search noise: zero.

Removing that restriction removes two upstream tests, `integer exponent part starts with zero` and `float number exponent part starts with zero`. That is the whole reason the paragraph above exists.

## Not changed

Nine rules separate `lexNum` from what GitHub accepts, and this changes two of them. [A conformance probe](https://github.com/kjanat/actionlint/pull/35) submits each literal to GitHub's own parser and reports the verdict; measured against it, fifteen forms are accepted by GitHub and still rejected here: `00`, `0123`, `1.`, `.5`, `.5e1`, `0o17`, `0x01`, `0x0123`, `0x0e1`, `+1`, `NaN`, `Infinity`, `-Infinity`, `2147483648` and `9007199254740993`. JSON accepts none of them.

Matching the runner is not a clean target here. The [doc comment on `ParseNumber`](https://github.com/actions/runner/blob/258d6c857db3519913f7deb6004b60172f8043ae/src/Sdk/DTExpressions2/Expressions2/Sdk/ExpressionUtility.cs#L189-L192) says it follows JavaScript's `Number()`:

> The rules here attempt to follow Javascript rules for coercing a string into a number for comparison. That is, the Number() function in Javascript.

That contradicts the documented JSON rule, and it follows JavaScript incompletely as well: there is a [hex branch](https://github.com/actions/runner/blob/258d6c857db3519913f7deb6004b60172f8043ae/src/Sdk/DTExpressions2/Expressions2/Sdk/ExpressionUtility.cs#L208-L221) and an [octal branch](https://github.com/actions/runner/blob/258d6c857db3519913f7deb6004b60172f8043ae/src/Sdk/DTExpressions2/Expressions2/Sdk/ExpressionUtility.cs#L222-L244) but none for binary. `Number()` reads `0X1F` as 31, `0O17` as 15, `0b101` as 5 and `1e309` as `Infinity`; GitHub rejects all four. The base prefix is case-sensitive where the exponent marker is not.

Two of the six also reach the number token by a different route than the citation above suggests. `NaN` and `Infinity` are not parsed by `ParseNumber` at all — they are [keywords in `ReadKeywordToken`](https://github.com/actions/runner/blob/258d6c857db3519913f7deb6004b60172f8043ae/src/Sdk/DTExpressions2/Expressions2/Tokens/LexicalAnalyzer.cs#L176-L185). `ParseNumber` returns `Double.NaN` as its [fall-through for anything it does not recognise](https://github.com/actions/runner/blob/258d6c857db3519913f7deb6004b60172f8043ae/src/Sdk/DTExpressions2/Expressions2/Sdk/ExpressionUtility.cs#L256-L257), and [`ReadNumberToken` turns that into `TokenKind.Unexpected`](https://github.com/actions/runner/blob/258d6c857db3519913f7deb6004b60172f8043ae/src/Sdk/DTExpressions2/Expressions2/Tokens/LexicalAnalyzer.cs#L120-L139), so NaN out of `ParseNumber` means rejected. And `.5` is [context-dependent](https://github.com/actions/runner/blob/258d6c857db3519913f7deb6004b60172f8043ae/src/Sdk/DTExpressions2/Expressions2/Tokens/LexicalAnalyzer.cs#L85-L113): a leading `.` only starts a number when the previous token is nothing, a separator, an opening bracket, or an operator.

Being stricter than all of that is defensible as long as each case has a reason, so the two that JSON *and* the runner accept are the two that changed.

Verified by running 28 expressions through binaries built from `main` and from this branch. Nineteen outputs are identical; the nine that differ are exactly the intended ones. All six rejected forms are unchanged down to the column, including `1 + 1`, which was the risk — a change to the exponent block could have disturbed operator lexing.

The hex branch is untouched, and it is one of the nine. GitHub reads `0x01` as `1`, `0x0123` as `291` and `0x0e1` as `225`, and all three are still errors here, as is `0123`. So is `2147483648`, because [`parseInt`](https://github.com/kjanat/actionlint/blob/77bd61b79cfecd46806cc4af085c699069abf9e9/expr_parser.go#L140-L151) parses with a bit size of 32.

## Coverage

`1e+01` is the only form exercising both changes at once, and it fails against either one alone — with two *different* failure points. Revert the plus sign and it stops at the `+`: `unexpected character '+' while lexing exponent part`. Revert the leading-zero change and it gets further, consuming the `+` and the `0`, then stopping at the second digit: `character following number 1e+0`. A test that failed at the same place both times would not prove it covers the combination.

## Credit

The plus-sign commit is ported from [rhysd/actionlint#708](https://github.com/rhysd/actionlint/pull/708) by `semx`; its lexer hunk is byte-identical to upstream [`6f716ad`](https://github.com/rhysd/actionlint/commit/6f716ada0ffa815572fd6a89c8958c2b74d7594b). Added here: an error case for `1.0e+` and `1.0e+_`, and two parser cases — upstream has neither, so the fixed line could have mutated without any test failing.

The leading-zero commit is not from that pull request and carries no trailer. It reverses an upstream decision.

## Verification

```
$ make build SKIP_GO_GENERATE=true
CGO_ENABLED=0 go build ./cmd/actionlint

$ make test
ok  	actionlint.kjanat.dev	414.639s
(all other packages ok)

$ make lint SKIP_GO_GENERATE=true
golangci-lint run
0 issues.
go run golang.org/x/vuln/cmd/govulncheck@latest ./...
No vulnerabilities found.
GOOS=js GOARCH=wasm golangci-lint run ./playground
0 issues.
go run ./scripts/check-checks -quiet ./docs/checks.md

$ dprint check
(no output, exit 0)
```

Each commit's tests were written first and fail against the other commit alone: seven cases for the plus sign, three for the leading zero. Reverting either change reproduces its own failures and leaves the other's green.

https://github.com/kjanat/actionlint/blob/5a1acfde03a899241c109ca4d457a08eafcfe0f3/CHANGELOG.md#L2122

One note for whoever reads this later: `CHANGELOG.md:2122`, the release note for v1.5.2 — the release that shipped `d14ac7b` — describes `0x01` and `1e0123` as invalid numbers. The exponent half is accurate on `main` today and merging this makes it wrong. The hex half is already wrong against GitHub, which reads `0x01` as `1`.

