### PR TITLE
Document the split between correctness checks and policy checks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,14 +1,33 @@
 # Policy for actionlint's features
 
-- actionlint focuses on detecting mistakes. Feature requests and patches for checks that enforces code style or
-  some conventions are generally not accepted.
-- actionlint tries to keep [the configuration](docs/config.md) as minimal as possible. Feature requests and patches
-  for checks that require user configurations are generally not accepted.
+actionlint has two kinds of checks.
 
-These are important to keep actionlint useful and convenient for everyone. I believe that no one wants to create and
-maintain a heavy configuration file just for linting CI workflows.
+**Correctness checks** report a workflow that GitHub rejects, that runs differently than its author meant, or that
+refers to something which does not exist. They always run. A configuration key may tell such a check what exists in
+this project, as `self-hosted-runner.labels` and `config-variables` do, but the check still exists and still reports
+the same thing in a repository with no configuration file. Errors from them are filtered with the `-ignore` option or
+the `ignore` key in [the configuration](docs/config.md).
 
-It's helpful to check if a similar patch has been rejected in the past before submitting it.
+**Policy checks** report a workflow that GitHub runs happily but that breaks a convention the project chose for
+itself, such as pinning every action to a commit hash or setting `timeout-minutes` on every job. They stay silent
+until the `policy` mapping in [the configuration](docs/config.md) turns them on, so a repository that configures
+nothing never sees them. Being opinionated is fine in a check that only runs for the projects which asked for it.
+
+Patches for both kinds are welcome. A patch for a policy check needs its own key under `policy`, a default of off,
+and a section in [the configuration document](docs/config.md). A patch that makes an existing correctness check
+depend on configuration for its current behaviour is not accepted, because a repository with no configuration file
+must keep getting the same results.
+
+Every new key must tell "not set" apart from "set to off". A boolean key is therefore a `*bool`, and a key with a
+list or an object value uses nil for "not set". actionlint reads a single configuration file today, but it is meant
+to read a user-global one as well, and at that point a key which cannot express "not set" leaves a repository unable
+to opt out of what the user-global file turned on.
+
+The configuration is read once at the start of a run, so a check may rely on it being available.
+
+This is where the fork differs from [the upstream project](https://github.com/rhysd/actionlint), which accepts
+neither checks that enforce conventions nor checks that require user configuration. A patch turned down upstream for
+that reason is worth proposing here.
 
 ## Reporting an issue
 

--- a/docs/checks.md
+++ b/docs/checks.md
@@ -44,8 +44,9 @@ List of checks:
 - [Deprecated inputs usage](#deprecated-inputs-usage)
 - [YAML anchors](#yaml-anchors)
 
-Note that actionlint focuses on catching mistakes in workflow files. If you want some general code style checks, please consider
-using a general YAML checker like [yamllint][yamllint].
+Note that the checks in this document always run and report mistakes in workflow files. actionlint also has policy
+checks that a repository turns on for itself, described in [the configuration document](config.md#policy-checks). For
+general code style checks, please consider using a general YAML checker like [yamllint][yamllint].
 
 <a id="check-unexpected-keys"></a>
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -2,9 +2,9 @@
 
 This document describes how to configure [actionlint](..) behavior.
 
-Note that configuration file is optional. The author tries to keep configuration file as minimal as possible not to
-bother users to configure behavior of actionlint. Running actionlint without configuration file would work fine in most
-cases.
+The configuration file is optional. Every correctness check runs without it, so actionlint works fine in a repository
+that has no configuration file. The file is where a repository tells actionlint what exists in its own environment,
+and where it turns on the opt-in [policy checks](#policy-checks).
 
 ## Configuration file
 
@@ -56,6 +56,23 @@ paths:
     - `ignore`: The configuration to ignore (filter) the errors by the error messages. This is an array of regular
       expressions. When one of the patterns matches the error message, the error will be ignored. It's similar to the
       `-ignore` command line option.
+
+## Policy checks
+
+The keys under `policy` turn on checks that enforce a convention the repository chose for itself. GitHub runs a
+workflow that violates one of them without complaining, so none of these checks reports anything until this mapping
+turns it on, and a repository with no configuration file never sees them. Errors from the checks in
+[the checks document](checks.md) are a different thing: those report a workflow that is broken, and they always run.
+
+Each check owns one key. The key name is also the name of the rule, so it is the name in the `[...]` suffix of the
+error message and the value of `{{$err.Kind}}` in the `-format` option. No policy check exists yet. Each one adds its
+own subsection here, in alphabetical order by key.
+
+Every key tells three states apart. Writing `false`, or an empty list for a key whose value is a list, turns the
+check off. Leaving the key out, or writing `null`, says nothing either way, so an empty `policy` mapping switches
+nothing off. That distinction is what lets a key which says nothing take its value from elsewhere once actionlint
+reads a user-global configuration file as well as the repository's. Today it reads one file: `-config-file` if given,
+otherwise the repository's.
 
 ## Generate the initial configuration
 


### PR DESCRIPTION
`CONTRIBUTING.md` opens with the rule that this fork is about to break, twice:

> - actionlint focuses on detecting mistakes. Feature requests and patches for checks that enforces code style or some conventions are generally not accepted.
> - actionlint tries to keep [the configuration](docs/config.md) as minimal as possible. Feature requests and patches for checks that require user configurations are generally not accepted.

The same two bullets are the current upstream text.

<details><summary>Measured</summary>

```console
$ git show HEAD~1:CONTRIBUTING.md | awk 'NR<=12 {printf "%d\t%s\n", NR, $0}'
1	# Policy for actionlint's features
2	
3	- actionlint focuses on detecting mistakes. Feature requests and patches for checks that enforces code style or
4	  some conventions are generally not accepted.
5	- actionlint tries to keep [the configuration](docs/config.md) as minimal as possible. Feature requests and patches
6	  for checks that require user configurations are generally not accepted.
7	
8	These are important to keep actionlint useful and convenient for everyone. I believe that no one wants to create and
9	maintain a heavy configuration file just for linting CI workflows.
10	
11	It's helpful to check if a similar patch has been rejected in the past before submitting it.
12

$ git show upstream/main:CONTRIBUTING.md | awk 'NR<=12 {printf "%d\t%s\n", NR, $0}'
1	# Policy for actionlint's features
2	
3	- actionlint focuses on detecting mistakes. Feature requests and patches for checks that enforces code style or
4	  some conventions are generally not accepted.
5	- actionlint tries to keep [the configuration](docs/config.md) as minimal as possible. Feature requests and patches
6	  for checks that require user configurations are generally not accepted.
7	
8	These are important to keep actionlint useful and convenient for everyone. I believe that no one wants to create and
9	maintain a heavy configuration file just for linting CI workflows.
10	
11	It's helpful to check if a similar patch has been rejected in the past before submitting it.
12
```

</details>

Five branches are queued that each add a configuration key and an opinionated check: SHA pinning, required actions, mandatory job timeouts, a secrets allowlist, and caller-callee permission comparison. A sixth, user-global configuration discovery, is planned and has no branch yet. Landing them against that text leaves the repository arguing with itself, and landing them one at a time is how a codebase ends up with `require-commit-hash` next to `requiredActions:` next to `policy.timeout.enabled`.

<details><summary>Measured</summary>

```console
$ for b in require-commit-hash required-actions require-job-timeout config-secrets caller-callee-permissions; do echo "--- $b"; git diff main..$b --stat -- config.go docs/config.md; done
--- require-commit-hash
 config.go      | 47 +++++++++++++++++++++++++++++++++++++++++++++++
 docs/config.md | 35 ++++++++++++++++++++++++++++++++---
 2 files changed, 79 insertions(+), 3 deletions(-)
--- required-actions
 config.go      | 92 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 docs/config.md | 54 ++++++++++++++++++++++++++++++++--
 2 files changed, 143 insertions(+), 3 deletions(-)
--- require-job-timeout
 config.go      | 124 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 docs/config.md |  55 +++++++++++++++++++++++--
 2 files changed, 176 insertions(+), 3 deletions(-)
--- config-secrets
 config.go      | 10 ++++++++++
 docs/config.md | 33 ++++++++++++++++++++++++++++++---
 2 files changed, 40 insertions(+), 3 deletions(-)
--- caller-callee-permissions
 config.go      | 41 +++++++++++++++++++++++++++++++++++++++++
 docs/config.md | 35 ++++++++++++++++++++++++++++++++---
 2 files changed, 73 insertions(+), 3 deletions(-)

$ git branch -a --format='%(refname:short)' | grep -i "global\|user-config\|discover"; echo "exit=$?"
exit=1
```

</details>

This is documentation only. No Go file changes, no key is implemented yet.

<details><summary>Measured</summary>

```console
$ git show --stat HEAD --format=""
 CONTRIBUTING.md | 33 ++++++++++++++++++++++++++-------
 docs/checks.md  |  5 +++--
 docs/config.md  | 23 ++++++++++++++++++++---
 3 files changed, 49 insertions(+), 12 deletions(-)

$ grep -rni "policy" config.go; echo "exit=$?"
exit=1
```

</details>

## The distinction it draws

**Correctness checks** report a workflow that GitHub rejects, that runs differently than its author meant, or that refers to something which does not exist. They always run. Configuration may tell such a check what exists in this project — `self-hosted-runner.labels` and `config-variables` already do — but the check still exists and reports the same thing in a repository with no configuration file.

**Policy checks** report a workflow that GitHub runs happily but that breaks a convention the project chose for itself. They stay silent until the `policy` mapping turns them on.

That line is what makes an opinionated check acceptable here: it only runs for the projects that asked for it. It also draws a boundary the fork keeps — a patch that makes an existing correctness check depend on configuration for its current behaviour is still not accepted, because a repository with no configuration file must keep getting the same results.

The upstream position is named rather than quietly dropped, since a contributor whose patch was turned down there should know it is worth proposing here.

## Where it lands

`docs/config.md` gains a `## Policy checks` section between the top-level key list and `## Generate the initial configuration`. Each policy branch adds one `###` subsection to it, in alphabetical order by key, so the branches insert at different offsets instead of on top of each other.

<details><summary>Measured</summary>

```console
$ awk 'NR>=55 && NR<=79 {printf "%d\t%s\n", NR, $0}' docs/config.md
55	    `.yaml` file extension). For the glob syntax, please read the [doublestar][doublestar] library's documentation.
56	    - `ignore`: The configuration to ignore (filter) the errors by the error messages. This is an array of regular
57	      expressions. When one of the patterns matches the error message, the error will be ignored. It's similar to the
58	      `-ignore` command line option.
59	
60	## Policy checks
61	
62	The keys under `policy` turn on checks that enforce a convention the repository chose for itself. GitHub runs a
63	workflow that violates one of them without complaining, so none of these checks reports anything until this mapping
64	turns it on, and a repository with no configuration file never sees them. Errors from the checks in
65	[the checks document](checks.md) are a different thing: those report a workflow that is broken, and they always run.
66	
67	Each check owns one key. The key name is also the name of the rule, so it is the name in the `[...]` suffix of the
68	error message and the value of `{{$err.Kind}}` in the `-format` option. No policy check exists yet. Each one adds its
69	own subsection here, in alphabetical order by key.
70	
71	Every key tells three states apart. Writing `false`, or an empty list for a key whose value is a list, turns the
72	check off. Leaving the key out, or writing `null`, says nothing either way, so an empty `policy` mapping switches
73	nothing off. That distinction is what lets a key which says nothing take its value from elsewhere once actionlint
74	reads a user-global configuration file as well as the repository's. Today it reads one file: `-config-file` if given,
75	otherwise the repository's.
76	
77	## Generate the initial configuration
```

</details>

`docs/checks.md` says in its introduction that its own checks always run, and points at the other kind. Its list is unchanged and no policy check will be added to it.

<details><summary>Measured</summary>

```console
$ git show HEAD -- docs/checks.md
diff --git a/docs/checks.md b/docs/checks.md
index 3695864..4d1a88d 100644
--- a/docs/checks.md
+++ b/docs/checks.md
@@ -44,8 +44,9 @@ List of checks:
 - [Deprecated inputs usage](#deprecated-inputs-usage)
 - [YAML anchors](#yaml-anchors)
 
-Note that actionlint focuses on catching mistakes in workflow files. If you want some general code style checks, please consider
-using a general YAML checker like [yamllint][yamllint].
+Note that the checks in this document always run and report mistakes in workflow files. actionlint also has policy
+checks that a repository turns on for itself, described in [the configuration document](config.md#policy-checks). For
+general code style checks, please consider using a general YAML checker like [yamllint][yamllint].
 
 <a id="check-unexpected-keys"></a>
 
```

</details>

## Claims that were checked rather than assumed

**The key name is the rule name.** A rule's `Kind` is the rule's own name, which is what appears in the `[...]` suffix of an error message and in `{{$err.Kind}}` under `-format`. Measured with the built binary against a throwaway workflow outside the repository, and read in the source.

<details><summary>Measured</summary>

```console
$ cat -n /tmp/kind-probe/.github/workflows/x.yaml
     1	on: push
     2	jobs:
     3	  test:
     4	    runs-on: ubuntu-latest
     5	    steps:
     6	      - run: echo "${{ github.nope }}"

$ actionlint -no-color .github/workflows/x.yaml; echo "exit=$?"
.github/workflows/x.yaml:6:24: property "nope" is not defined in object type {action: string; action_path: string; action_ref: string; action_repository: string; action_status: string; actor: string; actor_id: string; api_url: string; artifact_cache_size_limit: number; base_ref: string; env: string; event: object; event_name: string; event_path: string; graphql_url: string; head_ref: string; job: string; output: string; path: string; ref: string; ref_name: string; ref_protected: bool; ref_type: string; repository: string; repository_id: string; repository_owner: string; repository_owner_id: string; repository_visibility: string; repositoryurl: string; retention_days: number; run_attempt: string; run_id: string; run_number: string; secret_source: string; server_url: string; sha: string; state: string; step_summary: string; token: string; triggering_actor: string; workflow: string; workflow_ref: string; workflow_sha: string; workspace: string} [expression]
  |
6 |       - run: echo "${{ github.nope }}"
  |                        ^~~~~~~~~~~
exit=1

$ actionlint -no-color -format '{{range $e := .}}KIND={{$e.Kind}} {{end}}' .github/workflows/x.yaml; echo; echo "exit=$?"
KIND=expression 
exit=0

$ grep -rn 'Kind' error.go
error.go:35:	// Kind is a string to represent kind of the error. Usually rule name which found the error.
error.go:36:	Kind string
error.go:44:	return fmt.Sprintf("%s:%d:%d: %s [%s]", e.Filepath, e.Line, e.Column, e.Message, e.Kind)
error.go:56:		Kind:    kind,
error.go:65:		Kind:    kind,
error.go:88:		Kind:      e.Kind,
error.go:105:	_, _ = gray.Fprintf(w, " [%s]\n", e.Kind)
error.go:219:	// Kind is a rule name the error belongs to.
error.go:220:	Kind string `json:"kind"`
error.go:303:		"allKinds": func() []*ruleTemplateFields {

$ grep -n "r.name" rule.go
45:	err := errorAt(pos, r.name, msg)
52:	err := errorfAt(pos, r.name, format, args...)
58:	err := errorfAt(start, r.name, format, args...)
71:	format = fmt.Sprintf("[%s] %s\n", r.name, format)
82:	return r.name
```

</details>

**actionlint reads one configuration file, not several.** An earlier draft of this text said a key set in the nearer file wins, as present-tense fact. It is not: `linter.go:549-555` is an `if`/`else if` that selects `-config-file` or the repository file and never merges them. Both places that said otherwise now say what the code does, and state precedence as the reason a key must distinguish "not set" from "set to off" once a user-global file is read.

https://github.com/kjanat/actionlint/blob/8709d3738ac11a7a578a8c93074cc81800c32dd4/linter.go#L549-L555

**There are no policy keys yet.** The section ends by saying no policy check exists yet and that each one adds its subsection here. `grep -rni "policy" config.go` returns nothing; see the measurement above.

**The cross-document anchor resolves.** `## Policy checks` appears exactly once in `docs/config.md`, so GitHub's slug is `policy-checks` with no disambiguating suffix. Two links target it: `docs/checks.md:48` from the other document and `docs/config.md:7` within the same one. Checked by hand because the repository has no link checker: `lychee`, `link-check`, `markdown-link` and `mlc` appear nowhere in `.github/`, `Makefile`, `.dprint.jsonc` or `scripts/`.

<details><summary>Measured</summary>

```console
$ grep -c "^## Policy checks" docs/config.md
1

$ grep -rn "policy-checks" . --exclude-dir=.git
docs/config.md:7:and where it turns on the opt-in [policy checks](#policy-checks).
docs/checks.md:48:checks that a repository turns on for itself, described in [the configuration document](config.md#policy-checks). For

$ grep -rniE 'lychee|link-check|linkcheck|markdown-link|markdown_link|\bmlc\b' .github/ Makefile .dprint.jsonc scripts/; echo "exit=$?"
exit=1
```

</details>

## What binds the branches that follow

Recorded here so the branches do not each decide it:

```yaml
config-secrets: null
assume-default-permissions: restricted

policy:
  require-commit-hash: true
  require-job-timeout: true
  required-actions:
    - actions/checkout
```

- A nested `policy:` block, because every key in it has the same nature: opt-in, off by default, and non-conformance is a choice rather than a mistake. `config-secrets` stays flat next to the existing `config-variables`, because it declares what exists rather than enforcing anything.
- The configuration key name is the rule name. Policy diagnostics get no separate category `Kind`.
- Every key distinguishes "not set" from "explicitly off". A boolean is a `*bool`; a list uses nil.
- Validation lives in each type's own `UnmarshalYAML`, never in `ParseConfig`, which returns a plain error carrying no line or column and is a shared conflict point.
- Policy fixtures live in `testdata/projects/<name>/`, where the test picks up that directory's own `actionlint.yaml` and compares against that directory's own golden. Never in `testdata/examples/`, where every fixture is linted under one shared project root with `defaultConfig` set to an empty `Config`, so a fixture there cannot carry a configuration of its own.
- Turning a policy off means setting its key to `false` or `[]`. Correctness errors are suppressed with `ignore`. No third mechanism.

<details><summary>Measured</summary>

```console
$ grep -n "func ParseConfig" -A 12 config.go
91:func ParseConfig(b []byte) (*Config, error) {
92-	var c Config
93-	if err := yaml.Unmarshal(b, &c); err != nil {
94-		msg := strings.ReplaceAll(err.Error(), "\n", " ")
95-		return nil, errors.New(msg)
96-	}
97-	for pat := range c.Paths {
98-		if !doublestar.ValidatePattern(pat) {
99-			return nil, fmt.Errorf("invalid glob pattern %q in \"paths\"", pat)
100-		}
101-	}
102-	return &c, nil
103-}

$ awk 'NR>=324 && NR<=347 {printf "%d\t%s\n", NR, $0}' linter_test.go
324			t.Run("project/"+name, func(t *testing.T) {
325				repo := filepath.Join(root, name)
326				t.Log("Linting project at", repo)
327	
328				opts := LinterOptions{
329					WorkingDir: repo,
330				}
331				cfg := filepath.Join(repo, "actionlint.yaml")
332				if _, err := os.Stat(cfg); err == nil {
333					opts.ConfigFile = cfg
334				}
335				linter, err := NewLinter(io.Discard, &opts)
336				if err != nil {
337					t.Fatal(err)
338				}
339	
340				proj := &Project{root: repo}
341				errs, err := linter.LintDir(filepath.Join(repo, "workflows"), proj)
342				if err != nil {
343					t.Fatal(err)
344				}
345	
346				checkErrors(t, repo+".out", errs)
347			})

$ awk 'NR>=153 && NR<=213 {printf "%d\t%s\n", NR, $0}' linter_test.go
153	func TestLinterLintError(t *testing.T) {
154		for _, subdir := range []string{"examples", "err"} {
155			dir, infiles, err := testFindAllWorkflowsInDir(subdir)
156			if err != nil {
157				panic(err)
158			}
159	
160			proj := &Project{root: dir}
161	
162			shellcheck := ""
163			if p, err := execabs.LookPath("shellcheck"); err == nil {
164				shellcheck = p
165			}
166	
167			pyflakes := ""
168			if p, err := execabs.LookPath("pyflakes"); err == nil {
169				pyflakes = p
170			}
171	
172			for _, infile := range infiles {
173				base := strings.TrimSuffix(infile, filepath.Ext(infile))
174				testName := filepath.Base(base)
175				t.Run(subdir+"/"+testName, func(t *testing.T) {
176					t.Log("Linting workflow file", infile)
177					b, err := os.ReadFile(infile)
178					if err != nil {
179						panic(err)
180					}
181	
182					o := LinterOptions{}
183	
184					if strings.Contains(testName, "shellcheck") {
185						if shellcheck == "" {
186							t.Skip("skipped because \"shellcheck\" command does not exist in system")
187						}
188						o.Shellcheck = shellcheck
189					}
190	
191					if strings.Contains(testName, "pyflakes") {
192						if pyflakes == "" {
193							t.Skip("skipped because \"pyflakes\" command does not exist in system")
194						}
195						o.Pyflakes = pyflakes
196					}
197	
198					l, err := NewLinter(io.Discard, &o)
199					if err != nil {
200						t.Fatal(err)
201					}
202	
203					l.defaultConfig = &Config{}
204	
205					errs, err := l.Lint("test.yaml", b, proj)
206					if err != nil {
207						t.Fatal(err)
208					}
209	
210					checkErrors(t, base+".out", errs)
211				})
212			}
213		}
```

</details>

## Verification

Both gates were made to fail against these very files, so they demonstrably look at them. Each mutation was reverted from a copy taken beforehand, and the tree confirmed clean before the next command.

<details><summary>Failing the gates</summary>

```console
$ cp docs/checks.md /tmp/checks.md.orig && cp docs/config.md /tmp/config.md.orig && md5sum /tmp/checks.md.orig /tmp/config.md.orig docs/checks.md docs/config.md
8f75ab88f53171fde7a7e89a2b97e568  /tmp/checks.md.orig
daa431395da0155c59c745c62e27a26f  /tmp/config.md.orig
8f75ab88f53171fde7a7e89a2b97e568  docs/checks.md
daa431395da0155c59c745c62e27a26f  docs/config.md

$ sed -i '47s/^Note that/## Note that/' docs/checks.md && awk 'NR>=46 && NR<=50 {printf "%d\t%s\n", NR, $0}' docs/checks.md && go run ./scripts/check-checks -quiet ./docs/checks.md; echo "exit=$?"
46	
47	## Note that the checks in this document always run and report mistakes in workflow files. actionlint also has policy
48	checks that a repository turns on for itself, described in [the configuration document](config.md#policy-checks). For
49	general code style checks, please consider using a general YAML checker like [yamllint][yamllint].
50	
error at line 47 while generating section "": unexpected state "init". expected ["anchor"]
exit status 1
exit=1

$ cp /tmp/checks.md.orig docs/checks.md && git status --porcelain; md5sum docs/checks.md
8f75ab88f53171fde7a7e89a2b97e568  docs/checks.md

$ printf '\t- tab indented\n' > /tmp/ins.txt && sed -i '76r /tmp/ins.txt' docs/config.md && awk 'NR>=74 && NR<=79 {printf "%d\t%s\n", NR, $0}' docs/config.md | cat -A
74^Ireads a user-global configuration file as well as the repository's. Today it reads one file: `-config-file` if given,$
75^Iotherwise the repository's.$
76^I$
77^I^I- tab indented$
78^I## Generate the initial configuration$
79^I$

$ dprint check; echo "exit=$?"
from /home/kjanat/projects/actionlint/.worktrees/policy-rules-charter/docs/config.md:
74 74| reads·a·user-global·configuration·file·as·well·as·the·repository's.·Today·it·reads·one·file:·`-config-file`·if·given,
75 75| otherwise·the·repository's.
76 76| 
   77|-→-·tab·indented
77   |+····-·tab·indented
78   |+
79 78| ##·Generate·the·initial·configuration
80 79| 
81 80| You·don't·need·to·write·the·first·configuration·file·by·your·hand.·`actionlint`·command·can·generate·a·default·configuration
--
Found 1 not formatted file. Run dprint fmt to fix.
exit=20

$ cp /tmp/config.md.orig docs/config.md && git status --porcelain; md5sum docs/config.md
daa431395da0155c59c745c62e27a26f  docs/config.md
```

</details>

On the committed content:

<details><summary>Gates</summary>

```console
$ make build SKIP_GO_GENERATE=true
make: Nothing to be done for 'build'.

$ make test
go test -race ./...
ok  	actionlint.kjanat.dev	342.855s
?   	actionlint.kjanat.dev/cmd/actionlint	[no test files]
ok  	actionlint.kjanat.dev/cmd/actionlint-action	1.057s
ok  	actionlint.kjanat.dev/fuzz	1.025s
ok  	actionlint.kjanat.dev/scripts/bump-version	2.061s
ok  	actionlint.kjanat.dev/scripts/check-checks	61.319s
ok  	actionlint.kjanat.dev/scripts/generate-availability	1.394s
ok  	actionlint.kjanat.dev/scripts/generate-popular-actions	2.126s
ok  	actionlint.kjanat.dev/scripts/generate-webhook-events	1.327s

$ make lint SKIP_GO_GENERATE=true
golangci-lint run
0 issues.
go run golang.org/x/vuln/cmd/govulncheck@latest ./...
No vulnerabilities found.
GOOS=js GOARCH=wasm golangci-lint run ./playground
0 issues.
go run ./scripts/check-checks -quiet ./docs/checks.md

$ dprint check; echo "exit=$?"
exit=0
```

</details>

`make build` reports nothing to do because the commit touches no Go source. The target's prerequisites are the non-test `.go` files plus `go.mod` and `go.sum`, and the binary is newer than all of them.

`check-checks -fix` rewrites nothing in `docs/checks.md`. Its two summary lines are the last of a 446-line log, because `-fix` without `-quiet` traces every section; `-fix -quiet` prints nothing at all.

<details><summary>Measured</summary>

```console
$ go run ./scripts/check-checks -fix ./docs/checks.md 2>&1
[446 lines; the full log is 73KB of per-section trace, ending with:]
2026/08/21 21:56:29 Scanned 3348 lines and 39 sections
2026/08/21 21:56:29 Do nothing because there is no update in "./docs/checks.md"

$ go run ./scripts/check-checks -quiet -fix ./docs/checks.md 2>&1; echo "exit=$?"; git status --porcelain
exit=0
```

</details>

The worktree is clean after every command above.

<details><summary>Measured</summary>

```console
$ git status
On branch policy-rules-charter
Your branch is up to date with 'origin/policy-rules-charter'.

nothing to commit, working tree clean
```

</details>

