### PR TITLE
Add a gomod ecosystem to the Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,11 @@ updates:
       github-actions:
         patterns:
           - "*"
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      gomod:
+        patterns:
+          - "*"


### PR DESCRIPTION
Dependabot watches this repository's GitHub Actions and nothing else. `go.mod` has twelve direct requires and no automation keeping them current; today they move when somebody remembers.

## The entry

```yaml
  - package-ecosystem: "gomod"
    directory: "/"
    schedule:
      interval: "weekly"
    groups:
      gomod:
        patterns:
          - "*"
```

Same shape as the `github-actions` entry above it, down to key order, quoting and indentation. Normalising the ecosystem name out of both blocks produces an identical diff. The group collapses the whole ecosystem into one weekly pull request rather than one per module.

## No allow filter

All twelve direct requires fall inside Dependabot's default direct-only selection, so nothing is needed to reach them.

The two indirect requires are a deliberate omission rather than an oversight. `github.com/clipperhouse/uax29/v2` is pinned at v2.7.0 while its parent `go-runewidth@v0.0.28` requires only v2.2.0; `github.com/mattn/go-isatty` is at v0.0.24 while `fatih/color@v1.19.0` and `go-colorable@v0.1.15` require v0.0.20. Minimal version selection takes the maximum, so a parent bump will not lift either pin — and both parents are already at their latest release, so there is no parent bump to be had. All four modules are at their newest published version today.

What still covers them: Dependabot opens security updates regardless of `allow`, and this repository has vulnerability alerts and automated security fixes enabled. `make lint` runs `govulncheck ./...` in CI, and both modules are in the import graph it scans.

## Verification

```
$ dprint check
(no output, exit 0)
```

The committed file validates against SchemaStore's `dependabot-2.0.json` and against `check-jsonschema`'s bundled `vendor.dependabot`. Nine mutations were rejected, each on the property it broke: wrong ecosystem, wrong interval, wrong directory, renamed group, altered patterns, added `allow`, reordered keys, removed sibling entry, empty patterns.

The other four gates were run and are green, but they prove nothing about a Dependabot config that no Go code reads. `dprint check` is the only one with bearing here, and it is not vacuous — `.github/dependabot.yml` is in the formatter's file set, and malformed input fed through `dprint fmt --stdin` comes back normalised.

One note on how the assertion was written, since it cost two attempts. `yq`'s `==` operator glob-matches strings and never compares sequences as equal, so `patterns[0] == "*"` is true for any string at all and `patterns == ["*"]` is false even when it holds. Both forms silently passed a fixture with `patterns: ["golang.org/x/*"]` — the exact mutation that would break the grouping. The assertion uses `yq -o=json` piped into `jq` instead.
