### PR TITLE
Measure expression literal conformance against GitHub's own parser

### DIFF
--- a/.github/workflows/expr-conformance-probe.yaml
+++ b/.github/workflows/expr-conformance-probe.yaml
@@ -23,27 +23,27 @@ jobs:
       - name: Preflight
         run: |
           set -euo pipefail
-          repo="$GITHUB_REPOSITORY"
+          repo="${GITHUB_REPOSITORY}"
           wf_path="${GITHUB_WORKFLOW_REF%%@*}"
-          wf_path="${wf_path#"$repo/"}"
+          wf_path="${wf_path#"${repo}/"}"
 
           if ! blob="$(jq -n '{content: "cHJlZmxpZ2h0Cg==", encoding: "base64"}' \
-            | gh api -X POST "repos/$repo/git/blobs" --input - --jq .sha 2>&1)"; then
-            echo "::error::the probe token cannot write git objects: $blob"
+            | gh api -X POST "repos/${repo}/git/blobs" --input - --jq .sha 2>&1)"; then
+            echo "::error::the probe token cannot write git objects: ${blob}"
             echo 'Set the EXPR_PROBE_TOKEN secret to a token with contents write.'
             exit 1
           fi
           echo "git object write: ok"
 
-          tree="$(jq -n --arg p "$wf_path" --arg s "$blob" \
+          tree="$(jq -n --arg p "${wf_path}" --arg s "${blob}" \
             '{tree: [{path: $p, mode: "100644", type: "blob", sha: $s}]}' \
-            | gh api -X POST "repos/$repo/git/trees" --input - --jq .sha)"
-          commit="$(jq -n --arg t "$tree" '{message: "preflight", tree: $t}' \
-            | gh api -X POST "repos/$repo/git/commits" --input - --jq .sha)"
-          if ! out="$(jq -n --arg r "refs/heads/$WF_PREFIX/preflight" --arg s "$commit" \
+            | gh api -X POST "repos/${repo}/git/trees" --input - --jq .sha)"
+          commit="$(jq -n --arg t "${tree}" '{message: "preflight", tree: $t}' \
+            | gh api -X POST "repos/${repo}/git/commits" --input - --jq .sha)"
+          if ! out="$(jq -n --arg r "refs/heads/${WF_PREFIX}/preflight" --arg s "${commit}" \
             '{ref: $r, sha: $s}' \
-            | gh api -X POST "repos/$repo/git/refs" --input - --jq .ref 2>&1)"; then
-            echo "::error::the probe token may not write under .github/workflows: $out"
+            | gh api -X POST "repos/${repo}/git/refs" --input - --jq .ref 2>&1)"; then
+            echo "::error::the probe token may not write under .github/workflows: ${out}"
             echo 'Set the EXPR_PROBE_TOKEN secret to a token that also has workflows write.'
             exit 1
           fi
@@ -60,33 +60,34 @@ jobs:
           # case per file is not a choice: a workflow with an invalid expression
           # is rejected whole, and the rejection lists at most ten parse errors.
           dollar='$'
-          repo="$GITHUB_REPOSITORY"
+          repo="${GITHUB_REPOSITORY}"
           wf_path="${GITHUB_WORKFLOW_REF%%@*}"
-          wf_path="${wf_path#"$repo/"}"
-          wf_id="$(gh api "repos/$repo/actions/workflows" --paginate \
-            --jq ".workflows[] | select(.path == \"$wf_path\") | .id")"
-          echo "workflow $wf_path is id $wf_id"
+          wf_path="${wf_path#"${repo}/"}"
+          wf_id="$(gh api "repos/${repo}/actions/workflows" --paginate \
+            --jq ".workflows[] | select(.path == \"${wf_path}\") | .id")"
+          echo "workflow ${wf_path} is id ${wf_id}"
 
           exprs=(
             '1e5' '1e+5' '1E+5' '1e-5' '1e01' '1e+01' '1e0123' '1.0e+99'
             '1.0e+' '1e+' '1e' '1e-0' '1e5e5' '1e309'
             '0123' '00' '0' '-0' '1.5' '1.' '.5' '.5e1'
             '0o17' '0O17' '0o8'
-            '0x1F' '0X1F' '0x0123' '0x0e1' '0xG'
+            '0x1F' '0X1F' '0x01' '0x0123' '0x0e1' '0xG'
             '0b101' '0B101'
             '+1' '-1' '1_000'
             'NaN' 'Infinity' '-Infinity'
-            '9007199254740993' '0.1 + 0.2' '1 + 1' '1e+5 == 100000'
+            '2147483648' '9007199254740993'
+            '0.1 + 0.2' '1 + 1' '1e+5 == 100000'
           )
 
-          cases="$RUNNER_TEMP/cases"
-          mkdir -p "$cases"
+          cases="${RUNNER_TEMP}/cases"
+          mkdir -p "${cases}"
           for i in "${!exprs[@]}"; do
-            idx="$(printf '%02d' "$i")"
-            expr="${exprs[$i]}"
-            cat > "$cases/$idx.yaml" <<CASE
-          name: expression conformance case $idx
-          run-name: "CASE~$idx~${dollar}{{ $expr }}~${dollar}{{ toJSON($expr) }}"
+            idx="$(printf '%02d' "${i}")"
+            expr="${exprs[${i}]}"
+            cat > "${cases}/${idx}.yaml" <<CASE
+          name: expression conformance case ${idx}
+          run-name: "CASE~${idx}~${dollar}{{ ${expr} }}~${dollar}{{ toJSON(${expr}) }}"
           on:
             workflow_dispatch:
           permissions: {}
@@ -95,74 +96,77 @@ jobs:
               runs-on: ubuntu-latest
               steps:
                 - run: |
-                    echo "PROBE_ID=$idx"
-                    echo "PROBE_VALUE=${dollar}{{ $expr }}"
-                    echo "PROBE_JSON=${dollar}{{ toJSON($expr) }}"
+                    echo "PROBE_ID=${idx}"
+                    echo "PROBE_VALUE=${dollar}{{ ${expr} }}"
+                    echo "PROBE_JSON=${dollar}{{ toJSON(${expr}) }}"
                     echo "PROBE_IMAGE=\$ImageOS \$ImageVersion"
           CASE
-            blob="$(jq -n --arg c "$(base64 -w0 < "$cases/$idx.yaml")" \
+            case_b64="$(base64 -w0 < "${cases}/${idx}.yaml")"
+            blob="$(jq -n --arg c "${case_b64}" \
               '{content: $c, encoding: "base64"}' \
-              | gh api -X POST "repos/$repo/git/blobs" --input - --jq .sha)"
-            tree="$(jq -n --arg p "$wf_path" --arg s "$blob" \
+              | gh api -X POST "repos/${repo}/git/blobs" --input - --jq .sha)"
+            tree="$(jq -n --arg p "${wf_path}" --arg s "${blob}" \
               '{tree: [{path: $p, mode: "100644", type: "blob", sha: $s}]}' \
-              | gh api -X POST "repos/$repo/git/trees" --input - --jq .sha)"
-            commit="$(jq -n --arg m "expression conformance case $idx" --arg t "$tree" \
+              | gh api -X POST "repos/${repo}/git/trees" --input - --jq .sha)"
+            commit="$(jq -n --arg m "expression conformance case ${idx}" --arg t "${tree}" \
               '{message: $m, tree: $t}' \
-              | gh api -X POST "repos/$repo/git/commits" --input - --jq .sha)"
-            jq -n --arg r "refs/heads/$WF_PREFIX/$idx" --arg s "$commit" \
+              | gh api -X POST "repos/${repo}/git/commits" --input - --jq .sha)"
+            jq -n --arg r "refs/heads/${WF_PREFIX}/${idx}" --arg s "${commit}" \
               '{ref: $r, sha: $s}' \
-              | gh api -X POST "repos/$repo/git/refs" --input - --jq .ref
+              | gh api -X POST "repos/${repo}/git/refs" --input - --jq .ref
           done
-          echo "created ${#exprs[@]} case refs under $WF_PREFIX"
+          echo "created ${#exprs[@]} case refs under ${WF_PREFIX}"
 
           verdicts=()
           messages=()
           for i in "${!exprs[@]}"; do
-            idx="$(printf '%02d' "$i")"
+            idx="$(printf '%02d' "${i}")"
             set +e
-            body="$(gh api -X POST "repos/$repo/actions/workflows/$wf_id/dispatches" \
-              -f ref="$WF_PREFIX/$idx" 2>"$RUNNER_TEMP/dispatch.err")"
+            body="$(gh api -X POST "repos/${repo}/actions/workflows/${wf_id}/dispatches" \
+              -f ref="${WF_PREFIX}/${idx}" 2>"${RUNNER_TEMP}/dispatch.err")"
             rc=$?
-            message="$(printf '%s' "$body" | jq -r '.message // empty')"
+            message="$(printf '%s' "${body}" | jq -r '.message // empty')"
             set -e
-            if [ "$rc" -eq 0 ]; then
+            if [[ "${rc}" -eq 0 ]]; then
               verdicts+=('accepted')
               messages+=('')
-            elif [ "${message#*failed to parse workflow}" != "$message" ]; then
+            elif [[ "${message#*failed to parse workflow}" != "${message}" ]]; then
               verdicts+=('rejected')
-              messages+=("$message")
+              messages+=("${message}")
             else
               verdicts+=('error')
-              messages+=("${message:-$(cat "$RUNNER_TEMP/dispatch.err")}")
+              messages+=("${message:-$(cat "${RUNNER_TEMP}/dispatch.err")}")
             fi
             printf '%s %-20s %-8s %s\n' \
-              "$idx" "${exprs[$i]}" "${verdicts[$i]}" "${messages[$i]}"
+              "${idx}" "${exprs[${i}]}" "${verdicts[${i}]}" "${messages[${i}]}"
           done
 
           deadline=$(( $(date +%s) + 1200 ))
           runs='{"workflow_runs":[]}'
           while :; do
-            runs="$(gh api "repos/$repo/actions/workflows/$wf_id/runs?event=workflow_dispatch&per_page=100")"
+            runs="$(gh api "repos/${repo}/actions/workflows/${wf_id}/runs?event=workflow_dispatch&per_page=100")"
             pending=0
             for i in "${!exprs[@]}"; do
-              if [ "${verdicts[$i]}" != 'accepted' ]; then continue; fi
-              idx="$(printf '%02d' "$i")"
-              status="$(printf '%s' "$runs" | jq -r --arg b "$WF_PREFIX/$idx" \
+              if [[ "${verdicts[${i}]}" != 'accepted' ]]; then continue; fi
+              idx="$(printf '%02d' "${i}")"
+              status="$(printf '%s' "${runs}" | jq -r --arg b "${WF_PREFIX}/${idx}" \
                 '[.workflow_runs[] | select(.head_branch == $b)] | (first // {}) | .status // "missing"')"
-              if [ "$status" != 'completed' ]; then pending=$(( pending + 1 )); fi
+              if [[ "${status}" != 'completed' ]]; then pending=$(( pending + 1 )); fi
             done
-            echo "waiting for $pending case run(s)"
-            if [ "$pending" -eq 0 ]; then break; fi
-            if [ "$(date +%s)" -ge "$deadline" ]; then break; fi
+            echo "waiting for ${pending} case run(s)"
+            if [[ "${pending}" -eq 0 ]]; then break; fi
+            now="$(date +%s)"
+            if [[ "${now}" -ge "${deadline}" ]]; then break; fi
             sleep 15
           done
 
           bt=$'\x60'
+          measured="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
           {
             echo "## Expression literal conformance on GitHub"
             echo
-            echo "- measured: $(date -u '+%Y-%m-%dT%H:%M:%SZ')"
-            echo "- repository: \`$repo\` at \`$GITHUB_SHA\`"
+            echo "- measured: ${measured}"
+            echo "- repository: \`${repo}\` at \`${GITHUB_SHA}\`"
             echo "- driver runner: \`ubuntu-latest\` = \`${ImageOS:-unknown}\` \`${ImageVersion:-unknown}\`"
             echo "- verdict: \`POST /actions/workflows/{id}/dispatches\`, HTTP 422 means rejected"
             echo "- value: the \`run-name\` GitHub rendered for the accepted case"
@@ -170,37 +174,37 @@ jobs:
             echo "| # | expression | verdict | value | toJSON | run | parser message |"
             echo "| --- | --- | --- | --- | --- | --- | --- |"
             for i in "${!exprs[@]}"; do
-              idx="$(printf '%02d' "$i")"
+              idx="$(printf '%02d' "${i}")"
               value=''
               json=''
               conclusion=''
-              if [ "${verdicts[$i]}" = 'accepted' ]; then
-                found="$(printf '%s' "$runs" | jq -r --arg b "$WF_PREFIX/$idx" \
+              if [[ "${verdicts[${i}]}" == 'accepted' ]]; then
+                found="$(printf '%s' "${runs}" | jq -r --arg b "${WF_PREFIX}/${idx}" \
                   '[.workflow_runs[] | select(.head_branch == $b)] | (first // {})
                    | "\(.name // "")\t\(.conclusion // "incomplete")"')"
                 name="${found%%$'\t'*}"
                 conclusion="${found##*$'\t'}"
-                value="${name#"CASE~$idx~"}"
+                value="${name#"CASE~${idx}~"}"
                 json="${value##*~}"
                 value="${value%%~*}"
               fi
               printf '| %s | %s | %s | %s | %s | %s | %s |\n' \
-                "$idx" "$bt${exprs[$i]}$bt" "${verdicts[$i]}" \
-                "$bt$value$bt" "$bt$json$bt" \
-                "$conclusion" "${messages[$i]//|/\\|}"
+                "${idx}" "${bt}${exprs[${i}]}${bt}" "${verdicts[${i}]}" \
+                "${bt}${value}${bt}" "${bt}${json}${bt}" \
+                "${conclusion}" "${messages[${i}]//|/\\|}"
             done
-          } | tee -a "$GITHUB_STEP_SUMMARY"
+          } | tee -a "${GITHUB_STEP_SUMMARY}"
 
       - name: Delete the temporary case refs
         if: always()
         run: |
           set -euo pipefail
-          refs="$(gh api "repos/$GITHUB_REPOSITORY/git/matching-refs/heads/$WF_PREFIX/" --jq '.[].ref')"
-          if [ -z "$refs" ]; then
+          refs="$(gh api "repos/${GITHUB_REPOSITORY}/git/matching-refs/heads/${WF_PREFIX}/" --jq '.[].ref')"
+          if [[ -z "${refs}" ]]; then
             echo 'no case refs to delete'
             exit 0
           fi
           while read -r ref; do
-            gh api --silent -X DELETE "repos/$GITHUB_REPOSITORY/git/$ref"
-            echo "deleted $ref"
-          done <<< "$refs"
+            gh api --silent -X DELETE "repos/${GITHUB_REPOSITORY}/git/${ref}"
+            echo "deleted ${ref}"
+          done <<< "${refs}"

--- a/.github/workflows/expr-conformance-probe.yaml
+++ b/.github/workflows/expr-conformance-probe.yaml
@@ -1,0 +1,206 @@
+name: Expression conformance probe
+
+on:
+  workflow_dispatch:
+
+# contents: write creates and deletes the temporary case refs, and actions:
+# write is required by the workflow-dispatch endpoint that returns GitHub's
+# parser verdict. Neither is enough on its own: GITHUB_TOKEN is refused on any
+# ref update that touches .github/workflows, and the permissions block has no
+# key that grants it, so EXPR_PROBE_TOKEN must carry contents and workflows
+# write for this probe to run.
+permissions: { contents: write, actions: write }
+
+jobs:
+  probe:
+    name: Evaluate expression literals on GitHub
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      GH_TOKEN: ${{ secrets.EXPR_PROBE_TOKEN || github.token }}
+      WF_PREFIX: probe/expr-conformance/${{ github.run_id }}
+    steps:
+      - name: Preflight
+        run: |
+          set -euo pipefail
+          repo="$GITHUB_REPOSITORY"
+          wf_path="${GITHUB_WORKFLOW_REF%%@*}"
+          wf_path="${wf_path#"$repo/"}"
+
+          if ! blob="$(jq -n '{content: "cHJlZmxpZ2h0Cg==", encoding: "base64"}' \
+            | gh api -X POST "repos/$repo/git/blobs" --input - --jq .sha 2>&1)"; then
+            echo "::error::the probe token cannot write git objects: $blob"
+            echo 'Set the EXPR_PROBE_TOKEN secret to a token with contents write.'
+            exit 1
+          fi
+          echo "git object write: ok"
+
+          tree="$(jq -n --arg p "$wf_path" --arg s "$blob" \
+            '{tree: [{path: $p, mode: "100644", type: "blob", sha: $s}]}' \
+            | gh api -X POST "repos/$repo/git/trees" --input - --jq .sha)"
+          commit="$(jq -n --arg t "$tree" '{message: "preflight", tree: $t}' \
+            | gh api -X POST "repos/$repo/git/commits" --input - --jq .sha)"
+          if ! out="$(jq -n --arg r "refs/heads/$WF_PREFIX/preflight" --arg s "$commit" \
+            '{ref: $r, sha: $s}' \
+            | gh api -X POST "repos/$repo/git/refs" --input - --jq .ref 2>&1)"; then
+            echo "::error::the probe token may not write under .github/workflows: $out"
+            echo 'Set the EXPR_PROBE_TOKEN secret to a token that also has workflows write.'
+            exit 1
+          fi
+          echo "workflow ref write: ok"
+
+      - name: Probe
+        run: |
+          set -euo pipefail
+
+          # GitHub registers a workflow only once it is on the default branch or
+          # has already produced a run, so a ref-only file that has never run
+          # cannot be dispatched. Every case therefore reuses this file's own
+          # registered path on a ref of its own, dispatched with that ref. One
+          # case per file is not a choice: a workflow with an invalid expression
+          # is rejected whole, and the rejection lists at most ten parse errors.
+          dollar='$'
+          repo="$GITHUB_REPOSITORY"
+          wf_path="${GITHUB_WORKFLOW_REF%%@*}"
+          wf_path="${wf_path#"$repo/"}"
+          wf_id="$(gh api "repos/$repo/actions/workflows" --paginate \
+            --jq ".workflows[] | select(.path == \"$wf_path\") | .id")"
+          echo "workflow $wf_path is id $wf_id"
+
+          exprs=(
+            '1e5' '1e+5' '1E+5' '1e-5' '1e01' '1e+01' '1e0123' '1.0e+99'
+            '1.0e+' '1e+' '1e' '1e-0' '1e5e5' '1e309'
+            '0123' '00' '0' '-0' '1.5' '1.' '.5' '.5e1'
+            '0o17' '0O17' '0o8'
+            '0x1F' '0X1F' '0x0123' '0x0e1' '0xG'
+            '0b101' '0B101'
+            '+1' '-1' '1_000'
+            'NaN' 'Infinity' '-Infinity'
+            '9007199254740993' '0.1 + 0.2' '1 + 1' '1e+5 == 100000'
+          )
+
+          cases="$RUNNER_TEMP/cases"
+          mkdir -p "$cases"
+          for i in "${!exprs[@]}"; do
+            idx="$(printf '%02d' "$i")"
+            expr="${exprs[$i]}"
+            cat > "$cases/$idx.yaml" <<CASE
+          name: expression conformance case $idx
+          run-name: "CASE~$idx~${dollar}{{ $expr }}~${dollar}{{ toJSON($expr) }}"
+          on:
+            workflow_dispatch:
+          permissions: {}
+          jobs:
+            eval:
+              runs-on: ubuntu-latest
+              steps:
+                - run: |
+                    echo "PROBE_ID=$idx"
+                    echo "PROBE_VALUE=${dollar}{{ $expr }}"
+                    echo "PROBE_JSON=${dollar}{{ toJSON($expr) }}"
+                    echo "PROBE_IMAGE=\$ImageOS \$ImageVersion"
+          CASE
+            blob="$(jq -n --arg c "$(base64 -w0 < "$cases/$idx.yaml")" \
+              '{content: $c, encoding: "base64"}' \
+              | gh api -X POST "repos/$repo/git/blobs" --input - --jq .sha)"
+            tree="$(jq -n --arg p "$wf_path" --arg s "$blob" \
+              '{tree: [{path: $p, mode: "100644", type: "blob", sha: $s}]}' \
+              | gh api -X POST "repos/$repo/git/trees" --input - --jq .sha)"
+            commit="$(jq -n --arg m "expression conformance case $idx" --arg t "$tree" \
+              '{message: $m, tree: $t}' \
+              | gh api -X POST "repos/$repo/git/commits" --input - --jq .sha)"
+            jq -n --arg r "refs/heads/$WF_PREFIX/$idx" --arg s "$commit" \
+              '{ref: $r, sha: $s}' \
+              | gh api -X POST "repos/$repo/git/refs" --input - --jq .ref
+          done
+          echo "created ${#exprs[@]} case refs under $WF_PREFIX"
+
+          verdicts=()
+          messages=()
+          for i in "${!exprs[@]}"; do
+            idx="$(printf '%02d' "$i")"
+            set +e
+            body="$(gh api -X POST "repos/$repo/actions/workflows/$wf_id/dispatches" \
+              -f ref="$WF_PREFIX/$idx" 2>"$RUNNER_TEMP/dispatch.err")"
+            rc=$?
+            message="$(printf '%s' "$body" | jq -r '.message // empty')"
+            set -e
+            if [ "$rc" -eq 0 ]; then
+              verdicts+=('accepted')
+              messages+=('')
+            elif [ "${message#*failed to parse workflow}" != "$message" ]; then
+              verdicts+=('rejected')
+              messages+=("$message")
+            else
+              verdicts+=('error')
+              messages+=("${message:-$(cat "$RUNNER_TEMP/dispatch.err")}")
+            fi
+            printf '%s %-20s %-8s %s\n' \
+              "$idx" "${exprs[$i]}" "${verdicts[$i]}" "${messages[$i]}"
+          done
+
+          deadline=$(( $(date +%s) + 1200 ))
+          runs='{"workflow_runs":[]}'
+          while :; do
+            runs="$(gh api "repos/$repo/actions/workflows/$wf_id/runs?event=workflow_dispatch&per_page=100")"
+            pending=0
+            for i in "${!exprs[@]}"; do
+              if [ "${verdicts[$i]}" != 'accepted' ]; then continue; fi
+              idx="$(printf '%02d' "$i")"
+              status="$(printf '%s' "$runs" | jq -r --arg b "$WF_PREFIX/$idx" \
+                '[.workflow_runs[] | select(.head_branch == $b)] | (first // {}) | .status // "missing"')"
+              if [ "$status" != 'completed' ]; then pending=$(( pending + 1 )); fi
+            done
+            echo "waiting for $pending case run(s)"
+            if [ "$pending" -eq 0 ]; then break; fi
+            if [ "$(date +%s)" -ge "$deadline" ]; then break; fi
+            sleep 15
+          done
+
+          bt=$'\x60'
+          {
+            echo "## Expression literal conformance on GitHub"
+            echo
+            echo "- measured: $(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+            echo "- repository: \`$repo\` at \`$GITHUB_SHA\`"
+            echo "- driver runner: \`ubuntu-latest\` = \`${ImageOS:-unknown}\` \`${ImageVersion:-unknown}\`"
+            echo "- verdict: \`POST /actions/workflows/{id}/dispatches\`, HTTP 422 means rejected"
+            echo "- value: the \`run-name\` GitHub rendered for the accepted case"
+            echo
+            echo "| # | expression | verdict | value | toJSON | run | parser message |"
+            echo "| --- | --- | --- | --- | --- | --- | --- |"
+            for i in "${!exprs[@]}"; do
+              idx="$(printf '%02d' "$i")"
+              value=''
+              json=''
+              conclusion=''
+              if [ "${verdicts[$i]}" = 'accepted' ]; then
+                found="$(printf '%s' "$runs" | jq -r --arg b "$WF_PREFIX/$idx" \
+                  '[.workflow_runs[] | select(.head_branch == $b)] | (first // {})
+                   | "\(.name // "")\t\(.conclusion // "incomplete")"')"
+                name="${found%%$'\t'*}"
+                conclusion="${found##*$'\t'}"
+                value="${name#"CASE~$idx~"}"
+                json="${value##*~}"
+                value="${value%%~*}"
+              fi
+              printf '| %s | %s | %s | %s | %s | %s | %s |\n' \
+                "$idx" "$bt${exprs[$i]}$bt" "${verdicts[$i]}" \
+                "$bt$value$bt" "$bt$json$bt" \
+                "$conclusion" "${messages[$i]//|/\\|}"
+            done
+          } | tee -a "$GITHUB_STEP_SUMMARY"
+
+      - name: Delete the temporary case refs
+        if: always()
+        run: |
+          set -euo pipefail
+          refs="$(gh api "repos/$GITHUB_REPOSITORY/git/matching-refs/heads/$WF_PREFIX/" --jq '.[].ref')"
+          if [ -z "$refs" ]; then
+            echo 'no case refs to delete'
+            exit 0
+          fi
+          while read -r ref; do
+            gh api --silent -X DELETE "repos/$GITHUB_REPOSITORY/git/$ref"
+            echo "deleted $ref"
+          done <<< "$refs"


### PR DESCRIPTION
`ExprLexer.lexNum` is written against a specification. Which specification is an open question: [GitHub's expression reference](https://docs.github.com/en/actions/reference/workflows-and-actions/expressions#literals) says a `number` literal is "Any number format supported by JSON", while the runner's [`ParseNumber`](https://github.com/actions/runner/blob/258d6c857db3519913f7deb6004b60172f8043ae/src/Sdk/DTExpressions2/Expressions2/Sdk/ExpressionUtility.cs#L189-L192) says three lines above the parse that it follows JavaScript's `Number()`. Both statements are wrong about the thing that actually runs.

This adds a workflow that asks GitHub directly. It submits each expression to GitHub's own parser and prints what came back, so a claim about lexer conformance can cite a run instead of a reading of C#.

## What the design had to work around

Four constraints, each measured rather than assumed.

**An invalid expression rejects the whole file, and the reason is unreadable over REST.** The run's conclusion is `failure`, not `startup_failure`; it has no jobs, `latest_check_runs_count` is 0, and `/actions/runs/{id}/annotations`, `/check-suites/{id}/annotations`, `commits/{sha}/statuses` and the log endpoint are all empty or 404. GitHub's parser message exists only in the web UI.

**`POST /actions/workflows/{id}/dispatches` returns it.** On a ref whose workflow does not parse, that endpoint answers HTTP 422 with the literal text — `Invalid Argument - failed to parse workflow: (Line: 2, Col: 11): Unexpected symbol: '1e+'. Located at position 1 within expression: 1e+`. That is the verdict source here, so a rejected case costs no runner minutes.

**A workflow that only exists on a branch and has never run cannot be dispatched.** It does not appear in `/actions/workflows` and dispatch answers 404. Registration happens when the workflow first produces a run or lands on the default branch, and then persists. Every case therefore reuses this file's own registered path on a throwaway ref rather than getting a filename of its own.

**One file cannot hold the matrix.** Within a scalar the parser stops at the first error, and across scalars the reported list is capped at ten — a file with fourteen bad expressions returns ten. One expression per file is a requirement, not a preference.

So each case becomes a root commit whose tree holds exactly one file, on a ref `probe/expr-conformance/<run_id>/NN`, dispatched by ref. The verdict is the HTTP status and the value is the `run-name` GitHub rendered. Refs are deleted in an `if: always()` step.

## It needs a token this repository does not have yet

`GITHUB_TOKEN` cannot write under `.github/workflows` by any transport, and `permissions:` has no key that grants it.

- Over git: [run 32465209606](https://github.com/kjanat/actionlint/actions/runs/32465209606) — `! [remote rejected] ... refusing to allow a GitHub App to create or update workflow '.github/workflows/expr-conformance-probe.yaml' without 'workflows' permission`.
- Over the Git Data API: [run 32465621135](https://github.com/kjanat/actionlint/actions/runs/32465621135) and [run 32466233712](https://github.com/kjanat/actionlint/actions/runs/32466233712) — blob, tree and commit all succeed, then `POST /git/refs` answers `Resource not accessible by integration` with 403.
- The scope does not exist to ask for: [`rule_permissions.go:5-26`](https://github.com/kjanat/actionlint/blob/77bd61b79cfecd46806cc4af085c699069abf9e9/rule_permissions.go#L5-L26) lists the 20 scopes from [GitHub's workflow syntax](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#permissions), and `workflows` is not among them.

The job therefore reads `secrets.EXPR_PROBE_TOKEN || github.token`, and a preflight step separates the two failure modes before any case is created: it writes a git object, then writes a ref, and names whichever one was refused. Without the secret the probe stops in the first step with that message instead of half-creating refs.

## What the first run measured

Driven through the same mechanism from a workstation with a workflow-scoped token, since the hosted job cannot run until the secret exists. 44 expressions, 30 accepted, 14 rejected. `ubuntu-24.04` image `20260816.277.1`, runner 2.336.0. `toJSON()` returned the same text unquoted for every accepted case, so these are numbers and not strings.

`main` is actionlint at [`cf04c1f`](https://github.com/kjanat/actionlint/commit/cf04c1f1524510b1075d869f8db25524de7ee834); `#29` is [PR #29](https://github.com/kjanat/actionlint/pull/29) at `5a1acfd`.

| expression | GitHub | renders as | `main` | #29 |
| --- | --- | --- | --- | --- |
| `1e5` | accepted | `100000` | ok | ok |
| `1e+5` | accepted | `100000` | error | ok |
| `1E+5` | accepted | `100000` | error | ok |
| `1e-5` | accepted | `1E-05` | ok | ok |
| `1e01` | accepted | `10` | error | ok |
| `1e+01` | accepted | `10` | error | ok |
| `1e0123` | accepted | `1E+123` | error | ok |
| `1.0e+99` | accepted | `1E+99` | error | ok |
| `1e-0` | accepted | `1` | ok | ok |
| `1.0e+` | rejected | | error | error |
| `1e+` | rejected | | error | error |
| `1e` | rejected | | error | error |
| `1e5e5` | rejected | | error | error |
| `1e309` | rejected | | error | error |
| `0` | accepted | `0` | ok | ok |
| `-0` | accepted | `0` | ok | ok |
| `00` | accepted | `0` | error | error |
| `0123` | accepted | [`123`](https://github.com/kjanat/actionlint/actions/runs/32465823372) | error | error |
| `1.5` | accepted | `1.5` | ok | ok |
| `1.` | accepted | [`1`](https://github.com/kjanat/actionlint/actions/runs/32465831358) | error | error |
| `.5` | accepted | [`0.5`](https://github.com/kjanat/actionlint/actions/runs/32465833047) | error | error |
| `.5e1` | accepted | `5` | error | error |
| `0o17` | accepted | [`15`](https://github.com/kjanat/actionlint/actions/runs/32465837589) | error | error |
| `0O17` | rejected | | error | error |
| `0o8` | rejected | | error | error |
| `0x1F` | accepted | `31` | ok | ok |
| `0X1F` | rejected | | error | error |
| `0x01` | accepted | [`1`](https://github.com/kjanat/actionlint/actions/runs/32466600906) | error | error |
| `0x0123` | accepted | [`291`](https://github.com/kjanat/actionlint/actions/runs/32465845817) | error | error |
| `0x0e1` | accepted | [`225`](https://github.com/kjanat/actionlint/actions/runs/32465847785) | error | error |
| `0xG` | rejected | | error | error |
| `0b101` | rejected | | error | error |
| `0B101` | rejected | | error | error |
| `+1` | accepted | [`1`](https://github.com/kjanat/actionlint/actions/runs/32465853857) | error | error |
| `-1` | accepted | `-1` | ok | ok |
| `1_000` | rejected | | error | error |
| `NaN` | accepted | [`NaN`](https://github.com/kjanat/actionlint/actions/runs/32465858876) | error | error |
| `Infinity` | accepted | [`Infinity`](https://github.com/kjanat/actionlint/actions/runs/32465860522) | error | error |
| `-Infinity` | accepted | `-Infinity` | error | error |
| `2147483648` | accepted | [`2147483648`](https://github.com/kjanat/actionlint/actions/runs/32466602668) | error | error |
| `9007199254740993` | accepted | [`9.00719925474099E+15`](https://github.com/kjanat/actionlint/actions/runs/32465864067) | error | error |
| `0.1 + 0.2` | rejected | | error | error |
| `1 + 1` | rejected | | error | error |
| `1e+5 == 100000` | accepted | `true` | error | ok |

An unplanned second signal agrees with the first. Because the driving pushes came from a user token rather than an app, every invalid file also produced a push-event run — a workflow that cannot parse cannot read its own `on:` and fires on everything. That happened for exactly the fourteen cases the 422 marked rejected and for none of the thirty it accepted.

## What the numbers say

**GitHub's documented rule is wrong in both directions.** `0x1F`, `0o17`, `+1`, `.5`, `1.`, `0123`, `NaN` and `Infinity` are accepted and none is valid JSON. `1e309` is valid JSON and is rejected.

**The runner's own doc comment is wrong too.** `Number("0X1F")` is 31, `Number("0O17")` is 15, `Number("0b101")` is 5 and `Number("1e309")` is `Infinity`; GitHub rejects all four. The base prefix is case-sensitive — `0x` and `0o` work, `0X` and `0O` do not — while the exponent marker is not, since `1E+5` works.

**Numbers do not survive a round trip.** GitHub renders them .NET style at fifteen significant digits: `1e-5` becomes `1E-05`, `1e0123` becomes `1E+123`, and `9007199254740993` comes back as `9.00719925474099E+15`.

**`CHANGELOG.md:2122` is wrong about both of its examples.** The v1.5.2 note reads "Fix checking invalid numbers where some digit follows zero in a hex number (e.g. `0x01`) or an exponent part of number (e.g. `1e0123`)". GitHub accepts `0x01` as `1` and `1e0123` as `1E+123`.

**actionlint's integers are 32-bit.** [`expr_parser.go:140-151`](https://github.com/kjanat/actionlint/blob/77bd61b79cfecd46806cc4af085c699069abf9e9/expr_parser.go#L140-L151) calls `strconv.ParseInt(t.Value, 0, 32)`, so `2147483648` is reported as an invalid integer literal while GitHub evaluates it.

## Verification

```
$ make build SKIP_GO_GENERATE=true
CGO_ENABLED=0 go build ./cmd/actionlint

$ make test
ok  	actionlint.kjanat.dev	280.124s
(all other packages ok)

$ make lint SKIP_GO_GENERATE=true
golangci-lint run
0 issues.
govulncheck ./...
No vulnerabilities found.
GOOS=js GOARCH=wasm golangci-lint run ./playground
0 issues.
go run ./scripts/check-checks -quiet ./docs/checks.md

$ dprint check
(no output, exit 0)

$ ./actionlint -color -shellcheck 'shellcheck -o all'
(no output, exit 0)
```

The last one is the command [`ci.yaml:80`](https://github.com/kjanat/actionlint/blob/77bd61b79cfecd46806cc4af085c699069abf9e9/.github/workflows/ci.yaml#L80) runs. Under those settings the first draft of this file reported 112 issues while every other workflow in the repository reported none; they are fixed in code, with no suppressions and no `.shellcheckrc` entry, which would not apply anyway because actionlint invokes ShellCheck with `--norc`.

No Go code changes, so the Go gates cannot regress; they were run regardless.

## Before this can run here

Create an `EXPR_PROBE_TOKEN` secret holding a token with `contents: write` and `workflows: write`. Until then the preflight step fails with the specific missing permission rather than a 403 halfway through.
