### PR TITLE
Add a pre-commit hook that installs ShellCheck alongside actionlint

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -167,3 +167,39 @@ jobs:
         }
       - name: Test action image
         run: ./scripts/test-action.bash actionlint-action:test
+  pre-commit-shellcheck:
+    name: pre-commit ShellCheck integration
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with: { persist-credentials: false }
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
+        with: { go-version: "${{ env.GO }}", check-latest: true }
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+      - run: uv tool install pre-commit
+      # pre-commit's golang language prepends to PATH, so the runner's preinstalled shellcheck satisfies actionlint on its own.
+      - name: Remove the runner's ShellCheck so only the hook's own can be found
+        run: |
+          sudo apt-get remove -y shellcheck
+          if command -v shellcheck; then
+            echo "shellcheck is still on PATH; the hook dependency would not be the only source" >&2
+            exit 1
+          fi
+      - name: Confirm actionlint-shellcheck reports a fixture's SC2086
+        run: |
+          cat > .github/workflows/_pre-commit-shellcheck-fixture.yaml <<'FIXTURE'
+          on: push
+          jobs:
+            fixture:
+              runs-on: ubuntu-latest
+              steps:
+                - run: echo $GITHUB_SHA
+          FIXTURE
+          set +e
+          pre-commit try-repo . actionlint-shellcheck --files .github/workflows/_pre-commit-shellcheck-fixture.yaml --verbose > pre-commit-output.txt 2>&1
+          status=$?
+          set -e
+          cat pre-commit-output.txt
+          rm .github/workflows/_pre-commit-shellcheck-fixture.yaml
+          test "${status}" -ne 0
+          grep -q SC2086 pre-commit-output.txt

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -21,3 +21,12 @@
   types: ["yaml"]
   files: ^\.github/workflows/
   entry: actionlint
+- id: actionlint-shellcheck
+  name: Lint GitHub Actions workflow files (with ShellCheck)
+  description: Runs actionlint with the ShellCheck integration enabled via a Go build of ShellCheck
+  language: golang
+  types: ["yaml"]
+  files: ^\.github/workflows/
+  entry: actionlint
+  minimum_pre_commit_version: 3.0.0
+  additional_dependencies: ["github.com/wasilibs/go-shellcheck/cmd/shellcheck@latest"]

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -537,6 +537,7 @@ for the discussion.
 > The configuration below points directly at `kjanat/actionlint`. The
 > `actionlint` hook builds this fork, `actionlint-docker` pulls this fork's
 > image, and `actionlint-system` runs the `actionlint` executable on `PATH`.
+> `actionlint-shellcheck` builds this fork and installs ShellCheck next to it.
 
 [pre-commit][pre-commit] is a framework for managing and maintaining
 multi-language Git pre-commit hooks. actionlint is available as a pre-commit
@@ -553,14 +554,35 @@ repos:
       - id: actionlint
 ```
 
-As alternatives to `actionlint` hook, `actionlint-docker` or `actionlint-system`
-hooks are available.
+As alternatives to `actionlint` hook, `actionlint-docker`, `actionlint-system`,
+or `actionlint-shellcheck` hooks are available.
 
-| Hook ID             | Explanation                                                                                                   |
-| ------------------- | ------------------------------------------------------------------------------------------------------------- |
-| `actionlint`        | Automatically installs `actionlint` command in isolated `$GOPATH` directory using [Go toolchain][go-install]. |
-| `actionlint-docker` | Automatically pulls [the actionlint Docker image](#docker).                                                   |
-| `actionlint-system` | Uses system-installed `actionlint` command. The command is necessary to be [installed manually](install.md).  |
+| Hook ID                 | Explanation                                                                                                                                                                                                                         |
+| ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `actionlint`            | Automatically installs `actionlint` command in isolated `$GOPATH` directory using [Go toolchain][go-install].                                                                                                                       |
+| `actionlint-docker`     | Automatically pulls [the actionlint Docker image](#docker).                                                                                                                                                                         |
+| `actionlint-system`     | Uses system-installed `actionlint` command. The command is necessary to be [installed manually](install.md).                                                                                                                        |
+| `actionlint-shellcheck` | Same as `actionlint`, and additionally installs a Go build of ShellCheck ([`wasilibs/go-shellcheck`][go-shellcheck]) so [the shellcheck integration](checks.md#check-shellcheck-integ) works without a host-installed `shellcheck`. |
+
+The `actionlint` hook installs into an isolated `$GOPATH`, so it only finds a
+`shellcheck` executable that is already on `PATH`.
+
+`actionlint-shellcheck` asks for `@latest`, which resolves when pre-commit first
+builds the hook's environment. pre-commit then caches that environment and does
+not resolve it again, so the version you get is the one that was current when
+you installed the hook, and `pre-commit clean` is what fetches a newer one. To
+choose the version yourself, use `additional_dependencies` on the plain hook:
+
+```yaml
+---
+repos:
+  - repo: https://github.com/kjanat/actionlint
+    rev: v1.12.0
+    hooks:
+      - id: actionlint
+        additional_dependencies:
+          - github.com/wasilibs/go-shellcheck/cmd/shellcheck@v0.11.1
+```
 
 ### VS Code
 
@@ -689,6 +711,7 @@ You can also see actionlint issues inline in VS Code via the [Trunk VS Code exte
 [emacs-melpa]: https://melpa.org/
 [ga-annotate-error]: https://docs.github.com/en/actions/learn-github-actions/workflow-commands-for-github-actions#setting-an-error-message
 [go-install]: https://go.dev/doc/install
+[go-shellcheck]: https://github.com/wasilibs/go-shellcheck
 [go-template]: https://pkg.go.dev/text/template
 [jsonl]: https://jsonlines.org/
 [nova-extension]: https://extensions.panic.com/extensions/org.netwrk/org.netwrk.actionlint/

--- a/scripts/bump-version/targets.go
+++ b/scripts/bump-version/targets.go
@@ -59,10 +59,13 @@ var targets = []*target{
 			mustRule("download script argument", `download-actionlint\.bash\) (\d+\.\d+\.\d+)`, 3),
 			mustRule("CLI image tag example", "`ghcr\\.io/kjanat/actionlint:(\\d+\\.\\d+\\.\\d+)`", 1),
 			mustRule("action image tag example", "`action-(\\d+\\.\\d+\\.\\d+)`", 1),
-			mustRule("pre-commit revision", `(?m)^    rev: v(\d+\.\d+\.\d+)\r?$`, 1),
+			mustRule("pre-commit revision", `(?m)^    rev: v(\d+\.\d+\.\d+)\r?$`, 2),
 			mustRule("Trunk linter version", ` actionlint@(\d+\.\d+\.\d+)`, 2),
 		},
-		unrelated: []string{"sarif/v2.1.0/sarif-v2.1.0.html"},
+		unrelated: []string{
+			"sarif/v2.1.0/sarif-v2.1.0.html",
+			"github.com/wasilibs/go-shellcheck/cmd/shellcheck@v0.11.1",
+		},
 	},
 	{
 		path: "docs/install.md",


### PR DESCRIPTION
actionlint's ShellCheck integration is silent unless a `shellcheck` executable is on `PATH`. The `actionlint` pre-commit hook installs into an isolated `$GOPATH`, so in a pre-commit run it finds one only if the host already has it. A contributor without ShellCheck installed gets a green hook that skipped the check.

<details><summary>Measured</summary>

Same fixture, same binary, twice: once with an empty `PATH`, once with only a ShellCheck build on it.

````console
$ mkdir -p /tmp/scratch-verify-31/nopath-repo/.github/workflows && cd /tmp/scratch-verify-31/nopath-repo && cat > .github/workflows/fixture.yaml <<'EOF'
on: push
jobs:
  fixture:
    runs-on: ubuntu-latest
    steps:
      - run: echo $GITHUB_SHA
EOF
$ mkdir -p /tmp/scratch-verify-31/emptybin
$ env -i PATH=/tmp/scratch-verify-31/emptybin HOME="$HOME" /home/kjanat/projects/actionlint/.worktrees/pre-commit-shellcheck-dep/actionlint -verbose -no-color .github/workflows/fixture.yaml; echo "exit=$?"
verbose: Linting .github/workflows/fixture.yaml
verbose: Found 0 parse errors in 0 ms for .github/workflows/fixture.yaml
verbose: Rule "shellcheck" was disabled: exec: "shellcheck": executable file not found in $PATH
verbose: Rule "pyflakes" was disabled: exec: "pyflakes": executable file not found in $PATH
verbose: Found total 0 errors in 0 ms for .github/workflows/fixture.yaml
exit=0

$ git init -q . 2>/dev/null
$ env -i PATH=/tmp/scratch-verify-31/bin HOME="$HOME" /home/kjanat/projects/actionlint/.worktrees/pre-commit-shellcheck-dep/actionlint -verbose -no-color; echo "exit=$?"
verbose: Linting all workflow files in repository: /tmp/scratch-verify-31/nopath-repo
verbose: Detected project: /tmp/scratch-verify-31/nopath-repo
verbose: Collected 1 YAML files
verbose: Linting .github/workflows/fixture.yaml
verbose: Using project at /tmp/scratch-verify-31/nopath-repo
verbose: Found 0 parse errors in 0 ms for .github/workflows/fixture.yaml
verbose: Rule "pyflakes" was disabled: exec: "pyflakes": executable file not found in $PATH
verbose: Found total 1 errors in 2753 ms for .github/workflows/fixture.yaml
.github/workflows/fixture.yaml:6:19: shellcheck reported issue in this script: SC2086:info:1:6: Double quote to prevent globbing and word splitting [shellcheck]
  |
6 |       - run: echo $GITHUB_SHA
  |                   ^~~~~~~~~~~
exit=1
````

`/tmp/scratch-verify-31/bin` holds nothing but a `go install`ed `wasilibs/go-shellcheck`. The `Rule "shellcheck" was disabled` line comes from `l.log` at `linter.go:595`, so it only appears under `-verbose`; without that flag the first run prints nothing at all and still exits 0.

</details>

The isolated `$GOPATH` is `install_environment` in pre-commit's `golang` language pointing `GOPATH` at the hook's own environment directory.

<details><summary>Measured</summary>

````console
$ grep -n "def install_environment" -A 27 /home/kjanat/.local/share/uv/tools/pre-commit/lib/python3.14/site-packages/pre_commit/languages/golang.py
130:def install_environment(
131-        prefix: Prefix,
132-        version: str,
133-        additional_dependencies: Sequence[str],
134-) -> None:
135-    env_dir = lang_base.environment_dir(prefix, ENVIRONMENT_DIR, version)
136-
137-    if version != 'system':
138-        _install_go(version, env_dir)
139-
140-    if sys.platform == 'cygwin':  # pragma: no cover
141-        gopath = cmd_output('cygpath', '-w', env_dir)[1].strip()
142-    else:
143-        gopath = env_dir
144-
145-    env = no_git_env(dict(os.environ, GOPATH=gopath))
146-    env.pop('GOBIN', None)
147-    if version != 'system':
148-        env['GOTOOLCHAIN'] = 'local'
149-        env['GOROOT'] = os.path.join(env_dir, '.go')
150-        env['PATH'] = os.pathsep.join((
151-            os.path.join(env_dir, '.go', 'bin'), os.environ['PATH'],
152-        ))
153-
154-    lang_base.setup_cmd(prefix, ('go', 'install', './...'), env=env)
155-    for dependency in additional_dependencies:
156-        lang_base.setup_cmd(prefix, ('go', 'install', dependency), env=env)
157-
````

</details>

`actionlint-shellcheck` is the same hook with ShellCheck added through `additional_dependencies`.

```yaml
repos:
  - repo: https://github.com/kjanat/actionlint
    rev: v1.12.0
    hooks:
      - id: actionlint-shellcheck
```

<details><summary>Measured</summary>

Run end to end from a throwaway repository holding only the fixture above, against this branch at `a1ac51d`.

````console
$ cd /tmp/scratch-verify-31/nopath-repo && PRE_COMMIT_HOME=/tmp/scratch-verify-31/pc-home pre-commit run --all-files; echo "exit=$?"
[INFO] Initializing environment for /home/kjanat/projects/actionlint/.worktrees/pre-commit-shellcheck-dep.
[INFO] Initializing environment for /home/kjanat/projects/actionlint/.worktrees/pre-commit-shellcheck-dep:github.com/wasilibs/go-shellcheck/cmd/shellcheck@latest.
[INFO] Installing environment for /home/kjanat/projects/actionlint/.worktrees/pre-commit-shellcheck-dep.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
Lint GitHub Actions workflow files (with ShellCheck).......................Failed
- hook id: actionlint-shellcheck
- exit code: 1

.github/workflows/fixture.yaml:6:19: shellcheck reported issue in this script: SC2086:info:1:6: Double quote to prevent globbing and word splitting [shellcheck]
  |
6 |       - run: echo $GITHUB_SHA
  |                   ^~~~~~~~~~~

exit=1
````

</details>

Closes #477.

## The version is `@latest`, and that is a compromise rather than a solution

The first version of this branch pinned `@v0.11.1`. Nothing in this repository would have updated it: Dependabot has no ecosystem that reads `.pre-commit-hooks.yaml`, and the bump tool only rewrites the actionlint version, so the pin would have sat there until somebody noticed.

<details><summary>Measured</summary>

The bump-tool half. Every reference the tool knows about is an actionlint version, and nothing in its output covers a ShellCheck dependency.

````console
$ cd /home/kjanat/projects/actionlint/.worktrees/pre-commit-shellcheck-dep && go run ./scripts/bump-version -check; echo "exit=$?"
.pre-commit-hooks.yaml:16: pre-commit Docker image tag: 1.12.0
action.yml:75: action Docker image tag: 1.12.0
scripts/download-actionlint.bash:46: default version of the download script: 1.12.0
docs/usage.md:258: versioned release tag note: 1.12.0
docs/usage.md:319: download script argument: 1.12.0
docs/usage.md:331: download script argument: 1.12.0
docs/usage.md:391: CLI image tag example: 1.12.0
docs/usage.md:394: action image tag example: 1.12.0
docs/usage.md:502: download script argument: 1.12.0
docs/usage.md:552: pre-commit revision: 1.12.0
docs/usage.md:580: pre-commit revision: 1.12.0
docs/usage.md:675: Trunk linter version: 1.12.0
docs/usage.md:683: Trunk linter version: 1.12.0
docs/install.md:104: gh release download tag: 1.12.0
docs/install.md:105: release asset name: 1.12.0
docs/install.md:113: release asset name: 1.12.0
docs/install.md:129: download script example description: 1.12.0
docs/install.md:132: download script argument: 1.12.0
README.md:126: versioned release tag note: 1.12.0
README.md:209: document link: 1.12.0
README.md:210: document link: 1.12.0
README.md:211: document link: 1.12.0
README.md:212: document link: 1.12.0
README.md:213: document link: 1.12.0
README.md:214: document link: 1.12.0
man/actionlint.1.md:5: manual footer version: 1.12.0
man/actionlint.1.md:111: document link: 1.12.0
man/actionlint.1.md:117: document link: 1.12.0
man/actionlint.1.md:124: document link: 1.12.0
man/actionlint.1.md:131: document link: 1.12.0
man/actionlint.1.md:137: document link: 1.12.0
man/actionlint.1.md:143: document link: 1.12.0
playground/index.html:47: release page link: 1.12.0
playground/index.html:49: version badge: 1.12.0
playground/index.html:110: document link: 1.12.0
version 1.12.0 is referenced 35 time(s)
exit=0
````

</details>

<details><summary>Not measured</summary>

The Dependabot half is a claim about which package ecosystems GitHub's service supports. Nothing in this repository or on this machine observes that, and no command here produces it. It rests on Dependabot's documented ecosystem list, not on a measurement taken here.

</details>

`@latest` does not fully fix that either, and the documentation now says so rather than implying otherwise. pre-commit resolves it when it first builds the hook's environment and then caches that environment, so what you get is whatever was current when you installed the hook, and `pre-commit clean` is what fetches a newer one. What it does buy is that a new user starts on a current ShellCheck instead of one frozen at whatever was current when this was written.

<details><summary>Measured</summary>

`install_environment` above runs `go install <dependency>` once per environment build. `_hook_installed` decides whether that build happens again, and for `golang` the health check is `basic_health_check`, which always returns `None`. An environment whose state file exists is therefore never rebuilt, and `@latest` is never re-resolved.

````console
$ grep -n "def _hook_installed" -A 16 /home/kjanat/.local/share/uv/tools/pre-commit/lib/python3.14/site-packages/pre_commit/repository.py
46:def _hook_installed(hook: Hook) -> bool:
47-    lang = languages[hook.language]
48-    if lang.ENVIRONMENT_DIR is None:
49-        return True
50-
51-    venv = environment_dir(
52-        hook.prefix,
53-        lang.ENVIRONMENT_DIR,
54-        hook.language_version,
55-    )
56-    return (
57-        (
58-            os.path.exists(_state_filename_v2(venv)) or
59-            _read_state(venv) == _state(hook.additional_dependencies)
60-        ) and
61-        not lang.health_check(hook.prefix, hook.language_version)
62-    )

$ PC=/home/kjanat/.local/share/uv/tools/pre-commit/lib/python3.14/site-packages/pre_commit; grep -n "health_check = \|def basic_health_check" -A 2 "$PC/languages/golang.py" "$PC/lang_base.py"
/home/kjanat/.local/share/uv/tools/pre-commit/lib/python3.14/site-packages/pre_commit/languages/golang.py:32:health_check = lang_base.basic_health_check
/home/kjanat/.local/share/uv/tools/pre-commit/lib/python3.14/site-packages/pre_commit/languages/golang.py-33-run_hook = lang_base.basic_run_hook
/home/kjanat/.local/share/uv/tools/pre-commit/lib/python3.14/site-packages/pre_commit/languages/golang.py-34-
/home/kjanat/.local/share/uv/tools/pre-commit/lib/python3.14/site-packages/pre_commit/lang_base.py:118:def basic_health_check(prefix: Prefix, language_version: str) -> str | None:
/home/kjanat/.local/share/uv/tools/pre-commit/lib/python3.14/site-packages/pre_commit/lang_base.py-119-    return None
/home/kjanat/.local/share/uv/tools/pre-commit/lib/python3.14/site-packages/pre_commit/lang_base.py-120-
````

Observed as well as read. The first run built the environment; `@latest` resolved to `v0.11.1` on 2026-08-21. The second run reused the same file, same inode and mtime, with no install lines. `pre-commit clean` dropped the cache, and the next run resolved again into a new file.

````console
$ SC=$(find /tmp/scratch-verify-31/pc-home -type f -name shellcheck); echo "path: $SC"; stat -c 'inode=%i mtime=%Y size=%s' "$SC"; go version -m "$SC"
path: /tmp/scratch-verify-31/pc-home/repo9tumqcbo/golangenv-system/bin/shellcheck
inode=17278644 mtime=1787344295 size=15399070
/tmp/scratch-verify-31/pc-home/repo9tumqcbo/golangenv-system/bin/shellcheck: go1.26.6-X:nodwarf5
	path	github.com/wasilibs/go-shellcheck/cmd/shellcheck
	mod	github.com/wasilibs/go-shellcheck	v0.11.1	h1:NAjeqVHmbw/odOZEK5X+jfRDEi9PRF+LDRaFojG5WnE=
	dep	github.com/tetratelabs/wazero	v1.9.0	h1:IcZ56OuxrtaEz8UYNRHBrUa9bYeX9oVY93KspZZBf/I=
	build	-buildmode=exe
	build	-compiler=gc
	build	DefaultGODEBUG=containermaxprocs=0,cryptocustomrand=1,decoratemappings=0,gotestjsonbuildtext=1,httpcookiemaxnum=0,multipathtcp=0,randseednop=0,rsa1024min=0,tlsmlkem=0,tlssecpmlkem=0,tlssha1=1,updatemaxprocs=0,urlmaxqueryparams=0,urlstrictcolons=0,x509rsacrt=0,x509sha256skid=0,x509usepolicies=0
	build	CGO_ENABLED=1
	build	CGO_CFLAGS=
	build	CGO_CPPFLAGS=
	build	CGO_CXXFLAGS=
	build	CGO_LDFLAGS=
	build	GOARCH=amd64
	build	GOEXPERIMENT=nodwarf5
	build	GOOS=linux
	build	GOAMD64=v1

$ cd /tmp/scratch-verify-31/nopath-repo && PRE_COMMIT_HOME=/tmp/scratch-verify-31/pc-home pre-commit run --all-files; echo "exit=$?"; stat -c 'inode=%i mtime=%Y size=%s' /tmp/scratch-verify-31/pc-home/repo9tumqcbo/golangenv-system/bin/shellcheck
Lint GitHub Actions workflow files (with ShellCheck).......................Failed
- hook id: actionlint-shellcheck
- exit code: 1

.github/workflows/fixture.yaml:6:19: shellcheck reported issue in this script: SC2086:info:1:6: Double quote to prevent globbing and word splitting [shellcheck]
  |
6 |       - run: echo $GITHUB_SHA
  |                   ^~~~~~~~~~~

exit=1
inode=17278644 mtime=1787344295 size=15399070

$ PRE_COMMIT_HOME=/tmp/scratch-verify-31/pc-home pre-commit clean; echo "exit=$?"; ls /tmp/scratch-verify-31/pc-home
Cleaned /tmp/scratch-verify-31/pc-home.
exit=0
ls: cannot access '/tmp/scratch-verify-31/pc-home': No such file or directory

$ cd /tmp/scratch-verify-31/nopath-repo && PRE_COMMIT_HOME=/tmp/scratch-verify-31/pc-home pre-commit run --all-files; echo "exit=$?"; stat -c 'inode=%i mtime=%Y size=%s' /tmp/scratch-verify-31/pc-home/repo*/golangenv-system/bin/shellcheck
[INFO] Initializing environment for /home/kjanat/projects/actionlint/.worktrees/pre-commit-shellcheck-dep.
[INFO] Initializing environment for /home/kjanat/projects/actionlint/.worktrees/pre-commit-shellcheck-dep:github.com/wasilibs/go-shellcheck/cmd/shellcheck@latest.
[INFO] Installing environment for /home/kjanat/projects/actionlint/.worktrees/pre-commit-shellcheck-dep.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
Lint GitHub Actions workflow files (with ShellCheck).......................Failed
- hook id: actionlint-shellcheck
- exit code: 1

.github/workflows/fixture.yaml:6:19: shellcheck reported issue in this script: SC2086:info:1:6: Double quote to prevent globbing and word splitting [shellcheck]
  |
6 |       - run: echo $GITHUB_SHA
  |                   ^~~~~~~~~~~

exit=1
inode=17294242 mtime=1787344333 size=15399070
````

</details>

A repository that wants a specific version sets it on the plain hook, which is where pre-commit puts that choice:

```yaml
      - id: actionlint
        additional_dependencies:
          - github.com/wasilibs/go-shellcheck/cmd/shellcheck@v0.11.1
```

## `wasilibs/go-shellcheck` is ShellCheck, not a reimplementation

It is ShellCheck's own Haskell source compiled to WebAssembly through the GHC WASI backend and run under wazero. It reports `version: 0.11.0`, and its JSON output matches `shellcheckError` in `rule_shellcheck.go` field for field.

<details><summary>Measured</summary>

The project's own README on the compilation, and the built binary's module graph with wazero linked in:

````console
$ gh api repos/wasilibs/go-shellcheck/contents/README.md --jq '.content' | base64 -d
# go-shellcheck

go-shellcheck is a distribution of [shellcheck][1], that can be built with Go. It does not actually reimplement any
functionality of shellcheck in Go, instead compiling it with the GHC WASI backend, and
executing with the pure Go Wasm runtime [wazero][2]. This means that `go install` or `go run`
can be used to execute it, with no need to rely on separate package managers such as pnpm,
on any platform that Go supports.

## Installation

Precompiled binaries are available in the [releases](https://github.com/wasilibs/go-shellcheck/releases).
Alternatively, install the plugin you want using `go install`.

```bash
$ go install github.com/wasilibs/go-shellcheck/cmd/shellcheck@latest
```

To avoid installation entirely, it can be convenient to use `go run`

```bash
$ go run github.com/wasilibs/go-shellcheck/cmd/shellcheck@latest *.sh
```

_Due to [potential build breakage](https://github.com/golang/go/issues/71192) unrelated to this project,
`go tool` is not supported._

Note that due to the sandboxing of the filesystem when using Wasm, currently only files that descend
from the current directory when executing the tool are accessible to it, i.e., `../sql/my.sh` or
`/separate/root/my.sh` will not be found.

[1]: https://github.com/koalaman/shellcheck
[2]: https://wazero.io/

$ cd /tmp/scratch-verify-31 && GOBIN=/tmp/scratch-verify-31/bin go install github.com/wasilibs/go-shellcheck/cmd/shellcheck@latest; echo "exit=$?"
exit=0

$ ./bin/shellcheck --version
ShellCheck - shell script analysis tool
version: 0.11.0
license: GNU General Public License, version 3
website: https://www.shellcheck.net

$ go version -m ./bin/shellcheck
./bin/shellcheck: go1.26.6-X:nodwarf5
	path	github.com/wasilibs/go-shellcheck/cmd/shellcheck
	mod	github.com/wasilibs/go-shellcheck	v0.11.1	h1:NAjeqVHmbw/odOZEK5X+jfRDEi9PRF+LDRaFojG5WnE=
	dep	github.com/tetratelabs/wazero	v1.9.0	h1:IcZ56OuxrtaEz8UYNRHBrUa9bYeX9oVY93KspZZBf/I=
	build	-buildmode=exe
	build	-compiler=gc
	build	DefaultGODEBUG=containermaxprocs=0,cryptocustomrand=1,decoratemappings=0,gotestjsonbuildtext=1,httpcookiemaxnum=0,multipathtcp=0,randseednop=0,rsa1024min=0,tlsmlkem=0,tlssecpmlkem=0,tlssha1=1,updatemaxprocs=0,urlmaxqueryparams=0,urlstrictcolons=0,x509rsacrt=0,x509sha256skid=0,x509usepolicies=0
	build	CGO_ENABLED=1
	build	CGO_CFLAGS=
	build	CGO_CPPFLAGS=
	build	CGO_CXXFLAGS=
	build	CGO_LDFLAGS=
	build	GOARCH=amd64
	build	GOEXPERIMENT=nodwarf5
	build	GOOS=linux
	build	GOAMD64=v1
````

This machine also has an upstream ShellCheck build at `/usr/bin/shellcheck`, same version. Fed the same script with the exact argument list from `rule_shellcheck.go:202`, the two produce byte-identical JSON.

````console
$ /usr/bin/shellcheck --version
ShellCheck - shell script analysis tool
version: 0.11.0
license: GNU General Public License, version 3
website: https://www.shellcheck.net

$ cd /tmp/scratch-verify-31 && printf 'set -eo pipefail\necho $GITHUB_SHA\n' > script.sh
$ /usr/bin/shellcheck --norc -f json1 -x --shell bash -e SC1091,SC2194,SC2050,SC2153,SC2154,SC2157,SC2043 - < script.sh > real.json
$ ./bin/shellcheck --norc -f json1 -x --shell bash -e SC1091,SC2194,SC2050,SC2153,SC2154,SC2157,SC2043 - < script.sh > wasm.json
$ diff real.json wasm.json; echo "diff exit=$?"; sha256sum real.json wasm.json
diff exit=0
00a6097861e53db2ff223fc707f2fda0d7e376f27b2548e3b844a724907758c7  real.json
00a6097861e53db2ff223fc707f2fda0d7e376f27b2548e3b844a724907758c7  wasm.json

$ printf 'set -eo pipefail\necho $GITHUB_SHA\n' | ./bin/shellcheck --norc -f json1 -x --shell bash -e SC1091,SC2194,SC2050,SC2153,SC2154,SC2157,SC2043 -
{"comments":[{"file":"-","line":2,"endLine":2,"column":6,"endColumn":17,"level":"info","code":2086,"message":"Double quote to prevent globbing and word splitting.","fix":{"replacements":[{"column":6,"endColumn":6,"endLine":2,"insertionPoint":"afterEnd","line":2,"precedence":7,"replacement":"\""},{"column":17,"endColumn":17,"endLine":2,"insertionPoint":"beforeStart","line":2,"precedence":7,"replacement":"\""}]}}]}
````

"Field for field" holds in one direction. Every field of `shellcheckError` appears in the output under the same name with a compatible type. The output also carries `file` and `fix`, which the struct does not declare and `encoding/json` discards.

````console
$ cd /tmp/scratch-verify-31 && printf 'set -eo pipefail\necho $GITHUB_SHA\n' | ./bin/shellcheck --norc -f json1 -x --shell bash -e SC1091,SC2194,SC2050,SC2153,SC2154,SC2157,SC2043 - | jq -r '.comments[0] | keys_unsorted | join(", ")'
file, line, endLine, column, endColumn, level, code, message, fix

$ cd /home/kjanat/projects/actionlint/.worktrees/pre-commit-shellcheck-dep && grep -oP '(?<=json:")[a-zA-Z]+(?=")' rule_shellcheck.go
line
endLine
column
endColumn
level
code
message
comments
````

</details>

Its one sandbox restriction is that it cannot read files outside the working directory. That does not apply here: actionlint always feeds scripts to ShellCheck through stdin.

<details><summary>Measured</summary>

The argument list ends in `-`, and the script reaches the process as its stdin.

````console
$ cd /home/kjanat/projects/actionlint/.worktrees/pre-commit-shellcheck-dep && grep -n 'args := \[\]string{"--norc"' -A 11 rule_shellcheck.go
202:	args := []string{"--norc", "-f", "json1", "-x", "--shell", sh, "-e", "SC1091,SC2194,SC2050,SC2153,SC2154,SC2157,SC2043", "-"}
203-	rule.Debug("%s: Running %s command with %s", pos, rule.cmd.exe, args)
204-
205-	// Use same options to run shell process described at document
206-	// https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#using-a-specific-shell
207-	setup := "set -e"
208-	if sh == "bash" {
209-		setup = "set -eo pipefail"
210-	}
211-	script := fmt.Sprintf("%s\n%s\n", setup, src)
212-
213-	rule.cmd.run(args, script, func(stdout []byte, err error) error {
````

</details>

## The regression job, and why its first version proved nothing

The job runs the hook against a fixture with `run: echo $GITHUB_SHA` and requires SC2086 in the output.

The first version of that job passed with the dependency deleted. pre-commit's `golang` language *prepends* to `PATH` rather than replacing it, and `ubuntu-latest` is Ubuntu 24.04 with `shellcheck 0.9.0-1` preinstalled, so actionlint found the runner's own binary either way. The job proved that some ShellCheck ran, not that the hook supplied it.

<details><summary>Measured</summary>

The prepend is in `get_env_patch`: the environment's `bin` comes first, the inherited `PATH` after it.

````console
$ grep -n "def get_env_patch" -A 15 /home/kjanat/.local/share/uv/tools/pre-commit/lib/python3.14/site-packages/pre_commit/languages/golang.py
70:def get_env_patch(venv: str, version: str) -> PatchesT:
71-    if version == 'system':
72-        return (
73-            ('PATH', (os.path.join(venv, 'bin'), os.pathsep, Var('PATH'))),
74-        )
75-
76-    return (
77-        ('GOROOT', os.path.join(venv, '.go')),
78-        ('GOTOOLCHAIN', 'local'),
79-        (
80-            'PATH', (
81-                os.path.join(venv, 'bin'), os.pathsep,
82-                os.path.join(venv, '.go', 'bin'), os.pathsep, Var('PATH'),
83-            ),
84-        ),
85-    )
````

The runner image, from `actions/runner-images`:

````console
$ gh api repos/actions/runner-images/contents/README.md --jq '.content' | base64 -d | grep -in "ubuntu-latest"
25:| Ubuntu 24.04<br>![Endpoint Badge](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fhosted-runners-images-bot%2F79267492faab096d04cdd25ce7014cec%2Fraw%2Fubuntu24.json) | x64 | `ubuntu-latest` or `ubuntu-24.04` | [ubuntu-24.04] |
95:GitHub Actions and Azure DevOps use the `-latest` YAML label (ex: `ubuntu-latest`, `windows-latest`, and `macos-latest`). These labels point towards the newest stable OS version available.

$ gh api repos/actions/runner-images/contents/images/ubuntu/Ubuntu2404-Readme.md --jq '.content' | base64 -d | grep -in "shellcheck"
309:| shellcheck             | 0.9.0-1                      |
````

</details>

<details><summary>Not measured</summary>

That the earlier job actually passed on a GitHub runner with the dependency deleted describes a run on GitHub's infrastructure. There is no `ubuntu-latest` runner on this machine and nothing local attests to what a past workflow run did. Its two premises, the `PATH` prepend and the preinstalled `shellcheck 0.9.0-1`, are shown above; the conclusion drawn from them is not itself measured.

</details>

It now removes the runner's ShellCheck first and fails if anything is still on `PATH`:

<details><summary>Measured</summary>

````console
$ cd /home/kjanat/projects/actionlint/.worktrees/pre-commit-shellcheck-dep && grep -n "pre-commit-shellcheck:" -A 35 .github/workflows/ci.yaml
170:  pre-commit-shellcheck:
171-    name: pre-commit ShellCheck integration
172-    runs-on: ubuntu-latest
173-    steps:
174-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
175-        with: { persist-credentials: false }
176-      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
177-        with: { go-version: "${{ env.GO }}", check-latest: true }
178-      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
179-      - run: uv tool install pre-commit
180-      # pre-commit's golang language prepends to PATH, so the runner's preinstalled shellcheck satisfies actionlint on its own.
181-      - name: Remove the runner's ShellCheck so only the hook's own can be found
182-        run: |
183-          sudo apt-get remove -y shellcheck
184-          if command -v shellcheck; then
185-            echo "shellcheck is still on PATH; the hook dependency would not be the only source" >&2
186-            exit 1
187-          fi
188-      - name: Confirm actionlint-shellcheck reports a fixture's SC2086
189-        run: |
190-          cat > .github/workflows/_pre-commit-shellcheck-fixture.yaml <<'FIXTURE'
191-          on: push
192-          jobs:
193-            fixture:
194-              runs-on: ubuntu-latest
195-              steps:
196-                - run: echo $GITHUB_SHA
197-          FIXTURE
198-          set +e
199-          pre-commit try-repo . actionlint-shellcheck --files .github/workflows/_pre-commit-shellcheck-fixture.yaml --verbose > pre-commit-output.txt 2>&1
200-          status=$?
201-          set -e
202-          cat pre-commit-output.txt
203-          rm .github/workflows/_pre-commit-shellcheck-fixture.yaml
204-          test "${status}" -ne 0
205-          grep -q SC2086 pre-commit-output.txt
````

</details>

With the dependency deleted, the job now fails.

<details><summary>Not measured</summary>

Not observed on a runner, for the same reason as above. What has been observed locally is the behaviour both of the job's assertions rest on: with no `shellcheck` reachable, actionlint prints nothing and exits 0 (first block of this body), which leaves `test "${status}" -ne 0` and `grep -q SC2086` with nothing to succeed on.

</details>

## `scripts/bump-version/targets.go`

`docs/usage.md` gains a second `rev:` line, so that rule's expected count goes from 1 to 2. Both are genuine bump targets.

<details><summary>Measured</summary>

````console
$ cd /home/kjanat/projects/actionlint/.worktrees/pre-commit-shellcheck-dep && grep -cE '^    rev: v[0-9]+\.[0-9]+\.[0-9]+$' docs/usage.md
2

$ git show origin/main:docs/usage.md | grep -cE '^    rev: v[0-9]+\.[0-9]+\.[0-9]+$'
1

$ grep -n 'path: "docs/usage.md"' -B 1 -A 13 scripts/bump-version/targets.go
55-	{
56:		path: "docs/usage.md",
57-		rules: []rule{
58-			mustRule("versioned release tag note", "`v(\\d+\\.\\d+\\.\\d+)` is a versioned release tag", 1),
59-			mustRule("download script argument", `download-actionlint\.bash\) (\d+\.\d+\.\d+)`, 3),
60-			mustRule("CLI image tag example", "`ghcr\\.io/kjanat/actionlint:(\\d+\\.\\d+\\.\\d+)`", 1),
61-			mustRule("action image tag example", "`action-(\\d+\\.\\d+\\.\\d+)`", 1),
62-			mustRule("pre-commit revision", `(?m)^    rev: v(\d+\.\d+\.\d+)\r?$`, 2),
63-			mustRule("Trunk linter version", ` actionlint@(\d+\.\d+\.\d+)`, 2),
64-		},
65-		unrelated: []string{
66-			"sarif/v2.1.0/sarif-v2.1.0.html",
67-			"github.com/wasilibs/go-shellcheck/cmd/shellcheck@v0.11.1",
68-		},
69-	},

$ go test -count=1 ./scripts/bump-version/; echo "exit=$?"
ok  	actionlint.kjanat.dev/scripts/bump-version	0.265s
exit=0
````

The `-check` output further up lists both, at `docs/usage.md:552` and `docs/usage.md:580`.

</details>

The `@v0.11.1` in the documented pinning example is not, so it stays in `unrelated` for that file. The hook file no longer needs an entry there, because `@latest` contains no version to mistake for one.

<details><summary>Measured</summary>

`scan` rejects any version-shaped string that no rule matched and no `unrelated` literal covers, so the documented example needs its declaration.

````console
$ cd /home/kjanat/projects/actionlint/.worktrees/pre-commit-shellcheck-dep && grep -n "for _, lit := range t.unrelated" -A 23 scripts/bump-version/bump.go
130:	for _, lit := range t.unrelated {
131-		found := allIndex(content, lit)
132-		if len(found) == 0 {
133-			return nil, fmt.Errorf("%s: unrelated version reference %q no longer appears, so the declaration is stale", t.path, lit)
134-		}
135-		covered = append(covered, found...)
136-	}
137-
138-	for _, m := range anyVersion.FindAllIndex(content, -1) {
139-		found := span{m[0], m[1]}
140-		known := false
141-		for _, c := range covered {
142-			if c.contains(found) {
143-				known = true
144-				break
145-			}
146-		}
147-		if !known {
148-			return nil, fmt.Errorf(
149-				"%s:%d: undeclared version reference %q in %q. declare it in scripts/bump-version/targets.go or list it as unrelated",
150-				t.path, lineAt(content, found.start), string(content[found.start:found.end]), lineTextAt(content, found.start),
151-			)
152-		}
153-	}
````

The hook file's own `unrelated` list is untouched by this branch. Its single entry, `minimum_pre_commit_version: 3.0.0`, is already on `main`, and the only edit to `targets.go` is the `docs/usage.md` block.

````console
$ git show origin/main:scripts/bump-version/targets.go | grep -n "minimum_pre_commit_version\|pre-commit-hooks"
33:		path: ".pre-commit-hooks.yaml",
37:		unrelated: []string{"minimum_pre_commit_version: 3.0.0"},

$ git diff origin/main...HEAD -- scripts/bump-version/targets.go
diff --git a/scripts/bump-version/targets.go b/scripts/bump-version/targets.go
index bea22b5..4b207e2 100644
--- a/scripts/bump-version/targets.go
+++ b/scripts/bump-version/targets.go
@@ -59,10 +59,13 @@ var targets = []*target{
 			mustRule("download script argument", `download-actionlint\.bash\) (\d+\.\d+\.\d+)`, 3),
 			mustRule("CLI image tag example", "`ghcr\\.io/kjanat/actionlint:(\\d+\\.\\d+\\.\\d+)`", 1),
 			mustRule("action image tag example", "`action-(\\d+\\.\\d+\\.\\d+)`", 1),
-			mustRule("pre-commit revision", `(?m)^    rev: v(\d+\.\d+\.\d+)\r?$`, 1),
+			mustRule("pre-commit revision", `(?m)^    rev: v(\d+\.\d+\.\d+)\r?$`, 2),
 			mustRule("Trunk linter version", ` actionlint@(\d+\.\d+\.\d+)`, 2),
 		},
-		unrelated: []string{"sarif/v2.1.0/sarif-v2.1.0.html"},
+		unrelated: []string{
+			"sarif/v2.1.0/sarif-v2.1.0.html",
+			"github.com/wasilibs/go-shellcheck/cmd/shellcheck@v0.11.1",
+		},
 	},
 	{
 		path: "docs/install.md",
````

</details>

A real bump to a throwaway version, run in a clone of this branch: both `rev:` lines move and the example's `@v0.11.1` does not.

<details><summary>Mutation</summary>

````console
$ cd /tmp/scratch-verify-31 && git clone -q /home/kjanat/projects/actionlint/.worktrees/pre-commit-shellcheck-dep bump-repo && cd bump-repo && git checkout -q -b main a1ac51de8008f5311bc272c6fa99dca299d77690
$ go run ./scripts/bump-version 9.9.9; echo "exit=$?"
CHANGELOG.md: # Unreleased describes this release
Bumping the version to 9.9.9 (tag: v9.9.9)
.pre-commit-hooks.yaml: 1 reference(s) set to 9.9.9
action.yml: 1 reference(s) set to 9.9.9
scripts/download-actionlint.bash: 1 reference(s) set to 9.9.9
docs/usage.md: 10 reference(s) set to 9.9.9
docs/install.md: 5 reference(s) set to 9.9.9
README.md: 7 reference(s) set to 9.9.9
man/actionlint.1.md: 7 reference(s) set to 9.9.9
playground/index.html: 3 reference(s) set to 9.9.9

All version references were updated and verified. To release, run:

  git add .pre-commit-hooks.yaml action.yml scripts/download-actionlint.bash docs/usage.md docs/install.md README.md man/actionlint.1.md playground/index.html
  git commit -m 'bump up version to v9.9.9'
  git tag -s -m v9.9.9 v9.9.9
  git push origin main
  git push origin v9.9.9
exit=0

$ git diff -- docs/usage.md
diff --git a/docs/usage.md b/docs/usage.md
index 5984df2..5e5324d 100644
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -255,7 +255,7 @@ jobs:
 ```
 
 Docker actions require a Linux runner. `v1` moves to each new release.
-`v1.12.0` is a versioned release tag, but only a full-length commit SHA provides
+`v9.9.9` is a versioned release tag, but only a full-length commit SHA provides
 an immutable action reference.
 
 The action accepts these inputs:
@@ -316,7 +316,7 @@ jobs:
         with: { persist-credentials: false }
       - name: Download actionlint
         id: get_actionlint
-        run: bash <(curl -fsSL https://raw.githubusercontent.com/kjanat/actionlint/main/scripts/download-actionlint.bash) 1.12.0
+        run: bash <(curl -fsSL https://raw.githubusercontent.com/kjanat/actionlint/main/scripts/download-actionlint.bash) 9.9.9
         shell: bash
       - name: Check workflow files
         run: ${{ steps.get_actionlint.outputs.executable }} -color
@@ -328,7 +328,7 @@ Or simply download the executable and run it in one step:
 ```yaml
 - name: Check workflow files
   run: |
-    bash <(curl -fsSL https://raw.githubusercontent.com/kjanat/actionlint/main/scripts/download-actionlint.bash) 1.12.0
+    bash <(curl -fsSL https://raw.githubusercontent.com/kjanat/actionlint/main/scripts/download-actionlint.bash) 9.9.9
     ./actionlint -color
   shell: bash
 ```
@@ -388,10 +388,10 @@ Available tags are:
   Moving alias for the latest stable version of actionlint. This image is recommended.
 - `ghcr.io/kjanat/actionlint:{version}`:\
   Release-specific actionlint image rather than a moving alias.\
-  (e.g. `ghcr.io/kjanat/actionlint:1.12.0`)
+  (e.g. `ghcr.io/kjanat/actionlint:9.9.9`)
 - `ghcr.io/kjanat/actionlint:action-{version}`:\
   Release-specific image used by `action.yml` rather than a moving alias.\
-  (e.g. `action-1.12.0`)
+  (e.g. `action-9.9.9`)
 - `ghcr.io/kjanat/actionlint:action-v1`:\
   Moving alias for the latest compatible v1 image available to Docker Action users.
 - `ghcr.io/kjanat/actionlint:action-latest`:\
@@ -499,7 +499,7 @@ in the step of your workflow.
 - name: Check workflow files
   run: |
     echo "::add-matcher::.github/actionlint-matcher.json"
-    bash <(curl -fsSL https://raw.githubusercontent.com/kjanat/actionlint/main/scripts/download-actionlint.bash) 1.12.0
+    bash <(curl -fsSL https://raw.githubusercontent.com/kjanat/actionlint/main/scripts/download-actionlint.bash) 9.9.9
     ./actionlint -color
   shell: bash
 ```
@@ -549,7 +549,7 @@ Add this to your `.pre-commit-config.yaml` in your repository:
 ---
 repos:
   - repo: https://github.com/kjanat/actionlint
-    rev: v1.12.0
+    rev: v9.9.9
     hooks:
       - id: actionlint
 ```
@@ -577,7 +577,7 @@ choose the version yourself, use `additional_dependencies` on the plain hook:
 ---
 repos:
   - repo: https://github.com/kjanat/actionlint
-    rev: v1.12.0
+    rev: v9.9.9
     hooks:
       - id: actionlint
         additional_dependencies:
@@ -672,7 +672,7 @@ trunk check enable actionlint
 or if you'd like a specific version:
 
 ```bash
-trunk check enable actionlint@1.12.0
+trunk check enable actionlint@9.9.9
 ```
 
 or modify `.trunk/trunk.yaml` in your repository to contain:
@@ -680,7 +680,7 @@ or modify `.trunk/trunk.yaml` in your repository to contain:
 ```yaml
 lint:
   enabled:
-    - actionlint@1.12.0
+    - actionlint@9.9.9
 ```
 
 Then just run:

$ grep -n "wasilibs" docs/usage.md
565:| `actionlint-shellcheck` | Same as `actionlint`, and additionally installs a Go build of ShellCheck ([`wasilibs/go-shellcheck`][go-shellcheck]) so [the shellcheck integration](checks.md#check-shellcheck-integ) works without a host-installed `shellcheck`. |
584:          - github.com/wasilibs/go-shellcheck/cmd/shellcheck@v0.11.1
714:[go-shellcheck]: https://github.com/wasilibs/go-shellcheck
````

The clone lives under `/tmp` and this repository was left untouched.

</details>

## Credit

Ported from rhysd/actionlint#482 by `Aleksandr Kadykov`, with a `Co-authored-by` trailer.

That pull request is one line — `additional_dependencies` with `@latest` — added to the existing `actionlint` hook. This adds it to a separate hook instead, so a repository that already has ShellCheck on `PATH` does not pay for a second copy, and it comes with the documentation and the regression job that the upstream thread asked for and the patch did not carry.

Worth noting that reverting the pin to `@latest` in review is what made that line identical to upstream's again.

<details><summary>Measured</summary>

One file, one added line, nothing deleted:

````console
$ gh pr view 482 --repo rhysd/actionlint --json author,title,files,state,url
{"author":{"id":"MDQ6VXNlcjYyNTQ2NzA5","is_bot":false,"login":"kadykov","name":"Aleksandr Kadykov"},"files":[{"path":".pre-commit-hooks.yaml","additions":1,"deletions":0,"changeType":"MODIFIED"}],"state":"OPEN","title":"Add `shellcheck` dependency in pre-commit hooks","url":"https://github.com/rhysd/actionlint/pull/482"}

$ gh pr diff 482 --repo rhysd/actionlint
diff --git a/.pre-commit-hooks.yaml b/.pre-commit-hooks.yaml
index 419ade51b..eceb3c54d 100644
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -7,6 +7,7 @@
   files: ^\.github/workflows/
   entry: actionlint
   minimum_pre_commit_version: 3.0.0
+  additional_dependencies: ["github.com/wasilibs/go-shellcheck/cmd/shellcheck@latest"]
 - id: actionlint-docker
   name: Lint GitHub Actions workflow files
   description: Runs actionlint Docker image to lint GitHub Actions workflow files
````

Upstream's added line and ours, compared as bytes:

````console
$ cd /home/kjanat/projects/actionlint/.worktrees/pre-commit-shellcheck-dep && grep -n "additional_dependencies" .pre-commit-hooks.yaml
32:  additional_dependencies: ["github.com/wasilibs/go-shellcheck/cmd/shellcheck@latest"]

$ gh pr diff 482 --repo rhysd/actionlint | grep '^+' | grep -v '^+++' | sed 's/^+//' > /tmp/scratch-verify-31/upstream-line-clean.txt
$ sed -n '32p' .pre-commit-hooks.yaml > /tmp/scratch-verify-31/ours-line.txt
$ diff /tmp/scratch-verify-31/upstream-line-clean.txt /tmp/scratch-verify-31/ours-line.txt; echo "diff exit=$?"; sha256sum /tmp/scratch-verify-31/upstream-line-clean.txt /tmp/scratch-verify-31/ours-line.txt
diff exit=0
622279ee21a62b4ad3e5307479e11f83eac545442a218b187877554b26100cbc  /tmp/scratch-verify-31/upstream-line-clean.txt
622279ee21a62b4ad3e5307479e11f83eac545442a218b187877554b26100cbc  /tmp/scratch-verify-31/ours-line.txt
````

The trailer on the commit:

````console
$ git log -1 --format='%an <%ae>%n---trailers---%n%(trailers)' a1ac51de8008f5311bc272c6fa99dca299d77690
Kaj Kowalski <info@kajkowalski.nl>
---trailers---
Co-authored-by: Aleksandr Kadykov <git@kadykov.com>
````

</details>

## Verification

<details><summary>Gates</summary>

````console
$ cd /home/kjanat/projects/actionlint/.worktrees/pre-commit-shellcheck-dep && make build SKIP_GO_GENERATE=true; echo "exit=$?"
CGO_ENABLED=0 go build ./cmd/actionlint
exit=0

$ make test; echo "exit=$?"
go test -race ./...
ok  	actionlint.kjanat.dev	315.300s
?   	actionlint.kjanat.dev/cmd/actionlint	[no test files]
ok  	actionlint.kjanat.dev/cmd/actionlint-action	1.052s
ok  	actionlint.kjanat.dev/fuzz	1.020s
ok  	actionlint.kjanat.dev/scripts/bump-version	2.018s
ok  	actionlint.kjanat.dev/scripts/check-checks	69.564s
ok  	actionlint.kjanat.dev/scripts/generate-availability	1.352s
ok  	actionlint.kjanat.dev/scripts/generate-popular-actions	2.184s
ok  	actionlint.kjanat.dev/scripts/generate-webhook-events	1.305s
exit=0

$ make lint SKIP_GO_GENERATE=true; echo "exit=$?"
golangci-lint run
0 issues.
go run golang.org/x/vuln/cmd/govulncheck@latest ./...
No vulnerabilities found.
GOOS=js GOARCH=wasm golangci-lint run ./playground
0 issues.
go run ./scripts/check-checks -quiet ./docs/checks.md
exit=0

$ dprint check; echo "exit=$?"
exit=0

$ ./actionlint -color -shellcheck 'shellcheck -o all'; echo "exit=$?"
exit=0
````

</details>

