### PR TITLE
Enforce the staticcheck doc-comment checks through golangci-lint

### DIFF
--- a/.golangci.toml
+++ b/.golangci.toml
@@ -40,9 +40,12 @@ enable  = [
   "whitespace"
 ]
 
+[linters.settings.staticcheck]
+checks = ["all", "-ST1003"]
+
 [linters.exclusions]
 generated = "lax"
-presets   = ["comments", "std-error-handling"]
+presets   = ["std-error-handling"]
 paths     = [
   # An npm dependency ships Go sources that are not part of this module.
   "node_modules",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,16 +109,30 @@ Automated tests are as follows.
 
 ## Linting
 
-[staticcheck](https://staticcheck.io/) is used to lint Go sources.
+[golangci-lint](https://golangci-lint.run/) runs the Go linters, configured by [`.golangci.toml`](./.golangci.toml).
+Install the binary as described in [its documentation](https://golangci-lint.run/docs/welcome/install/). CI pins the
+version in [`ci.yaml`](.github/workflows/ci.yaml).
 
 ```sh
-staticcheck ./...
+golangci-lint run
 ```
+
+`.golangci.toml` turns on staticcheck's doc comment checks. A non-`main` package needs a package comment starting with
+`Package <name>`. A doc comment on an exported symbol must start with that symbol's name, with an optional leading
+article for types. An exported symbol carrying no doc comment at all is accepted.
 
 [govulncheck](https://go.dev/doc/security/vuln/) is used for security checks.
 
 ```sh
-govulncheck ./...
+go run golang.org/x/vuln/cmd/govulncheck@latest ./...
+```
+
+[modernize](https://pkg.go.dev/golang.org/x/tools/go/analysis/passes/modernize) rewrites code to newer Go idioms.
+golangci-lint reports its findings and the [autofix workflow](.github/workflows/autofix.yml) applies the fixes on every
+pull request. The same fixes can be applied locally with the following command.
+
+```sh
+go run golang.org/x/tools/go/analysis/passes/modernize/cmd/modernize@latest -fix ./...
 ```
 
 These lints can be run with other checks by the following command.

--- a/staticcheck.conf
+++ b/staticcheck.conf
@@ -1,6 +1,0 @@
-# https://staticcheck.dev/docs/configuration/
-
-# https://staticcheck.dev/docs/checks/
-checks = ["inherit", "ST1016", "ST1020", "ST1021", "ST1022", "ST1000"]
-
-# vim: ft=toml


### PR DESCRIPTION
`staticcheck.conf` asked for five checks and got none of them. Nothing in this repository reads the file: the `staticcheck` binary is never invoked, and golangci-lint carries its own staticcheck settings rather than reading a project's `staticcheck.conf`.

```toml
checks = ["inherit", "ST1016", "ST1020", "ST1021", "ST1022", "ST1000"]
```

Two separate layers were switching those checks off, and either one alone is enough to hide them. Measured on this tree with one existing doc comment deliberately rewritten so that it no longer starts with its symbol's name, golangci-lint 2.13.1:

| `[linters.settings.staticcheck].checks` | `comments` in `[linters.exclusions].presets` | result |
| --- | --- | --- |
| unset, so the golangci-lint default | present, as on `main` | `0 issues.` |
| `["all", "-ST1003"]` | present | `0 issues.` |
| unset | dropped | `0 issues.` |
| `["all", "-ST1003"]` | dropped | `ST1021` reported |

The default disables the checks, and the [`comments` preset](https://github.com/kjanat/actionlint/blob/77bd61b79cfecd46806cc4af085c699069abf9e9/.golangci.toml#L45) is `EXC0011`, which drops the findings after the linter has produced them. Only changing both turns the check on.

## What changes

`checks = ["all", "-ST1003"]` in `[linters.settings.staticcheck]`, and the `comments` preset drops out of the exclusion list.

That turns on the five checks the deleted file asked for. ST1003 stays off to hold the status quo — golangci-lint already had it off, and enabling it reports `package actionlint_fuzz` in all four files under `fuzz/`, which is a rename this change has no business making.

Dropping the preset also drops EXC0012 through EXC0015, which target `revive`. Revive is neither in the `enable` list nor in golangci-lint's standard set, so that has no effect today. Enabling revive later will surface exported-comment reports the preset used to hide.

## What the checks actually enforce

Narrower than the name suggests, and worth stating because the rule is easy to get wrong in both directions.

ST1020, ST1021 and ST1022 fire only on a doc comment that **exists** and does not start with the symbol's name. Their implementation reads `text, ok := docText(decl.Doc); if !ok { return }`, so a missing doc comment is silent. ST1000 is the only one that fires on absence, and it fires at package level and skips `package main`.

So from here `make lint` rejects a new non-`main` package with no package comment, and any doc comment on an exported symbol that does not lead with that symbol's name (types may lead with an article). It does not require that exported symbols carry doc comments.

The fourth row above is the control, in full:

```
$ golangci-lint run
rule_permissions.go:28:1: ST1021: comment on exported type RulePermissions should be of the form "RulePermissions ..." (with optional leading article) (staticcheck)
// This rule checker checks permission configurations in a workflow.
^
1 issues:
* staticcheck: 1
```

The tree as it stands passes unmodified.

## `CONTRIBUTING.md`

The Linting section told contributors to run `staticcheck ./...`, which has done nothing since golangci-lint took the job over, and gave `govulncheck ./...` as a bare binary invocation that [`Makefile`](https://github.com/kjanat/actionlint/blob/77bd61b79cfecd46806cc4af085c699069abf9e9/Makefile) does not use. It now describes golangci-lint, govulncheck and modernize the way `make lint` and the autofix workflow actually invoke them, and records the doc comment rules this configuration enforces.

## Provenance

Follow-up to [#27](https://github.com/kjanat/actionlint/pull/27), which is closed. That pull request bundled three unrelated things: pinning govulncheck and modernize as Go tool dependencies, adding a Dependabot ecosystem, and this cleanup. The tool pinning was rejected on its merits — pinning a vulnerability scanner freezes the analysis while its vulnerability database keeps moving, and pinning a modernization tool defeats the point of running one. The Dependabot entry shipped separately as [#32](https://github.com/kjanat/actionlint/pull/32). This is the third piece.

No upstream code is derived here, so there is no co-author trailer.

## Verification

```
$ make build SKIP_GO_GENERATE=true
CGO_ENABLED=0 go build ./cmd/actionlint

$ make test
ok  	actionlint.kjanat.dev	281.572s
ok  	actionlint.kjanat.dev/cmd/actionlint-action	1.050s
ok  	actionlint.kjanat.dev/fuzz	1.018s
ok  	actionlint.kjanat.dev/scripts/bump-version	(cached)
ok  	actionlint.kjanat.dev/scripts/check-checks	58.735s
ok  	actionlint.kjanat.dev/scripts/generate-availability	(cached)
ok  	actionlint.kjanat.dev/scripts/generate-popular-actions	2.065s
ok  	actionlint.kjanat.dev/scripts/generate-webhook-events	(cached)

$ make lint SKIP_GO_GENERATE=true
golangci-lint run
0 issues.
go run golang.org/x/vuln/cmd/govulncheck@latest ./...
No vulnerabilities found.
GOOS=js GOARCH=wasm golangci-lint run ./playground
0 issues.
go run ./scripts/check-checks -quiet ./docs/checks.md

$ dprint check
(no output, exit 0)
```

All four ran on this branch after it was rebased onto `main`, so the newly enabled checks were exercised against every Go file merged since the branch was cut.
