### PR TITLE
Add a config-secrets allowlist for the secrets context

### DIFF
--- a/config.go
+++ b/config.go
@@ -192,6 +192,11 @@ type Config struct {
 	// listed here as undefined config variables.
 	// https://docs.github.com/en/actions/learn-github-actions/variables
 	ConfigVariables []string `yaml:"config-variables"`
+	// ConfigSecrets is names of secrets used in the checked workflows. When this value is nil, property
+	// names of `secrets` context will not be checked. Otherwise actionlint will report a name which is
+	// not listed here as an undefined secret.
+	// https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions
+	ConfigSecrets []string `yaml:"config-secrets"`
 	// Paths is a "paths" mapping in the configuration file. The keys are glob patterns to match file paths.
 	// And the values are corresponding configurations applied to the file paths.
 	Paths map[string]PathConfig `yaml:"paths"`
@@ -297,6 +302,11 @@ func writeDefaultConfigFile(path string) error {
 # organization. ` + "`null`" + ` means disabling configuration variables check.
 # Empty array means no configuration variable is allowed.
 config-variables: null
+
+# Secrets in array of strings defined in your repository or organization.
+# ` + "`null`" + ` means disabling the secrets check. Empty array means no secret is
+# allowed.
+config-secrets: null
 
 # Configuration for file paths. The keys are glob patterns to match to file
 # paths relative to the repository root. The values are the configurations for

--- a/config_test.go
+++ b/config_test.go
@@ -57,6 +57,48 @@ func TestConfigParseSelfHostedRunnerOK(t *testing.T) {
 	}
 }
 
+func TestConfigParseConfigSecrets(t *testing.T) {
+	testCases := []struct {
+		what    string
+		input   string
+		secrets []string
+	}{
+		{
+			what:    "empty config",
+			input:   "",
+			secrets: nil,
+		},
+		{
+			what:    "null config-secrets",
+			input:   "config-secrets:",
+			secrets: nil,
+		},
+		{
+			what:    "empty config-secrets",
+			input:   "config-secrets: []",
+			secrets: []string{},
+		},
+		{
+			what:    "config-secrets",
+			input:   "config-secrets: [FOO, BAR]",
+			secrets: []string{"FOO", "BAR"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.what, func(t *testing.T) {
+			c, err := ParseConfig([]byte(tc.input))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(c.ConfigSecrets, tc.secrets); diff != "" {
+				t.Fatal(diff)
+			}
+		})
+	}
+}
+
 func TestConfigParseError(t *testing.T) {
 	tests := []struct {
 		in   string
@@ -311,6 +353,9 @@ func TestConfigGenerateDefaultConfigFileOK(t *testing.T) {
 	}
 	if c.ConfigVariables != nil {
 		t.Fatal(c.SelfHostedRunner.Labels)
+	}
+	if c.ConfigSecrets != nil {
+		t.Fatal(c.ConfigSecrets)
 	}
 	if len(c.Paths) != 0 {
 		t.Fatal(c.Paths)

--- a/docs/config.md
+++ b/docs/config.md
@@ -27,6 +27,11 @@ config-variables:
   - JOB_NAME
   - ENVIRONMENT_STAGE
 
+# Secrets in array of strings defined in your repository or organization.
+config-secrets:
+  - DEPLOY_TOKEN
+  - API_KEY
+
 # Path-specific configurations.
 paths:
   # Glob pattern relative to the repository root for matching files. The path separator is always '/'.
@@ -48,6 +53,10 @@ paths:
     is available.
 - `config-variables`: [Configuration variables][vars]. When an array is set, actionlint will check `vars` properties strictly.
   An empty array means no variable is allowed. The default value `null` disables the check.
+- `config-secrets`: [Secrets][secrets]. When an array is set, actionlint checks `secrets` properties against the list.
+  Names are compared case-insensitively. An empty array means no secret is allowed. The default value `null` disables
+  the check. The secrets GitHub always provides (`GITHUB_TOKEN`, `ACTIONS_STEP_DEBUG`, `ACTIONS_RUNNER_DEBUG`) are
+  always allowed. Secrets declared in `on.workflow_call.secrets` are also always allowed since a caller passes them.
 - `paths`: Configurations for specific file path patterns. This is a mapping from a glob pattern and the corresponding
   configuration.
   - `{glob}`: A file path glob pattern to apply the configuration. The path separator is always '/'. It is matched to the
@@ -142,4 +151,5 @@ vim .github/actionlint.yaml
 [Super-Linter]: https://github.com/super-linter/super-linter
 [pat]: https://pkg.go.dev/path#Match
 [vars]: https://docs.github.com/en/actions/learn-github-actions/variables
+[secrets]: https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions
 [doublestar]: https://github.com/bmatcuk/doublestar

--- a/expr_sema.go
+++ b/expr_sema.go
@@ -260,6 +260,14 @@ var BuiltinFuncSignatures = map[string][]*FuncSignature{
 
 // Global variables
 
+// builtinSecretProps are the secrets which GitHub Actions always provides to a workflow.
+// ACTIONS_STEP_DEBUG and ACTIONS_RUNNER_DEBUG seem supplied from caller of the workflow (#130).
+var builtinSecretProps = map[string]ExprType{
+	"github_token":         StringType{},
+	"actions_step_debug":   StringType{},
+	"actions_runner_debug": StringType{},
+}
+
 // BuiltinGlobalVariableTypes defines types of all global variables. All context variables are
 // documented at https://docs.github.com/en/actions/learn-github-actions/contexts
 var BuiltinGlobalVariableTypes = map[string]ExprType{
@@ -345,7 +353,10 @@ var BuiltinGlobalVariableTypes = map[string]ExprType{
 		"environment": StringType{}, // https://github.com/github/docs/issues/32443
 	}),
 	// https://docs.github.com/en/actions/learn-github-actions/contexts#secrets-context
-	"secrets": NewMapObjectType(StringType{}),
+	"secrets": &ObjectType{
+		Props:  maps.Clone(builtinSecretProps),
+		Mapped: StringType{},
+	},
 	// https://docs.github.com/en/actions/learn-github-actions/contexts#strategy-context
 	"strategy": NewObjectType(map[string]ExprType{
 		"fail-fast":    BoolType{},
@@ -382,17 +393,22 @@ type ExprSemanticsChecker struct {
 	availableContexts     []string
 	availableSpecialFuncs []string
 	configVars            []string
+	configSecrets         []string
 }
 
 // NewExprSemanticsChecker creates new ExprSemanticsChecker instance. When checkUntrustedInput is
-// set to true, the checker will make use of possibly untrusted inputs error.
-func NewExprSemanticsChecker(checkUntrustedInput bool, configVars []string) *ExprSemanticsChecker {
+// set to true, the checker will make use of possibly untrusted inputs error. The cfg parameter is
+// the user configuration used by the config-driven checks. It may be nil.
+func NewExprSemanticsChecker(checkUntrustedInput bool, cfg *Config) *ExprSemanticsChecker {
 	c := &ExprSemanticsChecker{
 		funcs:           BuiltinFuncSignatures,
 		vars:            BuiltinGlobalVariableTypes,
 		varsCopied:      false,
 		githubVarCopied: false,
-		configVars:      configVars,
+	}
+	if cfg != nil {
+		c.configVars = cfg.ConfigVariables
+		c.configSecrets = cfg.ConfigSecrets
 	}
 	if checkUntrustedInput {
 		c.untrusted = NewUntrustedInputChecker(BuiltinUntrustedInputs)
@@ -458,17 +474,13 @@ func (sema *ExprSemanticsChecker) UpdateNeeds(ty *ObjectType) {
 	sema.vars["needs"] = ty
 }
 
-// UpdateSecrets updates 'secrets' context object to given object type.
+// UpdateSecrets updates 'secrets' context object to given object type. The strictness of the
+// given type is preserved, so an open type keeps allowing unknown secret names.
 func (sema *ExprSemanticsChecker) UpdateSecrets(ty *ObjectType) {
 	sema.ensureVarsCopied()
 
 	// Merges automatically supplied secrets with manually defined secrets.
-	// ACTIONS_STEP_DEBUG and ACTIONS_RUNNER_DEBUG seem supplied from caller of the workflow (#130)
-	copied := NewStrictObjectType(map[string]ExprType{
-		"github_token":         StringType{},
-		"actions_step_debug":   StringType{},
-		"actions_runner_debug": StringType{},
-	})
+	copied := &ObjectType{Props: maps.Clone(builtinSecretProps), Mapped: ty.Mapped}
 	maps.Copy(copied.Props, ty.Props)
 	sema.vars["secrets"] = copied
 }
@@ -623,8 +635,13 @@ func (sema *ExprSemanticsChecker) checkObjectDeref(n *ObjectDerefNode) ExprType 
 			return t
 		}
 		if ty.Mapped != nil {
-			if v, ok := n.Receiver.(*VariableNode); ok && v.Name == "vars" {
-				sema.checkConfigVariables(n)
+			if v, ok := n.Receiver.(*VariableNode); ok {
+				switch v.Name {
+				case "vars":
+					sema.checkConfigVariables(n)
+				case "secrets":
+					sema.checkConfigSecrets(n)
+				}
 			}
 			return ty.Mapped
 		}
@@ -714,6 +731,31 @@ func (sema *ExprSemanticsChecker) checkConfigVariables(n *ObjectDerefNode) {
 		"undefined configuration variable %q. defined configuration variables in actionlint.yaml are %s",
 		n.Property,
 		sortedQuotes(sema.configVars),
+	)
+}
+
+func (sema *ExprSemanticsChecker) checkConfigSecrets(n *ObjectDerefNode) {
+	if sema.configSecrets == nil {
+		return
+	}
+	if len(sema.configSecrets) == 0 {
+		sema.errorf(
+			n,
+			"no secret is allowed since the secrets list is empty in actionlint.yaml. you may forget adding the secret %q to the list",
+			n.Property,
+		)
+		return
+	}
+	if slices.ContainsFunc(sema.configSecrets, func(s string) bool {
+		return strings.EqualFold(s, n.Property)
+	}) {
+		return
+	}
+	sema.errorf(
+		n,
+		"undefined secret %q. defined secrets in actionlint.yaml are %s",
+		n.Property,
+		sortedQuotes(sema.configSecrets),
 	)
 }
 

--- a/expr_sema.go
+++ b/expr_sema.go
@@ -638,9 +638,9 @@ func (sema *ExprSemanticsChecker) checkObjectDeref(n *ObjectDerefNode) ExprType 
 			if v, ok := n.Receiver.(*VariableNode); ok {
 				switch v.Name {
 				case "vars":
-					sema.checkConfigVariables(n)
+					sema.checkConfigVariables(n, n.Property)
 				case "secrets":
-					sema.checkConfigSecrets(n)
+					sema.checkConfigSecrets(n, n.Property)
 				}
 			}
 			return ty.Mapped
@@ -684,18 +684,18 @@ func (sema *ExprSemanticsChecker) checkObjectDeref(n *ObjectDerefNode) ExprType 
 	}
 }
 
-func (sema *ExprSemanticsChecker) checkConfigVariables(n *ObjectDerefNode) {
+func (sema *ExprSemanticsChecker) checkConfigVariables(n ExprNode, prop string) {
 	// https://docs.github.com/en/actions/learn-github-actions/variables#naming-conventions-for-configuration-variables
-	if strings.HasPrefix(n.Property, "github_") {
+	if strings.HasPrefix(prop, "github_") {
 		sema.errorf(
 			n,
 			"configuration variable name %q must not start with the GITHUB_ prefix (case insensitive). note: see the convention at https://docs.github.com/en/actions/learn-github-actions/variables#naming-conventions-for-configuration-variables",
-			n.Property,
+			prop,
 		)
 		return
 	}
-	for _, r := range n.Property {
-		// Note: `n.Property` was already converted to lower case by parser
+	for _, r := range prop {
+		// Note: `prop` was already converted to lower case
 		// Note: First character cannot be number, but it was already checked by parser
 		if '0' <= r && r <= '9' || 'a' <= r && r <= 'z' || r == '_' {
 			continue
@@ -703,7 +703,7 @@ func (sema *ExprSemanticsChecker) checkConfigVariables(n *ObjectDerefNode) {
 		sema.errorf(
 			n,
 			"configuration variable name %q can only contain alphabets, decimal numbers, and '_'. note: see the convention at https://docs.github.com/en/actions/learn-github-actions/variables#naming-conventions-for-configuration-variables",
-			n.Property,
+			prop,
 		)
 		return
 	}
@@ -715,13 +715,13 @@ func (sema *ExprSemanticsChecker) checkConfigVariables(n *ObjectDerefNode) {
 		sema.errorf(
 			n,
 			"no configuration variable is allowed since the variables list is empty in actionlint.yaml. you may forget adding the variable %q to the list",
-			n.Property,
+			prop,
 		)
 		return
 	}
 
 	for _, v := range sema.configVars {
-		if strings.EqualFold(v, n.Property) {
+		if strings.EqualFold(v, prop) {
 			return
 		}
 	}
@@ -729,12 +729,12 @@ func (sema *ExprSemanticsChecker) checkConfigVariables(n *ObjectDerefNode) {
 	sema.errorf(
 		n,
 		"undefined configuration variable %q. defined configuration variables in actionlint.yaml are %s",
-		n.Property,
+		prop,
 		sortedQuotes(sema.configVars),
 	)
 }
 
-func (sema *ExprSemanticsChecker) checkConfigSecrets(n *ObjectDerefNode) {
+func (sema *ExprSemanticsChecker) checkConfigSecrets(n ExprNode, prop string) {
 	if sema.configSecrets == nil {
 		return
 	}
@@ -742,19 +742,19 @@ func (sema *ExprSemanticsChecker) checkConfigSecrets(n *ObjectDerefNode) {
 		sema.errorf(
 			n,
 			"no secret is allowed since the secrets list is empty in actionlint.yaml. you may forget adding the secret %q to the list",
-			n.Property,
+			prop,
 		)
 		return
 	}
 	if slices.ContainsFunc(sema.configSecrets, func(s string) bool {
-		return strings.EqualFold(s, n.Property)
+		return strings.EqualFold(s, prop)
 	}) {
 		return
 	}
 	sema.errorf(
 		n,
 		"undefined secret %q. defined secrets in actionlint.yaml are %s",
-		n.Property,
+		prop,
 		sortedQuotes(sema.configSecrets),
 	)
 }
@@ -831,6 +831,15 @@ func (sema *ExprSemanticsChecker) checkIndexAccess(n *IndexAccessNode) ExprType 
 					return prop
 				}
 				if ty.Mapped != nil {
+					if v, ok := n.Operand.(*VariableNode); ok {
+						prop := strings.ToLower(lit.Value)
+						switch v.Name {
+						case "vars":
+							sema.checkConfigVariables(n, prop)
+						case "secrets":
+							sema.checkConfigSecrets(n, prop)
+						}
+					}
 					return ty.Mapped
 				}
 				if ty.IsStrict() {

--- a/expr_sema_test.go
+++ b/expr_sema_test.go
@@ -703,6 +703,18 @@ func TestExprSemanticsCheckOK(t *testing.T) {
 			configSecrets: []string{"My_Secret"},
 		},
 		{
+			what:          "known secret through index access",
+			input:         "secrets['MY_SECRET']",
+			expected:      StringType{},
+			configSecrets: []string{"MY_SECRET"},
+		},
+		{
+			what:       "known configuration variable through index access",
+			input:      "vars['SOME_VARIABLE']",
+			expected:   StringType{},
+			configVars: []string{"SOME_VARIABLE"},
+		},
+		{
 			what:          "builtin secret with allowlist",
 			input:         "secrets.GITHUB_TOKEN",
 			expected:      StringType{},
@@ -1385,6 +1397,22 @@ func TestExprSemanticsCheckError(t *testing.T) {
 				"undefined secret \"unknown_secret\". defined secrets in actionlint.yaml are \"MY_SECRET\"",
 			},
 			configSecrets: []string{"MY_SECRET"},
+		},
+		{
+			what:  "unknown secret through index access",
+			input: "secrets['UNKNOWN_SECRET']",
+			expected: []string{
+				"undefined secret \"unknown_secret\". defined secrets in actionlint.yaml are \"MY_SECRET\"",
+			},
+			configSecrets: []string{"MY_SECRET"},
+		},
+		{
+			what:  "unknown configuration variable through index access",
+			input: "vars['UNKNOWN_VARIABLE']",
+			expected: []string{
+				"undefined configuration variable \"unknown_variable\".",
+			},
+			configVars: []string{"FOO_BAR"},
 		},
 		{
 			what:  "declared secrets stay strict for a workflow_call-only workflow",

--- a/expr_sema_test.go
+++ b/expr_sema_test.go
@@ -24,6 +24,7 @@ func TestExprSemanticsCheckOK(t *testing.T) {
 		availContexts []string
 		availSPFuncs  []string
 		configVars    []string
+		configSecrets []string
 	}{
 		{
 			what:     "null",
@@ -685,6 +686,54 @@ func TestExprSemanticsCheckOK(t *testing.T) {
 			configVars: []string{"some_variable"},
 		},
 		{
+			what:     "secret without config",
+			input:    "secrets.MY_SECRET",
+			expected: StringType{},
+		},
+		{
+			what:          "known secret",
+			input:         "secrets.MY_SECRET",
+			expected:      StringType{},
+			configSecrets: []string{"MY_SECRET"},
+		},
+		{
+			what:          "secret name is case insensitive",
+			input:         "secrets.MY_SECRET",
+			expected:      StringType{},
+			configSecrets: []string{"My_Secret"},
+		},
+		{
+			what:          "builtin secret with allowlist",
+			input:         "secrets.GITHUB_TOKEN",
+			expected:      StringType{},
+			configSecrets: []string{"MY_SECRET"},
+		},
+		{
+			what:          "builtin debug secret with empty allowlist",
+			input:         "secrets.ACTIONS_STEP_DEBUG",
+			expected:      StringType{},
+			configSecrets: []string{},
+		},
+		{
+			what:     "declared secret is not checked against the allowlist",
+			input:    "secrets.FOO",
+			expected: StringType{},
+			secrets: &ObjectType{
+				Props:  map[string]ExprType{"foo": StringType{}},
+				Mapped: StringType{},
+			},
+			configSecrets: []string{"BAR"},
+		},
+		{
+			what:     "open secrets type still allows unknown names without config",
+			input:    "secrets.UNKNOWN_SECRET",
+			expected: StringType{},
+			secrets: &ObjectType{
+				Props:  map[string]ExprType{"foo": StringType{}},
+				Mapped: StringType{},
+			},
+		},
+		{
 			what:     "narrow type of && operator by assumed value (#384)",
 			input:    "('foo' && 10) || 20",
 			expected: NumberType{},
@@ -813,7 +862,7 @@ func TestExprSemanticsCheckOK(t *testing.T) {
 				t.Fatal("Parse error:", tc.input)
 			}
 
-			c := NewExprSemanticsChecker(false, nil)
+			c := NewExprSemanticsChecker(false, &Config{ConfigVariables: tc.configVars, ConfigSecrets: tc.configSecrets})
 			c.SetContextAvailability([]string{"github", "job", "jobs", "matrix", "steps", "needs", "env", "inputs", "secrets", "vars", "runner"})
 			if tc.funcs != nil {
 				c.funcs = tc.funcs
@@ -858,16 +907,18 @@ func TestExprSemanticsCheckOK(t *testing.T) {
 
 func TestExprSemanticsCheckError(t *testing.T) {
 	testCases := []struct {
-		what       string
-		input      string
-		expected   []string
-		funcs      map[string][]*FuncSignature
-		matrix     *ObjectType
-		steps      *ObjectType
-		needs      *ObjectType
-		availCtx   []string
-		availSP    []string
-		configVars []string
+		what          string
+		input         string
+		expected      []string
+		funcs         map[string][]*FuncSignature
+		matrix        *ObjectType
+		steps         *ObjectType
+		needs         *ObjectType
+		secrets       *ObjectType
+		availCtx      []string
+		availSP       []string
+		configVars    []string
+		configSecrets []string
 	}{
 		{
 			what:  "undefined variable",
@@ -1320,6 +1371,31 @@ func TestExprSemanticsCheckError(t *testing.T) {
 			configVars: []string{"FOO_BAR"},
 		},
 		{
+			what:  "no secret is allowed",
+			input: "secrets.UNKNOWN_SECRET",
+			expected: []string{
+				"no secret is allowed since the secrets list is empty in actionlint.yaml. you may forget adding the secret \"unknown_secret\" to the list",
+			},
+			configSecrets: []string{},
+		},
+		{
+			what:  "unknown secret",
+			input: "secrets.UNKNOWN_SECRET",
+			expected: []string{
+				"undefined secret \"unknown_secret\". defined secrets in actionlint.yaml are \"MY_SECRET\"",
+			},
+			configSecrets: []string{"MY_SECRET"},
+		},
+		{
+			what:  "declared secrets stay strict for a workflow_call-only workflow",
+			input: "secrets.BAR",
+			expected: []string{
+				"property \"bar\" is not defined in object type",
+			},
+			secrets:       NewStrictObjectType(map[string]ExprType{"foo": StringType{}}),
+			configSecrets: []string{"BAR"},
+		},
+		{
 			what:  "config variable naming convention",
 			input: "vars.FOO-BAR",
 			expected: []string{
@@ -1372,7 +1448,7 @@ func TestExprSemanticsCheckError(t *testing.T) {
 				t.Fatal("Parse error:", tc.input)
 			}
 
-			c := NewExprSemanticsChecker(false, tc.configVars)
+			c := NewExprSemanticsChecker(false, &Config{ConfigVariables: tc.configVars, ConfigSecrets: tc.configSecrets})
 			if tc.funcs != nil {
 				c.funcs = tc.funcs // Set functions for testing
 			}
@@ -1384,6 +1460,9 @@ func TestExprSemanticsCheckError(t *testing.T) {
 			}
 			if tc.needs != nil {
 				c.UpdateNeeds(tc.needs)
+			}
+			if tc.secrets != nil {
+				c.UpdateSecrets(tc.secrets)
 			}
 			if tc.availCtx != nil {
 				c.SetContextAvailability(tc.availCtx)

--- a/quotes.go
+++ b/quotes.go
@@ -1,7 +1,7 @@
 package actionlint
 
 import (
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 )
@@ -60,8 +60,9 @@ func quotes(ss []string) string {
 }
 
 func sortedQuotes(ss []string) string {
-	sort.Strings(ss)
-	return quotes(ss)
+	sorted := slices.Clone(ss)
+	slices.Sort(sorted)
+	return quotes(sorted)
 }
 
 func quotesAll(sss ...[]string) string {

--- a/quotes_test.go
+++ b/quotes_test.go
@@ -1,6 +1,7 @@
 package actionlint
 
 import (
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -29,6 +30,19 @@ func TestQuotesSortedQuotes(t *testing.T) {
 				t.Errorf("want: %s\nhave: %s", want, have)
 			}
 		})
+	}
+}
+
+func TestQuotesSortedQuotesDoesNotSortItsArgument(t *testing.T) {
+	ss := []string{"piyo", "foo", "bar"}
+	want := []string{"piyo", "foo", "bar"}
+
+	if have := sortedQuotes(ss); have != `"bar", "foo", "piyo"` {
+		t.Fatalf("unexpected result: %s", have)
+	}
+
+	if !slices.Equal(ss, want) {
+		t.Errorf("argument was reordered\nwant: %v\nhave: %v", want, ss)
 	}
 }
 

--- a/rule_expression.go
+++ b/rule_expression.go
@@ -151,10 +151,13 @@ func (rule *RuleExpression) VisitWorkflowPre(n *Workflow) error {
 			// So `secrets` context must be typed as { string => string }. `e.Secrets` is nil when `secrets:` does not
 			// exist. When `e.Secrets` is an empty map, `secrets:` exists but it has no child. A workflow with another
 			// trigger can also access repository secrets on that trigger path, so its secrets type must remain open.
-			if e.Secrets != nil && !hasNonWorkflowCallTrigger {
+			if e.Secrets != nil {
 				sty := NewEmptyStrictObjectType()
 				for id := range e.Secrets {
 					sty.Props[id] = StringType{}
+				}
+				if hasNonWorkflowCallTrigger {
+					sty.Mapped = StringType{}
 				}
 				rule.secretsTy = sty
 			}
@@ -789,11 +792,7 @@ func (rule *RuleExpression) exprError(err *ExprError, lineBase, colBase int) {
 }
 
 func (rule *RuleExpression) checkSemanticsOfExprNode(expr ExprNode, line, col int, checkUntrusted bool, workflowKey string) (ExprType, bool) {
-	var v []string
-	if rule.config != nil {
-		v = rule.config.ConfigVariables
-	}
-	c := NewExprSemanticsChecker(checkUntrusted, v)
+	c := NewExprSemanticsChecker(checkUntrusted, rule.config)
 	if rule.matrixTy != nil {
 		c.UpdateMatrix(rule.matrixTy)
 	}

--- a/testdata/projects/config_secrets.out
+++ b/testdata/projects/config_secrets.out
@@ -1,0 +1,3 @@
+/^workflows\/mixed_trigger\.yaml:17:24: undefined secret "nope"\. defined secrets in actionlint\.yaml are "API_KEY", "MY_SECRET" \[expression\]$/
+/^workflows\/reusable\.yaml:14:24: property "my_secret" is not defined in object type \{.*only_secret: string.*\} \[expression\]$/
+/^workflows\/test\.yaml:16:24: undefined secret "piyo"\. defined secrets in actionlint\.yaml are "API_KEY", "MY_SECRET" \[expression\]$/

--- a/testdata/projects/config_secrets.out
+++ b/testdata/projects/config_secrets.out
@@ -1,3 +1,4 @@
 /^workflows\/mixed_trigger\.yaml:17:24: undefined secret "nope"\. defined secrets in actionlint\.yaml are "API_KEY", "MY_SECRET" \[expression\]$/
 /^workflows\/reusable\.yaml:14:24: property "my_secret" is not defined in object type \{.*only_secret: string.*\} \[expression\]$/
 /^workflows\/test\.yaml:16:24: undefined secret "piyo"\. defined secrets in actionlint\.yaml are "API_KEY", "MY_SECRET" \[expression\]$/
+/^workflows\/test\.yaml:20:24: undefined secret "fuga"\. defined secrets in actionlint\.yaml are "API_KEY", "MY_SECRET" \[expression\]$/

--- a/testdata/projects/config_secrets/actionlint.yaml
+++ b/testdata/projects/config_secrets/actionlint.yaml
@@ -1,0 +1,1 @@
+config-secrets: [MY_SECRET, API_KEY]

--- a/testdata/projects/config_secrets/workflows/mixed_trigger.yaml
+++ b/testdata/projects/config_secrets/workflows/mixed_trigger.yaml
@@ -1,0 +1,17 @@
+on:
+  workflow_call:
+    secrets:
+      declared_secret:
+        required: false
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      # Declared by workflow_call
+      - run: echo '${{ secrets.declared_secret }}'
+      # Listed in actionlint.yaml
+      - run: echo '${{ secrets.MY_SECRET }}'
+      # ERROR: Neither declared nor listed
+      - run: echo '${{ secrets.NOPE }}'

--- a/testdata/projects/config_secrets/workflows/reusable.yaml
+++ b/testdata/projects/config_secrets/workflows/reusable.yaml
@@ -1,0 +1,14 @@
+on:
+  workflow_call:
+    secrets:
+      only_secret:
+        required: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      # Declared by workflow_call
+      - run: echo '${{ secrets.only_secret }}'
+      # ERROR: The declaration is closed, the allowlist does not open it
+      - run: echo '${{ secrets.MY_SECRET }}'

--- a/testdata/projects/config_secrets/workflows/test.yaml
+++ b/testdata/projects/config_secrets/workflows/test.yaml
@@ -14,3 +14,7 @@ jobs:
       - run: echo '${{ secrets.GITHUB_TOKEN }}'
       # ERROR: Undefined secret
       - run: echo '${{ secrets.PIYO }}'
+      # Index access with a string literal
+      - run: echo "${{ secrets['MY_SECRET'] }}"
+      # ERROR: Undefined secret
+      - run: echo "${{ secrets['FUGA'] }}"

--- a/testdata/projects/config_secrets/workflows/test.yaml
+++ b/testdata/projects/config_secrets/workflows/test.yaml
@@ -1,0 +1,16 @@
+on: push
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      # These are listed
+      - run: echo '${{ secrets.MY_SECRET }}'
+      - run: echo '${{ secrets.API_KEY }}'
+      # Name is case-insensitive
+      - run: echo '${{ secrets.my_secret }}'
+      - run: echo '${{ secrets.My_Secret }}'
+      # Always provided by GitHub
+      - run: echo '${{ secrets.GITHUB_TOKEN }}'
+      # ERROR: Undefined secret
+      - run: echo '${{ secrets.PIYO }}'

--- a/testdata/projects/config_secrets_empty.out
+++ b/testdata/projects/config_secrets_empty.out
@@ -1,0 +1,1 @@
+workflows/test.yaml:10:24: no secret is allowed since the secrets list is empty in actionlint.yaml. you may forget adding the secret "foo" to the list [expression]

--- a/testdata/projects/config_secrets_empty/actionlint.yaml
+++ b/testdata/projects/config_secrets_empty/actionlint.yaml
@@ -1,0 +1,1 @@
+config-secrets: []

--- a/testdata/projects/config_secrets_empty/workflows/test.yaml
+++ b/testdata/projects/config_secrets_empty/workflows/test.yaml
@@ -1,0 +1,10 @@
+on: push
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      # Always provided by GitHub
+      - run: echo '${{ secrets.GITHUB_TOKEN }}'
+      # ERROR: The list is empty so no secret is allowed
+      - run: echo '${{ secrets.FOO }}'


### PR DESCRIPTION
The `secrets` context accepts any property name, so `secrets.DEPLOY_TOEKN` and `secrets.DEPLOY_TOKEN` are equally valid to the linter and the typo reaches the runner as an empty string. `config-variables` already solves this for `vars`; this does the same for `secrets`.

```yaml
config-secrets:
  - DEPLOY_TOKEN
```

Names are matched case-insensitively, `null` or an absent key leaves the check off, and an empty list means no secret is allowed. `GITHUB_TOKEN`, `ACTIONS_RUNNER_DEBUG` and `ACTIONS_STEP_DEBUG` stay valid at every setting because the runner always provides them.

Behaviour of the three settings, through the CLI against config files outside the repo. The workflow under test:

```yaml
on: push

jobs:
  test:
    runs-on: ubuntu-latest
    steps:
      - run: echo '${{ secrets.DEPLOY_TOKEN }}'
      - run: echo '${{ secrets.GITHUB_TOKEN }}'
      - run: echo '${{ secrets.DEPLOY_TOEKN }}'
```

`populated.yaml` holds `config-secrets: [DEPLOY_TOKEN]`, `absent.yaml` holds only `config-variables: null`, and `empty.yaml` holds `config-secrets: []`.

<details><summary>Measured</summary>

```console
$ ./actionlint -no-color -config-file /tmp/al-cli-check/populated.yaml /tmp/al-cli-check/wf.yaml; echo "exit=$?"
../../../../../../tmp/al-cli-check/wf.yaml:9:24: undefined secret "deploy_toekn". defined secrets in actionlint.yaml are "DEPLOY_TOKEN" [expression]
  |
9 |       - run: echo '${{ secrets.DEPLOY_TOEKN }}'
  |                        ^~~~~~~~~~~~~~~~~~~~
exit=1

$ ./actionlint -no-color -config-file /tmp/al-cli-check/absent.yaml /tmp/al-cli-check/wf.yaml; echo "exit=$?"
exit=0

$ ./actionlint -no-color -config-file /tmp/al-cli-check/empty.yaml /tmp/al-cli-check/wf.yaml; echo "exit=$?"
../../../../../../tmp/al-cli-check/wf.yaml:7:24: no secret is allowed since the secrets list is empty in actionlint.yaml. you may forget adding the secret "deploy_token" to the list [expression]
  |
7 |       - run: echo '${{ secrets.DEPLOY_TOKEN }}'
  |                        ^~~~~~~~~~~~~~~~~~~~
../../../../../../tmp/al-cli-check/wf.yaml:9:24: no secret is allowed since the secrets list is empty in actionlint.yaml. you may forget adding the secret "deploy_toekn" to the list [expression]
  |
9 |       - run: echo '${{ secrets.DEPLOY_TOEKN }}'
  |                        ^~~~~~~~~~~~~~~~~~~~
exit=1
```

</details>

The key sits at the top level next to `config-variables`. `Config` has no `policy` key on this branch.

<details><summary>Measured</summary>

```console
$ grep -n 'policy' config.go; echo "grep-exit=$?"
grep-exit=1
```

</details>

Requires #39, which draws the line between correctness checks and policy checks.

## A data race, found by having three workflows in one fixture

`quotes.go` sorted its argument in place:

<details><summary>Before the fix</summary>

```console
$ git show HEAD~1:quotes.go | grep -n -A4 'func sortedQuotes'
62:func sortedQuotes(ss []string) string {
63-	sort.Strings(ss)
64-	return quotes(ss)
65-}
```

</details>

`expr_sema.go:733` passes `sema.configVars` straight in, and `linter.go:373-389` lints every workflow file in its own goroutine from one shared `*Config`. Two files that both reach the "undefined configuration variable" message therefore sort and read the same backing array at once.

Reproduced by reverting the fix, copying the existing fixture's only workflow to a second name, and running the project test under `-race`. The run printed two `WARNING: DATA RACE` blocks, one per element address; the first is below verbatim.

<details><summary>Before the fix</summary>

```console
$ git diff HEAD~1 HEAD -- quotes.go > /tmp/quotes-fix.patch
$ git apply -R /tmp/quotes-fix.patch
$ cp testdata/projects/config_variables/workflows/test.yaml testdata/projects/config_variables/workflows/test2.yaml
$ go test -race -count=1 -run 'TestLinterLintProject/project/config_variables' .
==================
WARNING: DATA RACE
Read at 0x00c00036a500 by goroutine 11:
  actionlint%2ekjanat%2edev.(*ExprSemanticsChecker).checkConfigVariables()
      /home/kjanat/projects/actionlint/.worktrees/config-secrets/expr_sema.go:723 +0x727
  actionlint%2ekjanat%2edev.(*ExprSemanticsChecker).checkObjectDeref()
      /home/kjanat/projects/actionlint/.worktrees/config-secrets/expr_sema.go:641 +0x1d9
  actionlint%2ekjanat%2edev.(*ExprSemanticsChecker).check()
      /home/kjanat/projects/actionlint/.worktrees/config-secrets/expr_sema.go:1126 +0x1c5
  actionlint%2ekjanat%2edev.(*ExprSemanticsChecker).Check()
      /home/kjanat/projects/actionlint/.worktrees/config-secrets/expr_sema.go:1152 +0x1b8
  actionlint%2ekjanat%2edev.(*RuleExpression).checkSemanticsOfExprNode()
      /home/kjanat/projects/actionlint/.worktrees/config-secrets/rule_expression.go:826 +0x12b7
  actionlint%2ekjanat%2edev.(*RuleExpression).checkSemantics()
      /home/kjanat/projects/actionlint/.worktrees/config-secrets/rule_expression.go:842 +0x704
  [9 further frames run down into Linter.LintFiles at linter.go:389, elided to fit GitHub's body limit]

Previous write at 0x00c00036a500 by goroutine 12:
  slices.insertionSortOrdered[go.shape.string]()
      /usr/lib/go/src/slices/zsortordered.go:15 +0x2f7
  slices.pdqsortOrdered[go.shape.string]()
      /usr/lib/go/src/slices/zsortordered.go:75 +0x824
  slices.Sort[go.shape.[]string,go.shape.string]()
      /usr/lib/go/src/slices/sort.go:18 +0x69
  actionlint%2ekjanat%2edev.sortedQuotes()
      /home/kjanat/projects/actionlint/.worktrees/config-secrets/quotes.go:63 +0x2b
  actionlint%2ekjanat%2edev.(*ExprSemanticsChecker).checkConfigVariables()
      /home/kjanat/projects/actionlint/.worktrees/config-secrets/expr_sema.go:733 +0x7a8
  [14 further frames run down into Linter.LintFiles at linter.go:389, elided to fit GitHub's body limit]

Goroutine 11 (running) created at:
  [errgroup.Group.Go in Linter.LintFiles at linter.go:373, elided]

Goroutine 12 (finished) created at:
  [errgroup.Group.Go in Linter.LintFiles at linter.go:373, elided]
==================
[a second WARNING: DATA RACE block follows with the same two stacks at the next element's address]
--- FAIL: TestLinterLintProject (0.01s)
    --- FAIL: TestLinterLintProject/project/config_variables (0.00s)
        linter_test.go:326: Linting project at testdata/projects/config_variables
        linter_test.go:346: Checking 2 errors with "testdata/projects/config_variables.out"
        linter_test.go:346:   Error[0]: workflows/test.yaml:14:24: undefined configuration variable "piyo". defined configuration variables in actionlint.yaml are "FOO", "WOO" [expression]
        linter_test.go:346:   Error[1]: workflows/test2.yaml:14:24: undefined configuration variable "piyo". defined configuration variables in actionlint.yaml are "FOO", "WOO" [expression]
        linter_test.go:346: 1 errors are expected but actually got 2 errors:
            workflows/test.yaml:14:24: undefined configuration variable "piyo". defined configuration variables in actionlint.yaml are "FOO", "WOO" [expression]
            workflows/test2.yaml:14:24: undefined configuration variable "piyo". defined configuration variables in actionlint.yaml are "FOO", "WOO" [expression]
        testing.go:1712: race detected during execution of test
FAIL
FAIL	actionlint.kjanat.dev	0.026s
FAIL
```

</details>

With the fix restored and the second fixture file still in place, the same command emits no race. Only the error count differs from `config_variables.out`.

<details><summary>After the fix</summary>

```console
$ git apply /tmp/quotes-fix.patch
$ go test -race -count=1 -run 'TestLinterLintProject/project/config_variables' .
--- FAIL: TestLinterLintProject (0.01s)
    --- FAIL: TestLinterLintProject/project/config_variables (0.00s)
        linter_test.go:326: Linting project at testdata/projects/config_variables
        linter_test.go:346: Checking 2 errors with "testdata/projects/config_variables.out"
        linter_test.go:346:   Error[0]: workflows/test.yaml:14:24: undefined configuration variable "piyo". defined configuration variables in actionlint.yaml are "FOO", "WOO" [expression]
        linter_test.go:346:   Error[1]: workflows/test2.yaml:14:24: undefined configuration variable "piyo". defined configuration variables in actionlint.yaml are "FOO", "WOO" [expression]
        linter_test.go:346: 1 errors are expected but actually got 2 errors:
            workflows/test.yaml:14:24: undefined configuration variable "piyo". defined configuration variables in actionlint.yaml are "FOO", "WOO" [expression]
            workflows/test2.yaml:14:24: undefined configuration variable "piyo". defined configuration variables in actionlint.yaml are "FOO", "WOO" [expression]
FAIL
FAIL	actionlint.kjanat.dev	0.026s
FAIL
```

</details>

After removing `test2.yaml`, the committed fixtures pass under `-race`.

<details><summary>After the fix</summary>

```console
$ git status
On branch config-secrets
Your branch is up to date with 'origin/config-secrets'.

nothing to commit, working tree clean

$ go test -race -count=1 -v -run 'TestLinterLintProject/project/config_variables|TestLinterLintProject/project/config_secrets' .
=== RUN   TestLinterLintProject
=== RUN   TestLinterLintProject/project/config_secrets
    linter_test.go:326: Linting project at testdata/projects/config_secrets
    linter_test.go:346: Checking 3 errors with "testdata/projects/config_secrets.out"
    linter_test.go:346:   Error[0]: workflows/mixed_trigger.yaml:17:24: undefined secret "nope". defined secrets in actionlint.yaml are "API_KEY", "MY_SECRET" [expression]
    linter_test.go:346:   Error[1]: workflows/reusable.yaml:14:24: property "my_secret" is not defined in object type {actions_runner_debug: string; actions_step_debug: string; github_token: string; only_secret: string} [expression]
    linter_test.go:346:   Error[2]: workflows/test.yaml:16:24: undefined secret "piyo". defined secrets in actionlint.yaml are "API_KEY", "MY_SECRET" [expression]
=== RUN   TestLinterLintProject/project/config_secrets_empty
    linter_test.go:326: Linting project at testdata/projects/config_secrets_empty
    linter_test.go:346: Checking 1 errors with "testdata/projects/config_secrets_empty.out"
    linter_test.go:346:   Error[0]: workflows/test.yaml:10:24: no secret is allowed since the secrets list is empty in actionlint.yaml. you may forget adding the secret "foo" to the list [expression]
=== RUN   TestLinterLintProject/project/config_variables
    linter_test.go:326: Linting project at testdata/projects/config_variables
    linter_test.go:346: Checking 1 errors with "testdata/projects/config_variables.out"
    linter_test.go:346:   Error[0]: workflows/test.yaml:14:24: undefined configuration variable "piyo". defined configuration variables in actionlint.yaml are "FOO", "WOO" [expression]
--- PASS: TestLinterLintProject (0.01s)
    --- PASS: TestLinterLintProject/project/config_secrets (0.00s)
    --- PASS: TestLinterLintProject/project/config_secrets_empty (0.00s)
    --- PASS: TestLinterLintProject/project/config_variables (0.00s)
PASS
ok  	actionlint.kjanat.dev	1.041s
```

</details>

`testdata/projects/config_variables/` has exactly one workflow file, and has never had a second one since the check was added. This branch's fixture has three, which is how the race surfaced.

<details><summary>Measured</summary>

```console
$ find testdata/projects/config_variables testdata/projects/config_secrets -type f | sort
testdata/projects/config_secrets/actionlint.yaml
testdata/projects/config_secrets/workflows/mixed_trigger.yaml
testdata/projects/config_secrets/workflows/reusable.yaml
testdata/projects/config_secrets/workflows/test.yaml
testdata/projects/config_variables/actionlint.yaml
testdata/projects/config_variables/workflows/test.yaml

$ git log --all --pretty=format: --name-only --diff-filter=A -- testdata/projects/config_variables | sort -u
testdata/projects/config_variables/actionlint.yaml
testdata/projects/config_variables/workflows/test.yaml
```

</details>

The fix is in `sortedQuotes` rather than at the call site. There are sixteen call sites.

<details><summary>Measured</summary>

```console
$ grep -rn 'sortedQuotes(' --include='*.go' .
quotes.go:62:func sortedQuotes(ss []string) string {
expr_insecure.go:290:			sortedQuotes(inputs),
rule_events.go:187:				sortedQuotes(expected),
rule_matrix.go:192:					sortedQuotes(ss),
rule_action.go:637:				sortedQuotes(ns),
rule_action.go:670:					sortedQuotes(ns),
rule_workflow_call.go:112:					note = "defined inputs are " + sortedQuotes(is)
rule_workflow_call.go:139:						note = "defined secrets are " + sortedQuotes(ss)
quotes_test.go:28:			have := sortedQuotes(tc)
quotes_test.go:40:	if have := sortedQuotes(ss); have != `"bar", "foo", "piyo"` {
parse.go:268:		m = fmt.Sprintf("unexpected key %q for %s. expected one of %v", s.Value, sec, sortedQuotes(expected))
rule_permissions.go:79:			rule.Errorf(p.Name.Pos, "unknown permission scope %q. all available permission scopes are %s", n, sortedQuotes(ss))
rule_shell_name.go:112:		sortedQuotes(available),
expr_sema.go:621:		sema.errorf(n, "undefined variable %q. available variables are %s", n.Token().Value, sortedQuotes(ss))
expr_sema.go:733:		sortedQuotes(sema.configVars),
expr_sema.go:758:		sortedQuotes(sema.configSecrets),
expr_sema.go:963:		sema.errorf(n, "undefined function %q. available functions are %s", n.Callee, sortedQuotes(ss))

$ grep -rn 'sortedQuotes(' --include='*.go' . | grep -v 'func sortedQuotes' | wc -l
16
```

</details>

Thirteen of the sixteen build their slice on the spot. Three reach into state shared across goroutines: `expr_sema.go:733` (`sema.configVars`), `expr_sema.go:758` (`sema.configSecrets`), and `rule_events.go:187`, whose `expected` parameter comes from the package-level `AllWebhookTypes` map by way of `rule_events.go:129`.

<details><summary>Measured</summary>

```console
$ grep -n 'AllWebhookTypes' all_webhooks.go rule_events.go
all_webhooks.go:5:// AllWebhookTypes is a table of all webhooks with their types. This variable was generated by
all_webhooks.go:10:var AllWebhookTypes = map[string][]string{
rule_events.go:129:	types, ok := AllWebhookTypes[hook]
```

</details>

With the in-place sort restored, linting one workflow with an invalid activity type permanently reorders that package-level slice, and linting two such files races. Both were measured with a scratch `_test.go` file that was removed afterwards.

<details><summary>Before the fix</summary>

```console
$ git apply -R /tmp/quotes-fix.patch
$ go test -count=1 -v -run 'TestVerifyWebhookTypesSharedSliceIsReordered' .
=== RUN   TestVerifyWebhookTypesSharedSliceIsReordered
    zz_verify_webhook_race_test.go:11: AllWebhookTypes["issues"] before lint: [opened edited deleted transferred pinned unpinned closed reopened assigned unassigned labeled unlabeled locked unlocked milestoned demilestoned typed untyped field_added field_removed]
    zz_verify_webhook_race_test.go:25: lint error: invalid activity type "bogus" for "issues" Webhook event. available types are "assigned", "closed", "deleted", "demilestoned", "edited", "field_added", "field_removed", "labeled", "locked", "milestoned", "opened", "pinned", "reopened", "transferred", "typed", "unassigned", "unlabeled", "unlocked", "unpinned", "untyped"
    zz_verify_webhook_race_test.go:29: AllWebhookTypes["issues"] after lint:  [assigned closed deleted demilestoned edited field_added field_removed labeled locked milestoned opened pinned reopened transferred typed unassigned unlabeled unlocked unpinned untyped]
    zz_verify_webhook_race_test.go:32: the package-level AllWebhookTypes slice was reordered in place by sortedQuotes
--- FAIL: TestVerifyWebhookTypesSharedSliceIsReordered (0.00s)
FAIL
FAIL	actionlint.kjanat.dev	0.009s
FAIL

$ go test -race -count=1 -v -run 'TestVerifyWebhookTypesRaceAcrossTwoFiles' .
=== RUN   TestVerifyWebhookTypesRaceAcrossTwoFiles
==================
WARNING: DATA RACE
Read at 0x00c000206500 by goroutine 10:
  slices.Index[go.shape.[]string,go.shape.string]()
      /usr/lib/go/src/slices/slices.go:98 +0x204
  slices.Contains[go.shape.[]string,go.shape.string]()
      /usr/lib/go/src/slices/slices.go:118 +0x1bf
  actionlint%2ekjanat%2edev.(*RuleEvents).checkTypes()
      /home/kjanat/projects/actionlint/.worktrees/config-secrets/rule_events.go:180 +0x1a2
  [remaining frames run down through RuleExpression and Linter.check into Linter.LintFiles at linter.go:389, elided to fit GitHub's body limit]

Previous write at 0x00c000206500 by goroutine 11:
  slices.partitionOrdered[go.shape.string]()
      /usr/lib/go/src/slices/zsortordered.go:138 +0x129
  slices.pdqsortOrdered[go.shape.string]()
      /usr/lib/go/src/slices/zsortordered.go:116 +0x64e
  slices.Sort[go.shape.[]string,go.shape.string]()
      /usr/lib/go/src/slices/sort.go:18 +0x64
  [remaining frames run down through RuleExpression and Linter.check into Linter.LintFiles at linter.go:389, elided to fit GitHub's body limit]

Goroutine 10 (running) created at:
  [both goroutines come from errgroup.Group.Go in Linter.LintFiles at linter.go:373, elided to fit GitHub's body limit]

Goroutine 11 (finished) created at:
  [both goroutines come from errgroup.Group.Go in Linter.LintFiles at linter.go:373, elided to fit GitHub's body limit]
==================
[nine further WARNING: DATA RACE blocks, same two stacks at addresses 0x00c000206510 through 0x00c000206630]
    testing.go:1712: race detected during execution of test
--- FAIL: TestVerifyWebhookTypesRaceAcrossTwoFiles (0.01s)
FAIL
FAIL	actionlint.kjanat.dev	0.039s
FAIL
```

</details>

With the fix, the global slice keeps its order and the two-file lint is race-free.

<details><summary>After the fix</summary>

```console
$ git apply /tmp/quotes-fix.patch
$ go test -race -count=1 -v -run 'TestVerifyWebhookTypes|TestQuotesSortedQuotes' .
=== RUN   TestQuotesSortedQuotes
=== RUN   TestQuotesSortedQuotes/0
=== RUN   TestQuotesSortedQuotes/1
=== RUN   TestQuotesSortedQuotes/2
=== RUN   TestQuotesSortedQuotes/3
--- PASS: TestQuotesSortedQuotes (0.00s)
    --- PASS: TestQuotesSortedQuotes/0 (0.00s)
    --- PASS: TestQuotesSortedQuotes/1 (0.00s)
    --- PASS: TestQuotesSortedQuotes/2 (0.00s)
    --- PASS: TestQuotesSortedQuotes/3 (0.00s)
=== RUN   TestQuotesSortedQuotesDoesNotSortItsArgument
--- PASS: TestQuotesSortedQuotesDoesNotSortItsArgument (0.00s)
=== RUN   TestVerifyWebhookTypesSharedSliceIsReordered
    zz_verify_webhook_race_test.go:15: AllWebhookTypes["issues"] before lint: [opened edited deleted transferred pinned unpinned closed reopened assigned unassigned labeled unlabeled locked unlocked milestoned demilestoned typed untyped field_added field_removed]
    zz_verify_webhook_race_test.go:27: lint error: invalid activity type "bogus" for "issues" Webhook event. available types are "assigned", "closed", "deleted", "demilestoned", "edited", "field_added", "field_removed", "labeled", "locked", "milestoned", "opened", "pinned", "reopened", "transferred", "typed", "unassigned", "unlabeled", "unlocked", "unpinned", "untyped"
    zz_verify_webhook_race_test.go:31: AllWebhookTypes["issues"] after lint:  [opened edited deleted transferred pinned unpinned closed reopened assigned unassigned labeled unlabeled locked unlocked milestoned demilestoned typed untyped field_added field_removed]
--- PASS: TestVerifyWebhookTypesSharedSliceIsReordered (0.00s)
=== RUN   TestVerifyWebhookTypesRaceAcrossTwoFiles
--- PASS: TestVerifyWebhookTypesRaceAcrossTwoFiles (0.00s)
PASS
ok  	actionlint.kjanat.dev	1.064s
```

</details>

`TestQuotesSortedQuotes` could not have caught this. It sorts its own input before building the expected string, so it passes either way. `TestQuotesSortedQuotesDoesNotSortItsArgument` passes an unsorted slice and asserts it comes back untouched, and fails when the in-place sort is restored.

<details><summary>Before the fix</summary>

```console
$ sed -n '11,47p' quotes_test.go
func TestQuotesSortedQuotes(t *testing.T) {
	testCases := [][]string{
		{},
		{"foo"},
		{"foo", "bar", "piyo"},
		{"\n", "\t"},
	}

	for i, tc := range testCases {
		t.Run(strconv.Itoa(i), func(t *testing.T) {
			ss := tc
			sort.Strings(ss)
			qs := make([]string, 0, len(ss))
			for _, s := range tc {
				qs = append(qs, strconv.Quote(s))
			}
			want := strings.Join(qs, ", ")
			have := sortedQuotes(tc)
			if want != have {
				t.Errorf("want: %s\nhave: %s", want, have)
			}
		})
	}
}

func TestQuotesSortedQuotesDoesNotSortItsArgument(t *testing.T) {
	ss := []string{"piyo", "foo", "bar"}
	want := []string{"piyo", "foo", "bar"}

	if have := sortedQuotes(ss); have != `"bar", "foo", "piyo"` {
		t.Fatalf("unexpected result: %s", have)
	}

	if !slices.Equal(ss, want) {
		t.Errorf("argument was reordered\nwant: %v\nhave: %v", want, ss)
	}
}

$ git apply -R /tmp/quotes-fix.patch
$ go test -count=1 -v -run 'TestQuotesSortedQuotes' .
=== RUN   TestQuotesSortedQuotes
=== RUN   TestQuotesSortedQuotes/0
=== RUN   TestQuotesSortedQuotes/1
=== RUN   TestQuotesSortedQuotes/2
=== RUN   TestQuotesSortedQuotes/3
--- PASS: TestQuotesSortedQuotes (0.00s)
    --- PASS: TestQuotesSortedQuotes/0 (0.00s)
    --- PASS: TestQuotesSortedQuotes/1 (0.00s)
    --- PASS: TestQuotesSortedQuotes/2 (0.00s)
    --- PASS: TestQuotesSortedQuotes/3 (0.00s)
=== RUN   TestQuotesSortedQuotesDoesNotSortItsArgument
    quotes_test.go:45: argument was reordered
        want: [piyo foo bar]
        have: [bar foo piyo]
--- FAIL: TestQuotesSortedQuotesDoesNotSortItsArgument (0.00s)
FAIL
FAIL	actionlint.kjanat.dev	0.004s
FAIL
```

</details>

Upstream has the same defect.

## Three defects in the upstream patch

Ported from rhysd/actionlint#649 by `Thierry Deo`, which is open with a CHANGES_REQUESTED review.

<details><summary>Measured</summary>

```console
$ gh pr view 649 --repo rhysd/actionlint --json state,author,title,createdAt,url,reviews
{"author":{"id":"MDQ6VXNlcjYyMzAyNzc=","is_bot":false,"login":"tdeo","name":"Thierry"},"createdAt":"2026-04-15T09:22:46Z","reviews":[{"id":"PRR_kwDOFhfz2872iJga","author":{"login":"rhysd"},"authorAssociation":"OWNER","body":"","submittedAt":"2026-04-19T14:59:14Z","includesCreatedEdit":false,"reactionGroups":[],"state":"CHANGES_REQUESTED","commit":{"oid":"a29b9d72ee4a6581376ea40331530b90b4641f57"}},{"id":"PRR_kwDOFhfz2872p_Ih","author":{"login":"tdeo"},"authorAssociation":"NONE","body":"","submittedAt":"2026-04-20T08:00:36Z","includesCreatedEdit":false,"reactionGroups":[],"state":"COMMENTED","commit":{"oid":"a29b9d72ee4a6581376ea40331530b90b4641f57"}},{"id":"PRR_kwDOFhfz2878GCD0","author":{"login":"tdeo"},"authorAssociation":"NONE","body":"","submittedAt":"2026-05-05T15:24:41Z","includesCreatedEdit":false,"reactionGroups":[],"state":"COMMENTED","commit":{"oid":"a29b9d72ee4a6581376ea40331530b90b4641f57"}}],"state":"OPEN","title":"add config-secrets option to allow-list secrets in workflows","url":"https://github.com/rhysd/actionlint/pull/649"}
```

</details>

**`secrets.GITHUB_TOKEN` was rejected the moment the allowlist was set.** Upstream leaves the global `secrets` type as `NewMapObjectType(StringType{})` with no properties, so every name reaches `checkConfigSecrets`. Restoring that shape here makes the token the runner always provides into an error in both fixtures.

<details><summary>Mutation</summary>

```console
$ git diff -- expr_sema.go
diff --git a/expr_sema.go b/expr_sema.go
index ba87be0..6986773 100644
--- a/expr_sema.go
+++ b/expr_sema.go
@@ -353,10 +353,7 @@ var BuiltinGlobalVariableTypes = map[string]ExprType{
 		"environment": StringType{}, // https://github.com/github/docs/issues/32443
 	}),
 	// https://docs.github.com/en/actions/learn-github-actions/contexts#secrets-context
-	"secrets": &ObjectType{
-		Props:  maps.Clone(builtinSecretProps),
-		Mapped: StringType{},
-	},
+	"secrets": NewMapObjectType(StringType{}),
 	// https://docs.github.com/en/actions/learn-github-actions/contexts#strategy-context
 	"strategy": NewObjectType(map[string]ExprType{
 		"fail-fast":    BoolType{},

$ go test -count=1 -run 'TestLinterLintProject/project/config_secrets' .
--- FAIL: TestLinterLintProject (0.00s)
    --- FAIL: TestLinterLintProject/project/config_secrets (0.00s)
        linter_test.go:326: Linting project at testdata/projects/config_secrets
        linter_test.go:346: Checking 4 errors with "testdata/projects/config_secrets.out"
        linter_test.go:346:   Error[0]: workflows/mixed_trigger.yaml:17:24: undefined secret "nope". defined secrets in actionlint.yaml are "API_KEY", "MY_SECRET" [expression]
        linter_test.go:346:   Error[1]: workflows/reusable.yaml:14:24: property "my_secret" is not defined in object type {actions_runner_debug: string; actions_step_debug: string; github_token: string; only_secret: string} [expression]
        linter_test.go:346:   Error[2]: workflows/test.yaml:14:24: undefined secret "github_token". defined secrets in actionlint.yaml are "API_KEY", "MY_SECRET" [expression]
        linter_test.go:346:   Error[3]: workflows/test.yaml:16:24: undefined secret "piyo". defined secrets in actionlint.yaml are "API_KEY", "MY_SECRET" [expression]
        linter_test.go:346: 3 errors are expected but actually got 4 errors:
            workflows/mixed_trigger.yaml:17:24: undefined secret "nope". defined secrets in actionlint.yaml are "API_KEY", "MY_SECRET" [expression]
            workflows/reusable.yaml:14:24: property "my_secret" is not defined in object type {actions_runner_debug: string; actions_step_debug: string; github_token: string; only_secret: string} [expression]
            workflows/test.yaml:14:24: undefined secret "github_token". defined secrets in actionlint.yaml are "API_KEY", "MY_SECRET" [expression]
            workflows/test.yaml:16:24: undefined secret "piyo". defined secrets in actionlint.yaml are "API_KEY", "MY_SECRET" [expression]
    --- FAIL: TestLinterLintProject/project/config_secrets_empty (0.00s)
        linter_test.go:326: Linting project at testdata/projects/config_secrets_empty
        linter_test.go:346: Checking 2 errors with "testdata/projects/config_secrets_empty.out"
        linter_test.go:346:   Error[0]: workflows/test.yaml:8:24: no secret is allowed since the secrets list is empty in actionlint.yaml. you may forget adding the secret "github_token" to the list [expression]
        linter_test.go:346:   Error[1]: workflows/test.yaml:10:24: no secret is allowed since the secrets list is empty in actionlint.yaml. you may forget adding the secret "foo" to the list [expression]
        linter_test.go:346: 1 errors are expected but actually got 2 errors:
            workflows/test.yaml:8:24: no secret is allowed since the secrets list is empty in actionlint.yaml. you may forget adding the secret "github_token" to the list [expression]
            workflows/test.yaml:10:24: no secret is allowed since the secrets list is empty in actionlint.yaml. you may forget adding the secret "foo" to the list [expression]
FAIL
FAIL	actionlint.kjanat.dev	0.005s
FAIL
```

</details>

**Declared `workflow_call` secrets were rejected on a workflow with mixed triggers.** A workflow with both `workflow_call` and another trigger keeps the open `secrets` type under the guard introduced in `1c3a18e`, so its own declared names are measured against the allowlist. Restoring that guard reports `declared_secret` on `mixed_trigger.yaml`.

<details><summary>Mutation</summary>

```console
$ git log -S 'hasNonWorkflowCallTrigger' --oneline -- rule_expression.go
1c3a18e Support current GitHub Actions syntax

$ git diff -- rule_expression.go
diff --git a/rule_expression.go b/rule_expression.go
index 15f6961..82fdc35 100644
--- a/rule_expression.go
+++ b/rule_expression.go
@@ -151,14 +151,11 @@ func (rule *RuleExpression) VisitWorkflowPre(n *Workflow) error {
 			// So `secrets` context must be typed as { string => string }. `e.Secrets` is nil when `secrets:` does not
 			// exist. When `e.Secrets` is an empty map, `secrets:` exists but it has no child. A workflow with another
 			// trigger can also access repository secrets on that trigger path, so its secrets type must remain open.
-			if e.Secrets != nil {
+			if e.Secrets != nil && !hasNonWorkflowCallTrigger {
 				sty := NewEmptyStrictObjectType()
 				for id := range e.Secrets {
 					sty.Props[id] = StringType{}
 				}
-				if hasNonWorkflowCallTrigger {
-					sty.Mapped = StringType{}
-				}
 				rule.secretsTy = sty
 			}
 			for _, s := range e.Secrets {

$ go test -count=1 -run 'TestLinterLintProject/project/config_secrets' .
--- FAIL: TestLinterLintProject (0.00s)
    --- FAIL: TestLinterLintProject/project/config_secrets (0.00s)
        linter_test.go:326: Linting project at testdata/projects/config_secrets
        linter_test.go:346: Checking 4 errors with "testdata/projects/config_secrets.out"
        linter_test.go:346:   Error[0]: workflows/mixed_trigger.yaml:13:24: undefined secret "declared_secret". defined secrets in actionlint.yaml are "API_KEY", "MY_SECRET" [expression]
        linter_test.go:346:   Error[1]: workflows/mixed_trigger.yaml:17:24: undefined secret "nope". defined secrets in actionlint.yaml are "API_KEY", "MY_SECRET" [expression]
        linter_test.go:346:   Error[2]: workflows/reusable.yaml:14:24: property "my_secret" is not defined in object type {actions_runner_debug: string; actions_step_debug: string; github_token: string; only_secret: string} [expression]
        linter_test.go:346:   Error[3]: workflows/test.yaml:16:24: undefined secret "piyo". defined secrets in actionlint.yaml are "API_KEY", "MY_SECRET" [expression]
        linter_test.go:346: 3 errors are expected but actually got 4 errors:
            workflows/mixed_trigger.yaml:13:24: undefined secret "declared_secret". defined secrets in actionlint.yaml are "API_KEY", "MY_SECRET" [expression]
            workflows/mixed_trigger.yaml:17:24: undefined secret "nope". defined secrets in actionlint.yaml are "API_KEY", "MY_SECRET" [expression]
            workflows/reusable.yaml:14:24: property "my_secret" is not defined in object type {actions_runner_debug: string; actions_step_debug: string; github_token: string; only_secret: string} [expression]
            workflows/test.yaml:16:24: undefined secret "piyo". defined secrets in actionlint.yaml are "API_KEY", "MY_SECRET" [expression]
FAIL
FAIL	actionlint.kjanat.dev	0.005s
FAIL
```

</details>

**A duplicated type assertion.** No test distinguishes the two shapes, so this one is read off the upstream diff rather than measured.

<details><summary>Measured</summary>

```console
$ gh pr diff 649 --repo rhysd/actionlint | grep -n -B4 -A6 'v.Name == "secrets"'
87-@@ -622,6 +624,9 @@ func (sema *ExprSemanticsChecker) checkObjectDeref(n *ObjectDerefNode) ExprType
88- 			if v, ok := n.Receiver.(*VariableNode); ok && v.Name == "vars" {
89- 				sema.checkConfigVariables(n)
90- 			}
91:+			if v, ok := n.Receiver.(*VariableNode); ok && v.Name == "secrets" {
92-+				sema.checkConfigSecrets(n)
93-+			}
94- 			return ty.Mapped
95- 		}
96- 		if ty.IsStrict() {
97-@@ -713,6 +718,33 @@ func (sema *ExprSemanticsChecker) checkConfigVariables(n *ObjectDerefNode) {
```

</details>

The review is answered by behaviour rather than by argument. rhysd asked the author whether they had reviewed the generated code, and the author replied that they do not know Go and had checked plausibility.

<details><summary>Measured</summary>

```console
$ gh api repos/rhysd/actionlint/issues/649/comments --jq '.[] | {user: .user.login, created_at, body}'
{"body":"Since this change seems to be generated by Claude, let me ask a question. Did you review the generated code, confirmed the test results, and validated the behavior with actual config files?","created_at":"2026-04-19T14:49:45Z","user":"rhysd"}
{"body":"> Since this change seems to be generated by Claude, let me ask a question. Did you review the generated code, confirmed the test results, and validated the behavior with actual config files?\r\n\r\nHello, that's a very good, while I didn't know anything about go and not much about this project's internal, what I did review myself was:\r\n- that the generated files under `testdata/` made sense, that they were implemented in a very similar way to what exists for config variables and that the output is the behavior I would expect for a project with that workflow and configuration\r\n- that the implementation of `checkConfigSecrets` seemed to be coherent with what existed for `checkConfigVariables`\r\n- that the test suite still worked locally (claude was able to run it by itself)\r\n- I did see that the signature change to `NewExprSemanticsChecker` may not be what we want long term and possibly it would be better for it to receive a config object instead of individual values but I didn't think such a change was appropriate in this PR and I had no idea how to start\r\n\r\nOverall, I did think opening a PR was a good way to get the conversation started about https://github.com/rhysd/actionlint/issues/609","created_at":"2026-04-20T07:55:22Z","user":"tdeo"}
```

</details>

rhysd also asked for the empty-list fast path to be dropped as redundant. Without it the message ends with a trailing space, because `quotes()` returns `""` for an empty slice. Removing it would mean rewriting the general message, which is existing `config-variables` behaviour. The follow-up question about whether `checkConfigVariables` should change too has been unanswered upstream since 2026-05-05, and that function is untouched here.

<details><summary>Mutation</summary>

```console
$ gh api repos/rhysd/actionlint/pulls/649/comments --jq '.[] | {user: .user.login, created_at, path, body}'
{"body":"I don't think this fast path is necessary because the below error message is comprehensive enough.","created_at":"2026-04-19T14:56:24Z","path":"expr_sema.go","user":"rhysd"}
{"body":"Do you think we should also remove the same fast path from `checkConfigVariables` just above?","created_at":"2026-04-20T08:00:36Z","path":"expr_sema.go","user":"tdeo"}
{"body":"@rhysd do you have any opinion whether I should handle checkConfigVariables at the same time?","created_at":"2026-05-05T15:24:41Z","path":"expr_sema.go","user":"tdeo"}

$ git diff -- expr_sema.go
diff --git a/expr_sema.go b/expr_sema.go
index ba87be0..986d7d3 100644
--- a/expr_sema.go
+++ b/expr_sema.go
@@ -738,14 +738,6 @@ func (sema *ExprSemanticsChecker) checkConfigSecrets(n *ObjectDerefNode) {
 	if sema.configSecrets == nil {
 		return
 	}
-	if len(sema.configSecrets) == 0 {
-		sema.errorf(
-			n,
-			"no secret is allowed since the secrets list is empty in actionlint.yaml. you may forget adding the secret %q to the list",
-			n.Property,
-		)
-		return
-	}
 	if slices.ContainsFunc(sema.configSecrets, func(s string) bool {
 		return strings.EqualFold(s, n.Property)
 	}) {

$ go test -count=1 -run 'TestLinterLintProject/project/config_secrets_empty' . | cat -A
--- FAIL: TestLinterLintProject (0.00s)$
    --- FAIL: TestLinterLintProject/project/config_secrets_empty (0.00s)$
        linter_test.go:326: Linting project at testdata/projects/config_secrets_empty$
        linter_test.go:346: Checking 1 errors with "testdata/projects/config_secrets_empty.out"$
        linter_test.go:346:   Error[0]: workflows/test.yaml:10:24: undefined secret "foo". defined secrets in actionlint.yaml are  [expression]$
        linter_test.go:346: error message mismatch at 1th error does not match exactly$
              want: "workflows/test.yaml:10:24: no secret is allowed since the secrets list is empty in actionlint.yaml. you may forget adding the secret \"foo\" to the list [expression]"$
              have: "workflows/test.yaml:10:24: undefined secret \"foo\". defined secrets in actionlint.yaml are  [expression]"$
FAIL$
FAIL^Iactionlint.kjanat.dev^I0.012s$
FAIL$
```

</details>

## Mutations

Each applied to the committed code, target test run, reverted, `git status` clean before the next one.

The nil guard, the `ContainsFunc` branch, `EqualFold` versus `==`, the builtin properties, the `Props`-before-`Mapped` lookup order, the empty-list branch, the final message and the mixed-trigger handling each produce a distinct failure when changed. The builtin-properties, mixed-trigger and empty-list runs are above; the rest follow.

<details><summary>Mutation</summary>

```console
$ git diff -- expr_sema.go
diff --git a/expr_sema.go b/expr_sema.go
index ba87be0..9425a10 100644
--- a/expr_sema.go
+++ b/expr_sema.go
@@ -735,9 +735,6 @@ func (sema *ExprSemanticsChecker) checkConfigVariables(n *ObjectDerefNode) {
 }
 
 func (sema *ExprSemanticsChecker) checkConfigSecrets(n *ObjectDerefNode) {
-	if sema.configSecrets == nil {
-		return
-	}
 	if len(sema.configSecrets) == 0 {
 		sema.errorf(
 			n,

$ go test -count=1 -run 'TestExprSemanticsCheckOK' .
--- FAIL: TestExprSemanticsCheckOK (0.00s)
    --- FAIL: TestExprSemanticsCheckOK/default_secrets_object (0.00s)
        expr_sema_test.go:898: semantics check failed: [1:1:0: no secret is allowed since the secrets list is empty in actionlint.yaml. you may forget adding the secret "any_value" to the list]
    --- FAIL: TestExprSemanticsCheckOK/secret_without_config (0.00s)
        expr_sema_test.go:898: semantics check failed: [1:1:0: no secret is allowed since the secrets list is empty in actionlint.yaml. you may forget adding the secret "my_secret" to the list]
    --- FAIL: TestExprSemanticsCheckOK/open_secrets_type_still_allows_unknown_names_without_config (0.00s)
        expr_sema_test.go:898: semantics check failed: [1:1:0: no secret is allowed since the secrets list is empty in actionlint.yaml. you may forget adding the secret "unknown_secret" to the list]
FAIL
FAIL	actionlint.kjanat.dev	0.008s
FAIL
```

```console
$ git diff -- expr_sema.go
diff --git a/expr_sema.go b/expr_sema.go
index ba87be0..6c6d4c0 100644
--- a/expr_sema.go
+++ b/expr_sema.go
@@ -746,11 +746,6 @@ func (sema *ExprSemanticsChecker) checkConfigSecrets(n *ObjectDerefNode) {
 		)
 		return
 	}
-	if slices.ContainsFunc(sema.configSecrets, func(s string) bool {
-		return strings.EqualFold(s, n.Property)
-	}) {
-		return
-	}
 	sema.errorf(
 		n,
 		"undefined secret %q. defined secrets in actionlint.yaml are %s",

$ go test -count=1 -run 'TestExprSemanticsCheckOK|TestLinterLintProject/project/config_secrets' .
--- FAIL: TestExprSemanticsCheckOK (0.00s)
    --- FAIL: TestExprSemanticsCheckOK/known_secret (0.00s)
        expr_sema_test.go:898: semantics check failed: [1:1:0: undefined secret "my_secret". defined secrets in actionlint.yaml are "MY_SECRET"]
    --- FAIL: TestExprSemanticsCheckOK/secret_name_is_case_insensitive (0.00s)
        expr_sema_test.go:898: semantics check failed: [1:1:0: undefined secret "my_secret". defined secrets in actionlint.yaml are "My_Secret"]
--- FAIL: TestLinterLintProject (0.00s)
    --- FAIL: TestLinterLintProject/project/config_secrets (0.00s)
        linter_test.go:326: Linting project at testdata/projects/config_secrets
        linter_test.go:346: Checking 8 errors with "testdata/projects/config_secrets.out"
        linter_test.go:346:   Error[0]: workflows/mixed_trigger.yaml:15:24: undefined secret "my_secret". defined secrets in actionlint.yaml are "API_KEY", "MY_SECRET" [expression]
        linter_test.go:346:   Error[1]: workflows/mixed_trigger.yaml:17:24: undefined secret "nope". defined secrets in actionlint.yaml are "API_KEY", "MY_SECRET" [expression]
        linter_test.go:346:   Error[2]: workflows/reusable.yaml:14:24: property "my_secret" is not defined in object type {actions_runner_debug: string; actions_step_debug: string; github_token: string; only_secret: string} [expression]
        linter_test.go:346:   Error[3]: workflows/test.yaml:8:24: undefined secret "my_secret". defined secrets in actionlint.yaml are "API_KEY", "MY_SECRET" [expression]
        linter_test.go:346:   Error[4]: workflows/test.yaml:9:24: undefined secret "api_key". defined secrets in actionlint.yaml are "API_KEY", "MY_SECRET" [expression]
        linter_test.go:346:   Error[5]: workflows/test.yaml:11:24: undefined secret "my_secret". defined secrets in actionlint.yaml are "API_KEY", "MY_SECRET" [expression]
        linter_test.go:346:   Error[6]: workflows/test.yaml:12:24: undefined secret "my_secret". defined secrets in actionlint.yaml are "API_KEY", "MY_SECRET" [expression]
        linter_test.go:346:   Error[7]: workflows/test.yaml:16:24: undefined secret "piyo". defined secrets in actionlint.yaml are "API_KEY", "MY_SECRET" [expression]
        linter_test.go:346: 3 errors are expected but actually got 8 errors:
            workflows/mixed_trigger.yaml:15:24: undefined secret "my_secret". defined secrets in actionlint.yaml are "API_KEY", "MY_SECRET" [expression]
            workflows/mixed_trigger.yaml:17:24: undefined secret "nope". defined secrets in actionlint.yaml are "API_KEY", "MY_SECRET" [expression]
            workflows/reusable.yaml:14:24: property "my_secret" is not defined in object type {actions_runner_debug: string; actions_step_debug: string; github_token: string; only_secret: string} [expression]
            workflows/test.yaml:8:24: undefined secret "my_secret". defined secrets in actionlint.yaml are "API_KEY", "MY_SECRET" [expression]
            workflows/test.yaml:9:24: undefined secret "api_key". defined secrets in actionlint.yaml are "API_KEY", "MY_SECRET" [expression]
            workflows/test.yaml:11:24: undefined secret "my_secret". defined secrets in actionlint.yaml are "API_KEY", "MY_SECRET" [expression]
            workflows/test.yaml:12:24: undefined secret "my_secret". defined secrets in actionlint.yaml are "API_KEY", "MY_SECRET" [expression]
            workflows/test.yaml:16:24: undefined secret "piyo". defined secrets in actionlint.yaml are "API_KEY", "MY_SECRET" [expression]
FAIL
FAIL	actionlint.kjanat.dev	0.010s
FAIL
```

```console
$ git diff -- expr_sema.go
diff --git a/expr_sema.go b/expr_sema.go
index ba87be0..d1072fc 100644
--- a/expr_sema.go
+++ b/expr_sema.go
@@ -631,9 +631,6 @@ func (sema *ExprSemanticsChecker) checkObjectDeref(n *ObjectDerefNode) ExprType
 	case AnyType:
 		return AnyType{}
 	case *ObjectType:
-		if t, ok := ty.Props[n.Property]; ok {
-			return t
-		}
 		if ty.Mapped != nil {
 			if v, ok := n.Receiver.(*VariableNode); ok {
 				switch v.Name {
@@ -645,6 +642,9 @@ func (sema *ExprSemanticsChecker) checkObjectDeref(n *ObjectDerefNode) ExprType
 			}
 			return ty.Mapped
 		}
+		if t, ok := ty.Props[n.Property]; ok {
+			return t
+		}
 		if ty.IsStrict() {
 			sema.errorf(n, "property %q is not defined in object type %s", n.Property, ty.String())
 		}

$ go test -count=1 -run 'TestExprSemanticsCheckOK|TestLinterLintProject/project/config_secrets' .
--- FAIL: TestExprSemanticsCheckOK (0.00s)
    --- FAIL: TestExprSemanticsCheckOK/object_property_dereference (0.00s)
        expr_sema_test.go:902: wanted: bool
            but got:any
            diff:
              any(
            - 	s"bool",
            + 	s"any",
              )
    --- FAIL: TestExprSemanticsCheckOK/array_element_dereference (0.00s)
        expr_sema_test.go:902: wanted: array<bool>
            but got:array<any>
            diff:
              &actionlint.ArrayType{
            - 	Elem:  s"bool",
            + 	Elem:  s"any",
              	Deref: true,
              }
    --- FAIL: TestExprSemanticsCheckOK/filter_object_property_by_array_element_dereference (0.00s)
        expr_sema_test.go:902: wanted: array<string>
            but got:array<any>
            diff:
              &actionlint.ArrayType{
            - 	Elem:  s"string",
            + 	Elem:  s"any",
              	Deref: true,
              }
    --- FAIL: TestExprSemanticsCheckOK/index_access_to_dereferenced_array (0.00s)
        expr_sema_test.go:902: wanted: string
            but got:any
            diff:
              any(
            - 	s"string",
            + 	s"any",
              )
    --- FAIL: TestExprSemanticsCheckOK/case_insensitive_comparison_for_object_property (0.00s)
        expr_sema_test.go:902: wanted: null
            but got:any
            diff:
              any(
            - 	s"null",
            + 	s"any",
              )
    --- FAIL: TestExprSemanticsCheckOK/available_context (0.00s)
        expr_sema_test.go:902: wanted: bool
            but got:any
            diff:
              any(
            - 	s"bool",
            + 	s"any",
              )
    --- FAIL: TestExprSemanticsCheckOK/available_contexts (0.00s)
        expr_sema_test.go:902: wanted: bool
            but got:any
            diff:
              any(
            - 	s"bool",
            + 	s"any",
              )
    --- FAIL: TestExprSemanticsCheckOK/builtin_secret_with_allowlist (0.00s)
        expr_sema_test.go:898: semantics check failed: [1:1:0: undefined secret "github_token". defined secrets in actionlint.yaml are "MY_SECRET"]
    --- FAIL: TestExprSemanticsCheckOK/builtin_debug_secret_with_empty_allowlist (0.00s)
        expr_sema_test.go:898: semantics check failed: [1:1:0: no secret is allowed since the secrets list is empty in actionlint.yaml. you may forget adding the secret "actions_step_debug" to the list]
    --- FAIL: TestExprSemanticsCheckOK/declared_secret_is_not_checked_against_the_allowlist (0.00s)
        expr_sema_test.go:898: semantics check failed: [1:1:0: undefined secret "foo". defined secrets in actionlint.yaml are "BAR"]
--- FAIL: TestLinterLintProject (0.00s)
    --- FAIL: TestLinterLintProject/project/config_secrets (0.00s)
        linter_test.go:326: Linting project at testdata/projects/config_secrets
        linter_test.go:346: Checking 5 errors with "testdata/projects/config_secrets.out"
        linter_test.go:346:   Error[0]: workflows/mixed_trigger.yaml:13:24: undefined secret "declared_secret". defined secrets in actionlint.yaml are "API_KEY", "MY_SECRET" [expression]
        linter_test.go:346:   Error[1]: workflows/mixed_trigger.yaml:17:24: undefined secret "nope". defined secrets in actionlint.yaml are "API_KEY", "MY_SECRET" [expression]
        linter_test.go:346:   Error[2]: workflows/reusable.yaml:14:24: property "my_secret" is not defined in object type {actions_runner_debug: string; actions_step_debug: string; github_token: string; only_secret: string} [expression]
        linter_test.go:346:   Error[3]: workflows/test.yaml:14:24: undefined secret "github_token". defined secrets in actionlint.yaml are "API_KEY", "MY_SECRET" [expression]
        linter_test.go:346:   Error[4]: workflows/test.yaml:16:24: undefined secret "piyo". defined secrets in actionlint.yaml are "API_KEY", "MY_SECRET" [expression]
        linter_test.go:346: 3 errors are expected but actually got 5 errors:
            workflows/mixed_trigger.yaml:13:24: undefined secret "declared_secret". defined secrets in actionlint.yaml are "API_KEY", "MY_SECRET" [expression]
            workflows/mixed_trigger.yaml:17:24: undefined secret "nope". defined secrets in actionlint.yaml are "API_KEY", "MY_SECRET" [expression]
            workflows/reusable.yaml:14:24: property "my_secret" is not defined in object type {actions_runner_debug: string; actions_step_debug: string; github_token: string; only_secret: string} [expression]
            workflows/test.yaml:14:24: undefined secret "github_token". defined secrets in actionlint.yaml are "API_KEY", "MY_SECRET" [expression]
            workflows/test.yaml:16:24: undefined secret "piyo". defined secrets in actionlint.yaml are "API_KEY", "MY_SECRET" [expression]
    --- FAIL: TestLinterLintProject/project/config_secrets_empty (0.00s)
        linter_test.go:326: Linting project at testdata/projects/config_secrets_empty
        linter_test.go:346: Checking 2 errors with "testdata/projects/config_secrets_empty.out"
        linter_test.go:346:   Error[0]: workflows/test.yaml:8:24: no secret is allowed since the secrets list is empty in actionlint.yaml. you may forget adding the secret "github_token" to the list [expression]
        linter_test.go:346:   Error[1]: workflows/test.yaml:10:24: no secret is allowed since the secrets list is empty in actionlint.yaml. you may forget adding the secret "foo" to the list [expression]
        linter_test.go:346: 1 errors are expected but actually got 2 errors:
            workflows/test.yaml:8:24: no secret is allowed since the secrets list is empty in actionlint.yaml. you may forget adding the secret "github_token" to the list [expression]
            workflows/test.yaml:10:24: no secret is allowed since the secrets list is empty in actionlint.yaml. you may forget adding the secret "foo" to the list [expression]
FAIL
FAIL	actionlint.kjanat.dev	0.012s
FAIL
```

```console
$ git diff -- expr_sema.go
diff --git a/expr_sema.go b/expr_sema.go
index ba87be0..41a6359 100644
--- a/expr_sema.go
+++ b/expr_sema.go
@@ -753,7 +753,7 @@ func (sema *ExprSemanticsChecker) checkConfigSecrets(n *ObjectDerefNode) {
 	}
 	sema.errorf(
 		n,
-		"undefined secret %q. defined secrets in actionlint.yaml are %s",
+		"undefined secret %q. secrets listed in actionlint.yaml are %s",
 		n.Property,
 		sortedQuotes(sema.configSecrets),
 	)

$ go test -count=1 -run 'TestExprSemanticsCheckError|TestLinterLintProject/project/config_secrets' .
--- FAIL: TestExprSemanticsCheckError (0.00s)
    --- FAIL: TestExprSemanticsCheckError/unknown_secret (0.00s)
        expr_sema_test.go:1489: error "1:1:0: undefined secret \"unknown_secret\". secrets listed in actionlint.yaml are \"MY_SECRET\"" did not match any expected error messages []string{"undefined secret \"unknown_secret\". defined secrets in actionlint.yaml are \"MY_SECRET\""}
--- FAIL: TestLinterLintProject (0.00s)
    --- FAIL: TestLinterLintProject/project/config_secrets (0.00s)
        linter_test.go:326: Linting project at testdata/projects/config_secrets
        linter_test.go:346: Checking 3 errors with "testdata/projects/config_secrets.out"
        linter_test.go:346:   Error[0]: workflows/mixed_trigger.yaml:17:24: undefined secret "nope". secrets listed in actionlint.yaml are "API_KEY", "MY_SECRET" [expression]
        linter_test.go:346:   Error[1]: workflows/reusable.yaml:14:24: property "my_secret" is not defined in object type {actions_runner_debug: string; actions_step_debug: string; github_token: string; only_secret: string} [expression]
        linter_test.go:346:   Error[2]: workflows/test.yaml:16:24: undefined secret "piyo". secrets listed in actionlint.yaml are "API_KEY", "MY_SECRET" [expression]
        linter_test.go:346: error message mismatch at 1th error does not match to regular expression
              want: /^workflows\/mixed_trigger\.yaml:17:24: undefined secret "nope"\. defined secrets in actionlint\.yaml are "API_KEY", "MY_SECRET" \[expression\]$/
              have: "workflows/mixed_trigger.yaml:17:24: undefined secret \"nope\". secrets listed in actionlint.yaml are \"API_KEY\", \"MY_SECRET\" [expression]"
        linter_test.go:346: error message mismatch at 3th error does not match to regular expression
              want: /^workflows\/test\.yaml:16:24: undefined secret "piyo"\. defined secrets in actionlint\.yaml are "API_KEY", "MY_SECRET" \[expression\]$/
              have: "workflows/test.yaml:16:24: undefined secret \"piyo\". secrets listed in actionlint.yaml are \"API_KEY\", \"MY_SECRET\" [expression]"
FAIL
FAIL	actionlint.kjanat.dev	0.009s
FAIL
```

</details>

The `yaml` tag is covered by `TestConfigParseConfigSecrets` and by both project fixtures.

<details><summary>Mutation</summary>

```console
$ git diff -- config.go
diff --git a/config.go b/config.go
index 73aa58a..1228c11 100644
--- a/config.go
+++ b/config.go
@@ -68,7 +68,7 @@ type Config struct {
 	// names of `secrets` context will not be checked. Otherwise actionlint will report a name which is
 	// not listed here as an undefined secret.
 	// https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions
-	ConfigSecrets []string `yaml:"config-secrets"`
+	ConfigSecrets []string `yaml:"config-secretz"`
 	// Paths is a "paths" mapping in the configuration file. The keys are glob patterns to match file paths.
 	// And the values are corresponding configurations applied to the file paths.
 	Paths map[string]PathConfig `yaml:"paths"`

$ go test -count=1 -run 'TestConfigParseConfigSecrets|TestLinterLintProject/project/config_secrets' .
--- FAIL: TestConfigParseConfigSecrets (0.00s)
    --- FAIL: TestConfigParseConfigSecrets/empty_config-secrets (0.00s)
        config_test.go:95:   []string(
            - 	nil,
            + 	{},
              )
            
    --- FAIL: TestConfigParseConfigSecrets/config-secrets (0.00s)
        config_test.go:95:   []string(
            - 	nil,
            + 	{"FOO", "BAR"},
              )
            
--- FAIL: TestLinterLintProject (0.00s)
    --- FAIL: TestLinterLintProject/project/config_secrets (0.00s)
        linter_test.go:326: Linting project at testdata/projects/config_secrets
        linter_test.go:346: Checking 1 errors with "testdata/projects/config_secrets.out"
        linter_test.go:346:   Error[0]: workflows/reusable.yaml:14:24: property "my_secret" is not defined in object type {actions_runner_debug: string; actions_step_debug: string; github_token: string; only_secret: string} [expression]
        linter_test.go:346: 3 errors are expected but actually got 1 errors:
            workflows/reusable.yaml:14:24: property "my_secret" is not defined in object type {actions_runner_debug: string; actions_step_debug: string; github_token: string; only_secret: string} [expression]
    --- FAIL: TestLinterLintProject/project/config_secrets_empty (0.00s)
        linter_test.go:326: Linting project at testdata/projects/config_secrets_empty
        linter_test.go:346: Checking 0 errors with "testdata/projects/config_secrets_empty.out"
        linter_test.go:346: 1 errors are expected but actually got 0 errors:
FAIL
FAIL	actionlint.kjanat.dev	0.010s
FAIL
```

</details>

The `config-secrets: null` entry in `writeDefaultConfigFile` is not covered. `TestConfigGenerateDefaultConfigFileOK` asserts `c.ConfigSecrets != nil`, which an absent key also satisfies, and removing the entry leaves the whole root package green.

<details><summary>Mutation</summary>

```console
$ git diff -- config.go
diff --git a/config.go b/config.go
index 73aa58a..0cfc10b 100644
--- a/config.go
+++ b/config.go
@@ -148,11 +148,6 @@ func writeDefaultConfigFile(path string) error {
 # Empty array means no configuration variable is allowed.
 config-variables: null
 
-# Secrets in array of strings defined in your repository or organization.
-# ` + "`null`" + ` means disabling the secrets check. Empty array means no secret is
-# allowed.
-config-secrets: null
-
 # Configuration for file paths. The keys are glob patterns to match to file
 # paths relative to the repository root. The values are the configurations for
 # the file paths. Note that the path separator is always '/'.

$ go test -count=1 .
ok  	actionlint.kjanat.dev	279.547s
```

</details>

## The case-insensitivity test case

The OK case named `secret name is case insensitive` uses `configSecrets: ["My_Secret"]` against `secrets.MY_SECRET`. `expr_parser.go:218` lower-cases the property before comparison, so upstream's `["my_secret"]` matched under a plain `==` and the case named after case-insensitivity did not test it.

<details><summary>Mutation</summary>

```console
$ sed -n '215,219p' expr_parser.go
			case TokenKindIdent:
				t := p.next() // eat 'b' of 'a.b'
				// Property name is case insensitive. github.event and github.EVENT are the same
				ret = &ObjectDerefNode{ret, strings.ToLower(t.Value)}
			default:

$ git diff -- expr_sema.go
diff --git a/expr_sema.go b/expr_sema.go
index ba87be0..0d6f577 100644
--- a/expr_sema.go
+++ b/expr_sema.go
@@ -747,7 +747,7 @@ func (sema *ExprSemanticsChecker) checkConfigSecrets(n *ObjectDerefNode) {
 		return
 	}
 	if slices.ContainsFunc(sema.configSecrets, func(s string) bool {
-		return strings.EqualFold(s, n.Property)
+		return s == n.Property
 	}) {
 		return
 	}

$ go test -count=1 -run 'TestExprSemanticsCheckOK' .
--- FAIL: TestExprSemanticsCheckOK (0.01s)
    --- FAIL: TestExprSemanticsCheckOK/known_secret (0.00s)
        expr_sema_test.go:898: semantics check failed: [1:1:0: undefined secret "my_secret". defined secrets in actionlint.yaml are "MY_SECRET"]
    --- FAIL: TestExprSemanticsCheckOK/secret_name_is_case_insensitive (0.00s)
        expr_sema_test.go:898: semantics check failed: [1:1:0: undefined secret "my_secret". defined secrets in actionlint.yaml are "My_Secret"]
FAIL
FAIL	actionlint.kjanat.dev	0.014s
FAIL

$ git diff -- expr_sema_test.go
diff --git a/expr_sema_test.go b/expr_sema_test.go
index 1881073..95696f4 100644
--- a/expr_sema_test.go
+++ b/expr_sema_test.go
@@ -700,7 +700,7 @@ func TestExprSemanticsCheckOK(t *testing.T) {
 			what:          "secret name is case insensitive",
 			input:         "secrets.MY_SECRET",
 			expected:      StringType{},
-			configSecrets: []string{"My_Secret"},
+			configSecrets: []string{"my_secret"},
 		},
 		{
 			what:          "builtin secret with allowlist",

$ go test -count=1 -v -run 'TestExprSemanticsCheckOK/secret_name_is_case_insensitive' .
=== RUN   TestExprSemanticsCheckOK
=== RUN   TestExprSemanticsCheckOK/secret_name_is_case_insensitive
--- PASS: TestExprSemanticsCheckOK (0.00s)
    --- PASS: TestExprSemanticsCheckOK/secret_name_is_case_insensitive (0.00s)
PASS
ok  	actionlint.kjanat.dev	0.009s
```

</details>

The same gap is in the existing `config-variables` tests. `expr_sema_test.go:683` sets `configVars: []string{"some_variable"}` against `vars.SOME_VARIABLE`, and replacing `EqualFold` with `==` in `checkConfigVariables` leaves that case green. Of its two adjacent cases only `known configuration variable` fails; `configuration variable` sets no `configVars` and so has the check disabled. The `config_variables` project fixture also fails. Left alone here, since it is outside this change.

<details><summary>Mutation</summary>

```console
$ git diff -- expr_sema.go
diff --git a/expr_sema.go b/expr_sema.go
index ba87be0..61f7d3e 100644
--- a/expr_sema.go
+++ b/expr_sema.go
@@ -721,7 +721,7 @@ func (sema *ExprSemanticsChecker) checkConfigVariables(n *ObjectDerefNode) {
 	}
 
 	for _, v := range sema.configVars {
-		if strings.EqualFold(v, n.Property) {
+		if v == n.Property {
 			return
 		}
 	}

$ go test -count=1 -v -run 'TestExprSemanticsCheckOK/configuration_variable|TestExprSemanticsCheckOK/known_configuration_variable|TestLinterLintProject/project/config_variables' .
=== RUN   TestExprSemanticsCheckOK
=== RUN   TestExprSemanticsCheckOK/configuration_variable
=== RUN   TestExprSemanticsCheckOK/known_configuration_variable
    expr_sema_test.go:898: semantics check failed: [1:1:0: undefined configuration variable "some_variable". defined configuration variables in actionlint.yaml are "SOME_VARIABLE"]
=== RUN   TestExprSemanticsCheckOK/configuration_variable_name_is_case_insensitive
--- FAIL: TestExprSemanticsCheckOK (0.01s)
    --- PASS: TestExprSemanticsCheckOK/configuration_variable (0.00s)
    --- FAIL: TestExprSemanticsCheckOK/known_configuration_variable (0.00s)
    --- PASS: TestExprSemanticsCheckOK/configuration_variable_name_is_case_insensitive (0.00s)
=== RUN   TestLinterLintProject
=== RUN   TestLinterLintProject/project/config_variables
    linter_test.go:326: Linting project at testdata/projects/config_variables
    linter_test.go:346: Checking 5 errors with "testdata/projects/config_variables.out"
    linter_test.go:346:   Error[0]: workflows/test.yaml:8:24: undefined configuration variable "foo". defined configuration variables in actionlint.yaml are "FOO", "WOO" [expression]
    linter_test.go:346:   Error[1]: workflows/test.yaml:9:24: undefined configuration variable "woo". defined configuration variables in actionlint.yaml are "FOO", "WOO" [expression]
    linter_test.go:346:   Error[2]: workflows/test.yaml:11:24: undefined configuration variable "foo". defined configuration variables in actionlint.yaml are "FOO", "WOO" [expression]
    linter_test.go:346:   Error[3]: workflows/test.yaml:12:24: undefined configuration variable "foo". defined configuration variables in actionlint.yaml are "FOO", "WOO" [expression]
    linter_test.go:346:   Error[4]: workflows/test.yaml:14:24: undefined configuration variable "piyo". defined configuration variables in actionlint.yaml are "FOO", "WOO" [expression]
    linter_test.go:346: 1 errors are expected but actually got 5 errors:
        workflows/test.yaml:8:24: undefined configuration variable "foo". defined configuration variables in actionlint.yaml are "FOO", "WOO" [expression]
        workflows/test.yaml:9:24: undefined configuration variable "woo". defined configuration variables in actionlint.yaml are "FOO", "WOO" [expression]
        workflows/test.yaml:11:24: undefined configuration variable "foo". defined configuration variables in actionlint.yaml are "FOO", "WOO" [expression]
        workflows/test.yaml:12:24: undefined configuration variable "foo". defined configuration variables in actionlint.yaml are "FOO", "WOO" [expression]
        workflows/test.yaml:14:24: undefined configuration variable "piyo". defined configuration variables in actionlint.yaml are "FOO", "WOO" [expression]
--- FAIL: TestLinterLintProject (0.00s)
    --- FAIL: TestLinterLintProject/project/config_variables (0.00s)
FAIL
FAIL	actionlint.kjanat.dev	0.031s
FAIL
```

</details>

## Credit

rhysd/actionlint#649 by `Thierry Deo`, with a `Co-authored-by` trailer. The key name, the message wording and the shape mirroring `config-variables` come from there. The author's own reservation in the review thread, that `NewExprSemanticsChecker` would be better receiving "a config object instead of individual values", is adopted: it now takes `(bool, *Config)`.

## Verification

<details><summary>Gates</summary>

```console
$ make build SKIP_GO_GENERATE=true
CGO_ENABLED=0 go build ./cmd/actionlint

$ make test
go test -race ./...
ok  	actionlint.kjanat.dev	285.061s
?   	actionlint.kjanat.dev/cmd/actionlint	[no test files]
ok  	actionlint.kjanat.dev/cmd/actionlint-action	1.052s
ok  	actionlint.kjanat.dev/fuzz	1.020s
ok  	actionlint.kjanat.dev/scripts/bump-version	2.020s
ok  	actionlint.kjanat.dev/scripts/check-checks	58.494s
ok  	actionlint.kjanat.dev/scripts/generate-availability	1.383s
ok  	actionlint.kjanat.dev/scripts/generate-popular-actions	2.228s
ok  	actionlint.kjanat.dev/scripts/generate-webhook-events	1.290s

$ make lint SKIP_GO_GENERATE=true
golangci-lint run
0 issues.
go run golang.org/x/vuln/cmd/govulncheck@latest ./...
No vulnerabilities found.
GOOS=js GOARCH=wasm golangci-lint run ./playground
0 issues.
go run ./scripts/check-checks -quiet ./docs/checks.md

$ dprint check; echo "exit=$?"
exit=0

$ git status
On branch config-secrets
Your branch is up to date with 'origin/config-secrets'.

nothing to commit, working tree clean
```

</details>

