### PR TITLE
Add the "required-actions" policy check

### DIFF
--- a/config.go
+++ b/config.go
@@ -58,6 +58,37 @@ type Policy struct {
 	// RequireCommitHash requires every "uses:" to be pinned to a full commit SHA, or to an image digest
 	// when it names a Docker image. Nil means the key was not set.
 	RequireCommitHash *bool `yaml:"require-commit-hash"`
+	// RequiredActions is the actions every workflow must use. Each entry is written like a "uses:"
+	// value and both of its halves are glob patterns. Nil means the key was not set. An empty non-nil
+	// value requires no action, which disables the check.
+	RequiredActions []string `yaml:"required-actions"`
+}
+
+// decodeRequiredActions decodes the value of the "required-actions" key and validates every entry of
+// it. A null value leaves the destination untouched so that a key set to nothing keeps the meaning of
+// an absent key.
+func decodeRequiredActions(n *yaml.Node, out *[]string) error {
+	if n.Kind == yaml.ScalarNode && n.Tag == "!!null" {
+		return nil
+	}
+	if n.Kind != yaml.SequenceNode {
+		return fmt.Errorf("yaml: \"required-actions\" must be a sequence node at line:%d,col:%d", n.Line, n.Column)
+	}
+	as := make([]string, 0, len(n.Content))
+	for _, c := range n.Content {
+		if c.Kind != yaml.ScalarNode || c.Tag != "!!str" {
+			return fmt.Errorf("yaml: an entry of \"required-actions\" must be a string at line:%d,col:%d", c.Line, c.Column)
+		}
+		if c.Value == "" {
+			return fmt.Errorf("yaml: an entry of \"required-actions\" must not be empty at line:%d,col:%d", c.Line, c.Column)
+		}
+		if p, ok := invalidActionPattern(c.Value); ok {
+			return fmt.Errorf("yaml: invalid glob pattern %q in an entry of \"required-actions\" at line:%d,col:%d", p, c.Line, c.Column)
+		}
+		as = append(as, c.Value)
+	}
+	*out = as
+	return nil
 }
 
 // UnmarshalYAML implements yaml.Unmarshaler.
@@ -71,6 +102,8 @@ func (p *Policy) UnmarshalYAML(n *yaml.Node) error {
 		switch k.Value {
 		case "require-commit-hash":
 			err = v.Decode(&p.RequireCommitHash)
+		case "required-actions":
+			err = decodeRequiredActions(v, &p.RequiredActions)
 		default:
 			return fmt.Errorf("yaml: unknown key %q in \"policy\" at line:%d,col:%d", k.Value, k.Line, k.Column)
 		}
@@ -123,6 +156,15 @@ func (cfg *Config) PathConfigs(path string) []PathConfig {
 // when the receiver is nil or when the key is not set.
 func (cfg *Config) RequiresCommitHash() bool {
 	return cfg != nil && cfg.Policy.RequireCommitHash != nil && *cfg.Policy.RequireCommitHash
+}
+
+// RequiredActions returns the actions which every workflow must use following the "required-actions"
+// policy. It returns nil when the receiver is nil or when the key is not set.
+func (cfg *Config) RequiredActions() []string {
+	if cfg == nil {
+		return nil
+	}
+	return cfg.Policy.RequiredActions
 }
 
 // ParseConfig parses the given bytes as an actionlint config file. When deserializing the YAML file
@@ -200,6 +242,9 @@ paths:
 #  # Require every "uses:" to be pinned to a full commit SHA or an image
 #  # digest.
 #  require-commit-hash: true
+#  # Actions every workflow must use. "owner/repo@ref" also pins the version.
+#  required-actions:
+#    - actions/checkout
 `)
 	if err := os.WriteFile(path, b, 0644); err != nil {
 		return fmt.Errorf("could not write default configuration file at %q: %w", path, err)

--- a/config_test.go
+++ b/config_test.go
@@ -89,6 +89,45 @@ paths:
 `,
 			want: `invalid glob pattern`,
 		},
+		{
+			in: `
+policy:
+  required-actions: true
+`,
+			want: `"required-actions" must be a sequence node at line:3,col:21`,
+		},
+		{
+			in: `
+policy:
+  required-actions:
+    - 42
+`,
+			want: `an entry of "required-actions" must be a string at line:4,col:7`,
+		},
+		{
+			in: `
+policy:
+  required-actions:
+    - ""
+`,
+			want: `an entry of "required-actions" must not be empty at line:4,col:7`,
+		},
+		{
+			in: `
+policy:
+  required-actions:
+    - actions/[checkout
+`,
+			want: `invalid glob pattern "actions/[checkout" in an entry of "required-actions" at line:4,col:7`,
+		},
+		{
+			in: `
+policy:
+  required-actions:
+    - actions/checkout@[v5
+`,
+			want: `invalid glob pattern "[v5" in an entry of "required-actions" at line:4,col:7`,
+		},
 	}
 
 	for _, tc := range tests {
@@ -283,7 +322,7 @@ func TestConfigGenerateDefaultConfigFileOK(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := "#policy:\n#  # Require every \"uses:\" to be pinned to a full commit SHA or an image\n#  # digest.\n#  require-commit-hash: true\n"
+	want := "#policy:\n#  # Require every \"uses:\" to be pinned to a full commit SHA or an image\n#  # digest.\n#  require-commit-hash: true\n#  # Actions every workflow must use. \"owner/repo@ref\" also pins the version.\n#  required-actions:\n#    - actions/checkout\n"
 	if !strings.Contains(string(b), want) {
 		t.Fatalf("wanted generated config file %q to contain %q", string(b), want)
 	}
@@ -406,5 +445,62 @@ func TestConfigPolicyNilConfig(t *testing.T) {
 	var c *Config
 	if c.RequiresCommitHash() {
 		t.Fatal("\"require-commit-hash\" is enabled for a nil config")
+	}
+	if as := c.RequiredActions(); as != nil {
+		t.Fatalf("\"required-actions\" is %v for a nil config", as)
+	}
+}
+
+func TestConfigParseRequiredActionsOK(t *testing.T) {
+	tests := []struct {
+		what  string
+		input string
+		want  []string
+	}{
+		{
+			what:  "key is not set",
+			input: "policy: {}\n",
+			want:  nil,
+		},
+		{
+			what:  "key is null",
+			input: "policy:\n  required-actions:\n",
+			want:  nil,
+		},
+		{
+			what:  "key is an empty sequence",
+			input: "policy:\n  required-actions: []\n",
+			want:  []string{},
+		},
+		{
+			what:  "one action without a ref",
+			input: "policy:\n  required-actions:\n    - actions/checkout\n",
+			want:  []string{"actions/checkout"},
+		},
+		{
+			what:  "one action with a ref",
+			input: "policy:\n  required-actions:\n    - my-org/scan@v2\n",
+			want:  []string{"my-org/scan@v2"},
+		},
+		{
+			what:  "glob patterns",
+			input: "policy:\n  required-actions:\n    - github/codeql-action/*\n    - actions/checkout@v4*\n",
+			want:  []string{"github/codeql-action/*", "actions/checkout@v4*"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.what, func(t *testing.T) {
+			c, err := ParseConfig([]byte(tc.input))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(tc.want, c.Policy.RequiredActions); diff != "" {
+				t.Fatal(diff)
+			}
+			if diff := cmp.Diff(tc.want, c.RequiredActions()); diff != "" {
+				t.Fatal(diff)
+			}
+		})
 	}
 }

--- a/docs/config.md
+++ b/docs/config.md
@@ -86,6 +86,25 @@ policy:
   require-commit-hash: true
 ```
 
+### required-actions
+
+This check reports a workflow which does not use an action this repository requires. An entry is written like a `uses:`
+value and both of its halves are glob patterns. `actions/checkout` accepts any ref, `actions/checkout@v5` accepts that
+ref only, and `actions/checkout@v4*` accepts `v4` and `v4.2.2`. `*` does not match `/`, so `github/codeql-action/*`
+matches every action in that repository. The name is matched case insensitively and the ref is matched case sensitively.
+
+One error per missing action is reported at the first job of the workflow. Only the steps written in the workflow file
+are searched, so the steps of a composite action and of a called reusable workflow are not. A workflow whose every job
+calls a reusable workflow runs no step of its own, so it is passed over. So is a workflow with a `uses:` built with
+`${{ }}`, because the action it names is not known before the workflow runs.
+
+```yaml
+policy:
+  required-actions:
+    - actions/checkout
+    - my-org/security-scan@v2*
+```
+
 ## Generate the initial configuration
 
 You don't need to write the first configuration file by your hand. `actionlint` command can generate a default configuration

--- a/linter.go
+++ b/linter.go
@@ -590,6 +590,9 @@ func (l *Linter) check(
 		if cfg.RequiresCommitHash() {
 			rules = append(rules, NewRuleRequireCommitHash())
 		}
+		if len(cfg.RequiredActions()) > 0 {
+			rules = append(rules, NewRuleRequiredActions())
+		}
 		if l.shellcheck != "" {
 			r, err := NewRuleShellcheck(l.shellcheck, proc)
 			if err == nil {

--- a/rule_required_actions.go
+++ b/rule_required_actions.go
@@ -1,0 +1,164 @@
+package actionlint
+
+import (
+	"path"
+	"strings"
+)
+
+// actionUse is one "uses:" value of an action step found while visiting a workflow.
+type actionUse struct {
+	spec string
+	name string
+	ref  string
+	pos  *Pos
+}
+
+// splitActionRef splits an action reference, or a pattern for one, into its name and its ref at the
+// first "@". The ref is empty when the value contains no "@".
+func splitActionRef(s string) (string, string) {
+	name, ref, _ := strings.Cut(s, "@")
+	return name, ref
+}
+
+// invalidActionPattern returns the half of the entry which path.Match rejects as a pattern. The
+// second return value is false when both halves are valid.
+func invalidActionPattern(s string) (string, bool) {
+	name, ref := splitActionRef(s)
+	for _, p := range []string{name, ref} {
+		if _, err := path.Match(p, ""); err != nil {
+			return p, true
+		}
+	}
+	return "", false
+}
+
+// matchGlob reports whether the value matches the pattern. An invalid pattern matches nothing, so a
+// policy built through the Go API with a broken pattern reports its action as missing instead of
+// silently passing.
+func matchGlob(pattern, value string) bool {
+	ok, err := path.Match(pattern, value)
+	return err == nil && ok
+}
+
+// firstJobPos returns the position of the job which appears first in the workflow source. Jobs are
+// stored in a map, so the smallest position is picked to keep the reported position stable across
+// runs. It returns nil when the workflow has no job.
+func firstJobPos(w *Workflow) *Pos {
+	var ret *Pos
+	for _, j := range w.Jobs {
+		if j == nil || j.Pos == nil {
+			continue
+		}
+		if ret == nil || j.Pos.IsBefore(ret) {
+			ret = j.Pos
+		}
+	}
+	return ret
+}
+
+// runsOwnSteps reports whether at least one job of the workflow runs steps written in this file. A
+// job which calls a reusable workflow runs the steps of the callee, and those are not part of this
+// workflow.
+func runsOwnSteps(w *Workflow) bool {
+	for _, j := range w.Jobs {
+		if j != nil && j.WorkflowCall == nil {
+			return true
+		}
+	}
+	return false
+}
+
+// RuleRequiredActions is a rule to check that a workflow uses the actions which the repository
+// requires. The "required-actions" policy in the configuration file enables it and lists the actions.
+type RuleRequiredActions struct {
+	RuleBase
+	uses    []actionUse
+	unknown bool
+}
+
+// NewRuleRequiredActions creates a new RuleRequiredActions instance.
+func NewRuleRequiredActions() *RuleRequiredActions {
+	return &RuleRequiredActions{
+		RuleBase: RuleBase{
+			name: "required-actions",
+			desc: "Checks that the actions listed in the \"required-actions\" policy in actionlint.yaml are used",
+		},
+	}
+}
+
+// VisitWorkflowPre is callback when visiting Workflow node before visiting its children.
+func (rule *RuleRequiredActions) VisitWorkflowPre(n *Workflow) error {
+	rule.uses = nil
+	rule.unknown = false
+	return nil
+}
+
+// VisitStep is callback when visiting Step node.
+func (rule *RuleRequiredActions) VisitStep(n *Step) error {
+	e, ok := n.Exec.(*ExecAction)
+	if !ok || e.Uses == nil {
+		return nil
+	}
+	if e.Uses.ContainsExpression() {
+		rule.unknown = true
+		return nil
+	}
+	name, ref := splitActionRef(e.Uses.Value)
+	rule.uses = append(rule.uses, actionUse{
+		spec: e.Uses.Value,
+		name: name,
+		ref:  ref,
+		pos:  e.Uses.Pos,
+	})
+	return nil
+}
+
+// VisitWorkflowPost is callback when visiting Workflow node after visiting its children.
+func (rule *RuleRequiredActions) VisitWorkflowPost(n *Workflow) error {
+	if rule.unknown || !runsOwnSteps(n) {
+		return nil
+	}
+	pos := firstJobPos(n)
+	if pos == nil {
+		return nil
+	}
+	for _, a := range rule.config.RequiredActions() {
+		rule.report(a, pos)
+	}
+	return nil
+}
+
+func (rule *RuleRequiredActions) report(required string, pos *Pos) {
+	name, ref := splitActionRef(required)
+	name = strings.ToLower(name)
+
+	var near *actionUse
+	for i, u := range rule.uses {
+		if !matchGlob(name, strings.ToLower(u.name)) {
+			continue
+		}
+		if ref == "" || matchGlob(ref, u.ref) {
+			return
+		}
+		if near == nil || u.pos.IsBefore(near.pos) {
+			near = &rule.uses[i]
+		}
+	}
+
+	if near != nil {
+		rule.Errorf(
+			pos,
+			"no step in this workflow uses action %q which is required by the \"required-actions\" policy in actionlint.yaml. %q at %s matches the action name but not the required ref",
+			required,
+			near.spec,
+			near.pos,
+		)
+		return
+	}
+
+	rule.Errorf(
+		pos,
+		"no step in this workflow uses action %q which is required by the \"required-actions\" policy in actionlint.yaml",
+		required,
+	)
+}

--- a/rule_required_actions_test.go
+++ b/rule_required_actions_test.go
@@ -1,0 +1,272 @@
+package actionlint
+
+import (
+	"strings"
+	"testing"
+)
+
+func runRuleRequiredActions(t *testing.T, src string, required []string) []*Error {
+	t.Helper()
+	w, errs := Parse([]byte(src))
+	if len(errs) > 0 {
+		t.Fatal(errs)
+	}
+	r := NewRuleRequiredActions()
+	r.SetConfig(&Config{Policy: Policy{RequiredActions: required}})
+	v := NewVisitor()
+	v.AddPass(r)
+	if err := v.Visit(w); err != nil {
+		t.Fatal(err)
+	}
+	return r.Errs()
+}
+
+func TestRuleRequiredActionsSplitActionRef(t *testing.T) {
+	tests := []struct {
+		in   string
+		name string
+		ref  string
+	}{
+		{"actions/checkout@v5", "actions/checkout", "v5"},
+		{"actions/checkout", "actions/checkout", ""},
+		{"./.github/actions/scan", "./.github/actions/scan", ""},
+		{"docker://alpine:3", "docker://alpine:3", ""},
+		{"owner/repo/path@abc123", "owner/repo/path", "abc123"},
+		{"a@b@c", "a", "b@c"},
+		{"", "", ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.in, func(t *testing.T) {
+			name, ref := splitActionRef(tc.in)
+			if name != tc.name || ref != tc.ref {
+				t.Fatalf("wanted (%q, %q) but got (%q, %q)", tc.name, tc.ref, name, ref)
+			}
+		})
+	}
+}
+
+func TestRuleRequiredActionsMatchNameCaseInsensitively(t *testing.T) {
+	src := `on: push
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: Actions/Checkout@v5
+`
+
+	tests := []struct {
+		what     string
+		required string
+		want     int
+	}{
+		{"lower case name matches upper case use", "actions/checkout", 0},
+		{"upper case name matches lower case pattern", "ACTIONS/CHECKOUT", 0},
+		{"ref is matched case sensitively", "actions/checkout@V5", 1},
+		{"ref matches with the same case", "actions/checkout@v5", 0},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.what, func(t *testing.T) {
+			errs := runRuleRequiredActions(t, src, []string{tc.required})
+			if len(errs) != tc.want {
+				t.Fatalf("wanted %d errors but got %d: %v", tc.want, len(errs), errs)
+			}
+		})
+	}
+}
+
+func TestRuleRequiredActionsGlobPatterns(t *testing.T) {
+	src := `on: push
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.2.2
+      - uses: github/codeql-action/analyze@v3
+`
+
+	tests := []struct {
+		required string
+		want     int
+	}{
+		{"actions/checkout@v4*", 0},
+		{"actions/checkout@v5*", 1},
+		{"github/codeql-action/*", 0},
+		{"github/codeql-action/*@v3", 0},
+		{"github/*", 1},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.required, func(t *testing.T) {
+			errs := runRuleRequiredActions(t, src, []string{tc.required})
+			if len(errs) != tc.want {
+				t.Fatalf("wanted %d errors but got %d: %v", tc.want, len(errs), errs)
+			}
+		})
+	}
+}
+
+func TestRuleRequiredActionsFirstJobPos(t *testing.T) {
+	w := &Workflow{Jobs: map[string]*Job{}}
+	for i := range 8 {
+		id := string(rune('a' + i))
+		w.Jobs[id] = &Job{
+			ID:  &String{Value: id, Pos: &Pos{Line: 2 + i, Col: 3}},
+			Pos: &Pos{Line: 2 + i, Col: 3},
+		}
+	}
+
+	for range 100 {
+		p := firstJobPos(w)
+		if p == nil {
+			t.Fatal("no position was returned")
+		}
+		if p.String() != "line:2,col:3" {
+			t.Fatalf("wanted line:2,col:3 but got %s", p)
+		}
+	}
+
+	if p := firstJobPos(&Workflow{}); p != nil {
+		t.Fatalf("wanted nil for a workflow without a job but got %s", p)
+	}
+}
+
+func TestRuleRequiredActionsTwoRefsOfSameAction(t *testing.T) {
+	src := `on: push
+
+jobs:
+  a:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+  b:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+`
+
+	for range 100 {
+		if errs := runRuleRequiredActions(t, src, []string{"actions/checkout@v5"}); len(errs) != 0 {
+			t.Fatalf("wanted no error but got %v", errs)
+		}
+	}
+
+	want := `no step in this workflow uses action "actions/checkout@v6" which is required by the "required-actions" policy in actionlint.yaml. "actions/checkout@v4" at line:7,col:15 matches the action name but not the required ref`
+	for range 100 {
+		errs := runRuleRequiredActions(t, src, []string{"actions/checkout@v6"})
+		if len(errs) != 1 {
+			t.Fatalf("wanted exactly one error but got %v", errs)
+		}
+		if errs[0].Message != want {
+			t.Fatalf("wanted message %q but got %q", want, errs[0].Message)
+		}
+		if p := errs[0].Line; p != 4 {
+			t.Fatalf("wanted the error at line 4 but got line %d", p)
+		}
+	}
+}
+
+func TestRuleRequiredActionsWithoutConfig(t *testing.T) {
+	src := `on: push
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo 'hello'
+`
+
+	w, parsed := Parse([]byte(src))
+	if len(parsed) > 0 {
+		t.Fatal(parsed)
+	}
+	r := NewRuleRequiredActions()
+	v := NewVisitor()
+	v.AddPass(r)
+	if err := v.Visit(w); err != nil {
+		t.Fatal(err)
+	}
+	if errs := r.Errs(); len(errs) > 0 {
+		t.Fatalf("wanted no error without a config but got %v", errs)
+	}
+}
+
+func TestRuleRequiredActionsInvalidActionPattern(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+		ok   bool
+	}{
+		{"actions/checkout", "", false},
+		{"actions/checkout@v4*", "", false},
+		{"actions/[checkout", "actions/[checkout", true},
+		{"actions/checkout@[v4", "[v4", true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.in, func(t *testing.T) {
+			p, ok := invalidActionPattern(tc.in)
+			if ok != tc.ok || p != tc.want {
+				t.Fatalf("wanted (%q, %v) but got (%q, %v)", tc.want, tc.ok, p, ok)
+			}
+		})
+	}
+}
+
+func TestRuleRequiredActionsReusableWorkflowCallOnly(t *testing.T) {
+	src := `on: push
+
+jobs:
+  call:
+    uses: ./.github/workflows/reusable.yaml
+`
+
+	errs := runRuleRequiredActions(t, src, []string{"actions/checkout"})
+	if len(errs) > 0 {
+		t.Fatalf("wanted no error for a workflow which runs no step of its own but got %v", errs)
+	}
+}
+
+func TestRuleRequiredActionsExpressionInUses(t *testing.T) {
+	src := `on: push
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ${{ format('{0}/checkout@v5', 'actions') }}
+`
+
+	errs := runRuleRequiredActions(t, src, []string{"my-org/scan@v2"})
+	if len(errs) > 0 {
+		t.Fatalf("wanted no error when a \"uses:\" contains an expression but got %v", errs)
+	}
+}
+
+func TestRuleRequiredActionsNestedInParallelStep(t *testing.T) {
+	src := `on: push
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - parallel:
+          - uses: actions/checkout@v5
+`
+
+	errs := runRuleRequiredActions(t, src, []string{"actions/checkout"})
+	if len(errs) > 0 {
+		t.Fatalf("wanted no error for an action nested in a \"parallel:\" group but got %v", errs)
+	}
+
+	errs = runRuleRequiredActions(t, src, []string{"my-org/scan@v2"})
+	if len(errs) != 1 {
+		t.Fatalf("wanted exactly one error but got %v", errs)
+	}
+	if want := `no step in this workflow uses action "my-org/scan@v2"`; !strings.Contains(errs[0].Message, want) {
+		t.Fatalf("wanted message %q to contain %q", errs[0].Message, want)
+	}
+}

--- a/testdata/projects/required_actions.out
+++ b/testdata/projects/required_actions.out
@@ -1,0 +1,2 @@
+workflows/missing.yaml:4:3: no step in this workflow uses action "my-org/scan@v2" which is required by the "required-actions" policy in actionlint.yaml [required-actions]
+workflows/ref_mismatch.yaml:4:3: no step in this workflow uses action "my-org/scan@v2" which is required by the "required-actions" policy in actionlint.yaml. "my-org/scan@v1" at line:8,col:15 matches the action name but not the required ref [required-actions]

--- a/testdata/projects/required_actions/actionlint.yaml
+++ b/testdata/projects/required_actions/actionlint.yaml
@@ -1,0 +1,4 @@
+policy:
+  required-actions:
+    - actions/checkout
+    - my-org/scan@v2

--- a/testdata/projects/required_actions/reusable/noop.yaml
+++ b/testdata/projects/required_actions/reusable/noop.yaml
@@ -1,0 +1,8 @@
+on:
+  workflow_call:
+
+jobs:
+  noop:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo 'noop'

--- a/testdata/projects/required_actions/workflows/call.yaml
+++ b/testdata/projects/required_actions/workflows/call.yaml
@@ -1,0 +1,5 @@
+on: push
+
+jobs:
+  call:
+    uses: ./reusable/noop.yaml

--- a/testdata/projects/required_actions/workflows/expression.yaml
+++ b/testdata/projects/required_actions/workflows/expression.yaml
@@ -1,0 +1,7 @@
+on: push
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ${{ format('{0}/checkout@v5', 'actions') }}

--- a/testdata/projects/required_actions/workflows/missing.yaml
+++ b/testdata/projects/required_actions/workflows/missing.yaml
@@ -1,0 +1,11 @@
+on: push
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo 'lint'

--- a/testdata/projects/required_actions/workflows/nested.yaml
+++ b/testdata/projects/required_actions/workflows/nested.yaml
@@ -1,0 +1,9 @@
+on: push
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - parallel:
+          - uses: actions/checkout@v5
+          - uses: my-org/scan@v2

--- a/testdata/projects/required_actions/workflows/ref_mismatch.yaml
+++ b/testdata/projects/required_actions/workflows/ref_mismatch.yaml
@@ -1,0 +1,8 @@
+on: push
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: my-org/scan@v1


### PR DESCRIPTION
`policy.required-actions` reports a workflow that does not use an action the repository requires. A security scanner, a licence check, a step that has to run everywhere: a repository can name it and get told when a workflow forgets it. It reports nothing unless the key is set.

Requires #40, which lands the `policy` mapping's scaffolding, and #39 under that.

The fixture project produces these two errors.

```
workflows/missing.yaml:4:3: no step in this workflow uses action "my-org/scan@v2" which is required by the "required-actions" policy in actionlint.yaml
workflows/ref_mismatch.yaml:4:3: no step in this workflow uses action "my-org/scan@v2" which is required by the "required-actions" policy in actionlint.yaml. "my-org/scan@v1" at line:8,col:15 matches the action name but not the required ref
```

<details><summary>Measured</summary>

```console
$ go test -v -count=1 -run 'TestLinterLintProject/project/required_actions' .
=== RUN   TestLinterLintProject
=== RUN   TestLinterLintProject/project/required_actions
    linter_test.go:326: Linting project at testdata/projects/required_actions
    linter_test.go:346: Checking 2 errors with "testdata/projects/required_actions.out"
    linter_test.go:346:   Error[0]: workflows/missing.yaml:4:3: no step in this workflow uses action "my-org/scan@v2" which is required by the "required-actions" policy in actionlint.yaml [required-actions]
    linter_test.go:346:   Error[1]: workflows/ref_mismatch.yaml:4:3: no step in this workflow uses action "my-org/scan@v2" which is required by the "required-actions" policy in actionlint.yaml. "my-org/scan@v1" at line:8,col:15 matches the action name but not the required ref [required-actions]
--- PASS: TestLinterLintProject (0.00s)
    --- PASS: TestLinterLintProject/project/required_actions (0.00s)
PASS
ok  	actionlint.kjanat.dev	0.008s
```

</details>

The second message is the one worth having. Being told an action is missing when the workflow visibly uses it, on the wrong version, is a worse experience than not being told at all.

## Scope: per workflow, and what that leaves out

The requirement is per workflow, not per job, and one missing action produces one error at the first job in source order. That follows from the key being a list of strings: there is nowhere to write a per-entry scope.

Two exclusions, both from the same cause. The steps of a composite action and the steps of a called reusable workflow are not searched, because neither is reachable. `action_metadata.go:134` keeps `runs.steps` as `[]any` with no `uses` field, and `ReusableWorkflowMetadata` at `reusable_workflow.go:160` holds no steps at all. So a required action satisfied inside a composite action is reported as missing.

<details><summary>Measured</summary>

```console
$ sed -n '133,134p' action_metadata.go
	// Steps is `steps` configuration of action.yaml for Composite action.
	Steps []any `yaml:"steps" json:"steps"`

$ sed -n '157,164p' reusable_workflow.go
// ReusableWorkflowMetadata is metadata to validate local reusable workflows. This struct does not
// contain all metadata from YAML file. It only contains metadata which is necessary to validate
// reusable workflow files by actionlint.
type ReusableWorkflowMetadata struct {
	Inputs  ReusableWorkflowMetadataInputs  `yaml:"inputs"`
	Outputs ReusableWorkflowMetadataOutputs `yaml:"outputs"`
	Secrets ReusableWorkflowMetadataSecrets `yaml:"secrets"`
}

$ grep -n 'func (v \*Visitor) visitStep' pass.go
132:func (v *Visitor) visitStep(n *Step) error {

$ sed -n '144,159p' pass.go
	// Steps grouped in a 'parallel' step are visited as well so that rules are applied to them.
	// https://github.blog/changelog/2026-06-25-actions-steps-can-now-be-run-in-parallel/
	if e, ok := n.Exec.(*ExecParallel); ok {
		for _, s := range e.Steps {
			if err := v.visitStep(s); err != nil {
				return err
			}
		}
	}

	if v.dbg != nil {
		v.reportElapsedTime(fmt.Sprintf("VisitStep at %s", n.Pos), t)
	}

	return nil
}

$ sed -n '1259,1260p' parse.go
		case "uses":
			ret.Uses = p.parseString(e.val, false)
```

</details>

A workflow whose only step calls a local composite action which itself uses the required action is reported as missing.

<details><summary>Measured</summary>

```console
$ cat .github/actions/scan/action.yml
name: scan
description: scan
runs:
  using: composite
  steps:
    - uses: my-org/scan@v2

$ cat workflows/composite.yaml
on: push

jobs:
  build:
    runs-on: ubuntu-latest
    steps:
      - uses: ./.github/actions/scan

$ /tmp/actionlint-ra -config-file actionlint.yaml -no-color workflows/composite.yaml
workflows/composite.yaml:4:3: no step in this workflow uses action "my-org/scan@v2" which is required by the "required-actions" policy in actionlint.yaml [required-actions]
  |
4 |   build:
  |   ^~~~~~
```

</details>

That produces one case the check has to pass over: a workflow whose every job calls a reusable workflow runs no step of its own and could never satisfy the requirement. It is skipped. A workflow with one call job and one ordinary job is still checked, with the requirement measured against the ordinary job's steps. That is a consequence of the guard being "any job runs steps", not a special case, and it is the behaviour you want.

A `uses:` built with `${{ }}` is passed over too, since the action it names is not known until the workflow runs.

One wart worth stating rather than discovering. The error is anchored at the first job in source order, and that job may itself be a reusable-workflow call, which by definition cannot satisfy the requirement. The near-miss half of the message still points at the real step. Anchoring on the first job that runs its own steps would read better and is one line, but it makes the anchor depend on the kind of job rather than on file order, and file order is the only anchor that cannot drift with map iteration, which is the upstream defect this branch is avoiding in the first place.

The fixture below has a reusable-workflow call as its first job and an ordinary job second. The error lands on the call job at line 4, and the near-miss half points at the real step at line 9.

<details><summary>Measured</summary>

```console
$ cat workflows/call_first.yaml
on: push

jobs:
  call:
    uses: ./reusable/noop.yaml
  build:
    runs-on: ubuntu-latest
    steps:
      - uses: my-org/scan@v1

$ /tmp/actionlint-ra -config-file actionlint.yaml -no-color workflows/call_first.yaml
workflows/call_first.yaml:4:3: no step in this workflow uses action "my-org/scan@v2" which is required by the "required-actions" policy in actionlint.yaml. "my-org/scan@v1" at line:9,col:15 matches the action name but not the required ref [required-actions]
  |
4 |   call:
  |   ^~~~~
```

</details>

Nested steps are searched, and this branch adds no traversal to do it. `pass.go:146-152`, inside `visitStep` at `pass.go:132`, already recurses into `ExecParallel.Steps`. That the check relies on it rather than duplicating it is measured: removing the recursion in `pass.go` makes both the unit test and the fixture fail, and `git diff --exit-code pass.go` is clean afterwards.

## Matching

An entry is written like a `uses:` value and both halves are globs. `actions/checkout` accepts any ref, `actions/checkout@v5` only that one, `actions/checkout@v4*` accepts `v4` and `v4.2.2`, and `*` does not match `/`, so `github/codeql-action/*` covers every action in that repository while `github/*` does not.

The name is matched case insensitively and the ref case sensitively. That asymmetry is not decoration. `parse.go:1260` parses a `uses:` value with `p.parseString(e.val, false)`, so only mapping keys are lower-cased and `uses: Actions/Checkout@v5` keeps its capitals. A tag, by contrast, is case sensitive on GitHub.

`splitActionRef` keeps `./.github/actions/scan` and `docker://alpine:3` intact through the split.

<details><summary>Measured</summary>

```console
$ go test -v -count=1 -run 'TestRuleRequiredActionsSplitActionRef|TestRuleRequiredActionsMatchNameCaseInsensitively|TestRuleRequiredActionsGlobPatterns' .
=== RUN   TestRuleRequiredActionsSplitActionRef
=== RUN   TestRuleRequiredActionsSplitActionRef/actions/checkout@v5
=== RUN   TestRuleRequiredActionsSplitActionRef/actions/checkout
=== RUN   TestRuleRequiredActionsSplitActionRef/./.github/actions/scan
=== RUN   TestRuleRequiredActionsSplitActionRef/docker://alpine:3
=== RUN   TestRuleRequiredActionsSplitActionRef/owner/repo/path@abc123
=== RUN   TestRuleRequiredActionsSplitActionRef/a@b@c
=== RUN   TestRuleRequiredActionsSplitActionRef/#00
--- PASS: TestRuleRequiredActionsSplitActionRef (0.00s)
    --- PASS: TestRuleRequiredActionsSplitActionRef/actions/checkout@v5 (0.00s)
    --- PASS: TestRuleRequiredActionsSplitActionRef/actions/checkout (0.00s)
    --- PASS: TestRuleRequiredActionsSplitActionRef/./.github/actions/scan (0.00s)
    --- PASS: TestRuleRequiredActionsSplitActionRef/docker://alpine:3 (0.00s)
    --- PASS: TestRuleRequiredActionsSplitActionRef/owner/repo/path@abc123 (0.00s)
    --- PASS: TestRuleRequiredActionsSplitActionRef/a@b@c (0.00s)
    --- PASS: TestRuleRequiredActionsSplitActionRef/#00 (0.00s)
=== RUN   TestRuleRequiredActionsMatchNameCaseInsensitively
=== RUN   TestRuleRequiredActionsMatchNameCaseInsensitively/lower_case_name_matches_upper_case_use
=== RUN   TestRuleRequiredActionsMatchNameCaseInsensitively/upper_case_name_matches_lower_case_pattern
=== RUN   TestRuleRequiredActionsMatchNameCaseInsensitively/ref_is_matched_case_sensitively
=== RUN   TestRuleRequiredActionsMatchNameCaseInsensitively/ref_matches_with_the_same_case
--- PASS: TestRuleRequiredActionsMatchNameCaseInsensitively (0.00s)
    --- PASS: TestRuleRequiredActionsMatchNameCaseInsensitively/lower_case_name_matches_upper_case_use (0.00s)
    --- PASS: TestRuleRequiredActionsMatchNameCaseInsensitively/upper_case_name_matches_lower_case_pattern (0.00s)
    --- PASS: TestRuleRequiredActionsMatchNameCaseInsensitively/ref_is_matched_case_sensitively (0.00s)
    --- PASS: TestRuleRequiredActionsMatchNameCaseInsensitively/ref_matches_with_the_same_case (0.00s)
=== RUN   TestRuleRequiredActionsGlobPatterns
=== RUN   TestRuleRequiredActionsGlobPatterns/actions/checkout@v4*
=== RUN   TestRuleRequiredActionsGlobPatterns/actions/checkout@v5*
=== RUN   TestRuleRequiredActionsGlobPatterns/github/codeql-action/*
=== RUN   TestRuleRequiredActionsGlobPatterns/github/codeql-action/*@v3
=== RUN   TestRuleRequiredActionsGlobPatterns/github/*
--- PASS: TestRuleRequiredActionsGlobPatterns (0.00s)
    --- PASS: TestRuleRequiredActionsGlobPatterns/actions/checkout@v4* (0.00s)
    --- PASS: TestRuleRequiredActionsGlobPatterns/actions/checkout@v5* (0.00s)
    --- PASS: TestRuleRequiredActionsGlobPatterns/github/codeql-action/* (0.00s)
    --- PASS: TestRuleRequiredActionsGlobPatterns/github/codeql-action/*@v3 (0.00s)
    --- PASS: TestRuleRequiredActionsGlobPatterns/github/* (0.00s)
PASS
ok  	actionlint.kjanat.dev	0.018s
```

</details>

## Fifteen controls, none of them free

Every control was switched off in turn, the target test run, and the control restored. Fifteen out of fifteen produced a failure. Nothing was uncovered.

| switched off | fails |
| --- | --- |
| the "runs its own steps" guard | the reusable-workflow-only test and the fixture, 4 errors instead of 2 |
| the `ContainsExpression` branch | the expression test and the fixture, 4 errors instead of 2 |
| the `ExecParallel` recursion in `pass.go` | the nested-step test and the fixture, 4 errors instead of 2 |
| `IsBefore` when picking the first job | two tests, both on the reported line number |
| lower-casing the name | the case-insensitivity test |
| the empty-ref shortcut | the fixture at 5 errors instead of 2, plus four subtests across three tests |
| the near-miss branch | the fixture's `ref_mismatch` error and the two-refs test, both on the exact message |
| the nil guard on the config accessor | `TestConfigPolicyNilConfig` panics with SIGSEGV |
| the config gate in `linter.go` | `TestLinterFormatErrorMessageInSARIF` |
| the `!!null` branch when decoding the key | the null-key parse test |
| the template lines | `TestConfigGenerateDefaultConfigFileOK` |
| the sequence-node check | the corresponding parse-error test |
| the string-entry check | the corresponding parse-error test |
| the empty-entry check | the corresponding parse-error test |
| glob validation | two parse-error tests |

<details><summary>Mutation: the guard, the expression branch, the recursion</summary>

```console
$ git diff -- rule_required_actions.go
diff --git a/rule_required_actions.go b/rule_required_actions.go
index 9d409cd..efe47ee 100644
--- a/rule_required_actions.go
+++ b/rule_required_actions.go
@@ -115,7 +115,7 @@ func (rule *RuleRequiredActions) VisitStep(n *Step) error {
 
 // VisitWorkflowPost is callback when visiting Workflow node after visiting its children.
 func (rule *RuleRequiredActions) VisitWorkflowPost(n *Workflow) error {
-	if rule.unknown || !runsOwnSteps(n) {
+	if rule.unknown {
 		return nil
 	}
 	pos := firstJobPos(n)

$ go test -count=1 -run 'TestRuleRequiredActionsReusableWorkflowCallOnly|TestLinterLintProject/project/required_actions' .
--- FAIL: TestLinterLintProject (0.00s)
    --- FAIL: TestLinterLintProject/project/required_actions (0.00s)
        linter_test.go:326: Linting project at testdata/projects/required_actions
        linter_test.go:346: Checking 4 errors with "testdata/projects/required_actions.out"
        linter_test.go:346:   Error[0]: workflows/call.yaml:4:3: no step in this workflow uses action "actions/checkout" which is required by the "required-actions" policy in actionlint.yaml [required-actions]
        linter_test.go:346:   Error[1]: workflows/call.yaml:4:3: no step in this workflow uses action "my-org/scan@v2" which is required by the "required-actions" policy in actionlint.yaml [required-actions]
        linter_test.go:346:   Error[2]: workflows/missing.yaml:4:3: no step in this workflow uses action "my-org/scan@v2" which is required by the "required-actions" policy in actionlint.yaml [required-actions]
        linter_test.go:346:   Error[3]: workflows/ref_mismatch.yaml:4:3: no step in this workflow uses action "my-org/scan@v2" which is required by the "required-actions" policy in actionlint.yaml. "my-org/scan@v1" at line:8,col:15 matches the action name but not the required ref [required-actions]
        linter_test.go:346: 2 errors are expected but actually got 4 errors:
            workflows/call.yaml:4:3: no step in this workflow uses action "actions/checkout" which is required by the "required-actions" policy in actionlint.yaml [required-actions]
            workflows/call.yaml:4:3: no step in this workflow uses action "my-org/scan@v2" which is required by the "required-actions" policy in actionlint.yaml [required-actions]
            workflows/missing.yaml:4:3: no step in this workflow uses action "my-org/scan@v2" which is required by the "required-actions" policy in actionlint.yaml [required-actions]
            workflows/ref_mismatch.yaml:4:3: no step in this workflow uses action "my-org/scan@v2" which is required by the "required-actions" policy in actionlint.yaml. "my-org/scan@v1" at line:8,col:15 matches the action name but not the required ref [required-actions]
--- FAIL: TestRuleRequiredActionsReusableWorkflowCallOnly (0.00s)
    rule_required_actions_test.go:229: wanted no error for a workflow which runs no step of its own but got [:4:3: no step in this workflow uses action "actions/checkout" which is required by the "required-actions" policy in actionlint.yaml [required-actions]]
FAIL
FAIL	actionlint.kjanat.dev	0.014s
FAIL

$ git diff -- rule_required_actions.go
diff --git a/rule_required_actions.go b/rule_required_actions.go
index 9d409cd..934142d 100644
--- a/rule_required_actions.go
+++ b/rule_required_actions.go
@@ -99,10 +99,6 @@ func (rule *RuleRequiredActions) VisitStep(n *Step) error {
 	if !ok || e.Uses == nil {
 		return nil
 	}
-	if e.Uses.ContainsExpression() {
-		rule.unknown = true
-		return nil
-	}
 	name, ref := splitActionRef(e.Uses.Value)
 	rule.uses = append(rule.uses, actionUse{
 		spec: e.Uses.Value,

$ go test -count=1 -run 'TestRuleRequiredActionsExpressionInUses|TestLinterLintProject/project/required_actions' .
--- FAIL: TestLinterLintProject (0.01s)
    --- FAIL: TestLinterLintProject/project/required_actions (0.00s)
        linter_test.go:326: Linting project at testdata/projects/required_actions
        linter_test.go:346: Checking 4 errors with "testdata/projects/required_actions.out"
        linter_test.go:346:   Error[0]: workflows/expression.yaml:4:3: no step in this workflow uses action "actions/checkout" which is required by the "required-actions" policy in actionlint.yaml [required-actions]
        linter_test.go:346:   Error[1]: workflows/expression.yaml:4:3: no step in this workflow uses action "my-org/scan@v2" which is required by the "required-actions" policy in actionlint.yaml [required-actions]
        linter_test.go:346:   Error[2]: workflows/missing.yaml:4:3: no step in this workflow uses action "my-org/scan@v2" which is required by the "required-actions" policy in actionlint.yaml [required-actions]
        linter_test.go:346:   Error[3]: workflows/ref_mismatch.yaml:4:3: no step in this workflow uses action "my-org/scan@v2" which is required by the "required-actions" policy in actionlint.yaml. "my-org/scan@v1" at line:8,col:15 matches the action name but not the required ref [required-actions]
        linter_test.go:346: 2 errors are expected but actually got 4 errors:
            workflows/expression.yaml:4:3: no step in this workflow uses action "actions/checkout" which is required by the "required-actions" policy in actionlint.yaml [required-actions]
            workflows/expression.yaml:4:3: no step in this workflow uses action "my-org/scan@v2" which is required by the "required-actions" policy in actionlint.yaml [required-actions]
            workflows/missing.yaml:4:3: no step in this workflow uses action "my-org/scan@v2" which is required by the "required-actions" policy in actionlint.yaml [required-actions]
            workflows/ref_mismatch.yaml:4:3: no step in this workflow uses action "my-org/scan@v2" which is required by the "required-actions" policy in actionlint.yaml. "my-org/scan@v1" at line:8,col:15 matches the action name but not the required ref [required-actions]
--- FAIL: TestRuleRequiredActionsExpressionInUses (0.00s)
    rule_required_actions_test.go:245: wanted no error when a "uses:" contains an expression but got [:4:3: no step in this workflow uses action "my-org/scan@v2" which is required by the "required-actions" policy in actionlint.yaml [required-actions]]
FAIL
FAIL	actionlint.kjanat.dev	0.018s
FAIL

$ git diff -- pass.go
diff --git a/pass.go b/pass.go
index addbbb7..698e97b 100644
--- a/pass.go
+++ b/pass.go
@@ -143,13 +143,6 @@ func (v *Visitor) visitStep(n *Step) error {
 
 	// Steps grouped in a 'parallel' step are visited as well so that rules are applied to them.
 	// https://github.blog/changelog/2026-06-25-actions-steps-can-now-be-run-in-parallel/
-	if e, ok := n.Exec.(*ExecParallel); ok {
-		for _, s := range e.Steps {
-			if err := v.visitStep(s); err != nil {
-				return err
-			}
-		}
-	}
 
 	if v.dbg != nil {
 		v.reportElapsedTime(fmt.Sprintf("VisitStep at %s", n.Pos), t)

$ go test -count=1 -run 'TestRuleRequiredActionsNestedInParallelStep|TestLinterLintProject/project/required_actions' .
--- FAIL: TestLinterLintProject (0.01s)
    --- FAIL: TestLinterLintProject/project/required_actions (0.01s)
        linter_test.go:326: Linting project at testdata/projects/required_actions
        linter_test.go:346: Checking 4 errors with "testdata/projects/required_actions.out"
        linter_test.go:346:   Error[0]: workflows/missing.yaml:4:3: no step in this workflow uses action "my-org/scan@v2" which is required by the "required-actions" policy in actionlint.yaml [required-actions]
        linter_test.go:346:   Error[1]: workflows/nested.yaml:4:3: no step in this workflow uses action "actions/checkout" which is required by the "required-actions" policy in actionlint.yaml [required-actions]
        linter_test.go:346:   Error[2]: workflows/nested.yaml:4:3: no step in this workflow uses action "my-org/scan@v2" which is required by the "required-actions" policy in actionlint.yaml [required-actions]
        linter_test.go:346:   Error[3]: workflows/ref_mismatch.yaml:4:3: no step in this workflow uses action "my-org/scan@v2" which is required by the "required-actions" policy in actionlint.yaml. "my-org/scan@v1" at line:8,col:15 matches the action name but not the required ref [required-actions]
        linter_test.go:346: 2 errors are expected but actually got 4 errors:
            workflows/missing.yaml:4:3: no step in this workflow uses action "my-org/scan@v2" which is required by the "required-actions" policy in actionlint.yaml [required-actions]
            workflows/nested.yaml:4:3: no step in this workflow uses action "actions/checkout" which is required by the "required-actions" policy in actionlint.yaml [required-actions]
            workflows/nested.yaml:4:3: no step in this workflow uses action "my-org/scan@v2" which is required by the "required-actions" policy in actionlint.yaml [required-actions]
            workflows/ref_mismatch.yaml:4:3: no step in this workflow uses action "my-org/scan@v2" which is required by the "required-actions" policy in actionlint.yaml. "my-org/scan@v1" at line:8,col:15 matches the action name but not the required ref [required-actions]
--- FAIL: TestRuleRequiredActionsNestedInParallelStep (0.00s)
    rule_required_actions_test.go:262: wanted no error for an action nested in a "parallel:" group but got [:4:3: no step in this workflow uses action "actions/checkout" which is required by the "required-actions" policy in actionlint.yaml [required-actions]]
FAIL
FAIL	actionlint.kjanat.dev	0.025s
FAIL
```

</details>

<details><summary>Mutation: IsBefore, lower-casing, the empty-ref shortcut, the near-miss branch</summary>

```console
$ git diff -- rule_required_actions.go
diff --git a/rule_required_actions.go b/rule_required_actions.go
index 9d409cd..ba18864 100644
--- a/rule_required_actions.go
+++ b/rule_required_actions.go
@@ -49,7 +49,7 @@ func firstJobPos(w *Workflow) *Pos {
 		if j == nil || j.Pos == nil {
 			continue
 		}
-		if ret == nil || j.Pos.IsBefore(ret) {
+		if ret == nil {
 			ret = j.Pos
 		}
 	}

$ go test -count=1 -run 'TestRuleRequiredActions|TestLinterLintProject/project/required_actions' .
--- FAIL: TestRuleRequiredActionsFirstJobPos (0.00s)
    rule_required_actions_test.go:128: wanted line:2,col:3 but got line:5,col:3
--- FAIL: TestRuleRequiredActionsTwoRefsOfSameAction (0.00s)
    rule_required_actions_test.go:167: wanted the error at line 4 but got line 8
FAIL
FAIL	actionlint.kjanat.dev	0.020s
FAIL

$ git diff -- rule_required_actions.go
diff --git a/rule_required_actions.go b/rule_required_actions.go
index 9d409cd..af8df22 100644
--- a/rule_required_actions.go
+++ b/rule_required_actions.go
@@ -130,7 +130,6 @@ func (rule *RuleRequiredActions) VisitWorkflowPost(n *Workflow) error {
 
 func (rule *RuleRequiredActions) report(required string, pos *Pos) {
 	name, ref := splitActionRef(required)
-	name = strings.ToLower(name)
 
 	var near *actionUse
 	for i, u := range rule.uses {

$ go test -count=1 -run 'TestRuleRequiredActions|TestLinterLintProject/project/required_actions' .
--- FAIL: TestRuleRequiredActionsMatchNameCaseInsensitively (0.00s)
    --- FAIL: TestRuleRequiredActionsMatchNameCaseInsensitively/upper_case_name_matches_lower_case_pattern (0.00s)
        rule_required_actions_test.go:74: wanted 0 errors but got 1: [:4:3: no step in this workflow uses action "ACTIONS/CHECKOUT" which is required by the "required-actions" policy in actionlint.yaml [required-actions]]
FAIL
FAIL	actionlint.kjanat.dev	0.029s
FAIL

$ git diff -- rule_required_actions.go
diff --git a/rule_required_actions.go b/rule_required_actions.go
index 9d409cd..8e7d14f 100644
--- a/rule_required_actions.go
+++ b/rule_required_actions.go
@@ -137,7 +137,7 @@ func (rule *RuleRequiredActions) report(required string, pos *Pos) {
 		if !matchGlob(name, strings.ToLower(u.name)) {
 			continue
 		}
-		if ref == "" || matchGlob(ref, u.ref) {
+		if matchGlob(ref, u.ref) {
 			return
 		}
 		if near == nil || u.pos.IsBefore(near.pos) {

$ go test -count=1 -run 'TestRuleRequiredActions|TestLinterLintProject/project/required_actions' .
--- FAIL: TestLinterLintProject (0.01s)
    --- FAIL: TestLinterLintProject/project/required_actions (0.00s)
        linter_test.go:326: Linting project at testdata/projects/required_actions
        linter_test.go:346: Checking 5 errors with "testdata/projects/required_actions.out"
        linter_test.go:346:   Error[0]: workflows/missing.yaml:4:3: no step in this workflow uses action "actions/checkout" which is required by the "required-actions" policy in actionlint.yaml. "actions/checkout@v5" at line:7,col:15 matches the action name but not the required ref [required-actions]
        linter_test.go:346:   Error[1]: workflows/missing.yaml:4:3: no step in this workflow uses action "my-org/scan@v2" which is required by the "required-actions" policy in actionlint.yaml [required-actions]
        linter_test.go:346:   Error[2]: workflows/nested.yaml:4:3: no step in this workflow uses action "actions/checkout" which is required by the "required-actions" policy in actionlint.yaml. "actions/checkout@v5" at line:8,col:19 matches the action name but not the required ref [required-actions]
        linter_test.go:346:   Error[3]: workflows/ref_mismatch.yaml:4:3: no step in this workflow uses action "actions/checkout" which is required by the "required-actions" policy in actionlint.yaml. "actions/checkout@v5" at line:7,col:15 matches the action name but not the required ref [required-actions]
        linter_test.go:346:   Error[4]: workflows/ref_mismatch.yaml:4:3: no step in this workflow uses action "my-org/scan@v2" which is required by the "required-actions" policy in actionlint.yaml. "my-org/scan@v1" at line:8,col:15 matches the action name but not the required ref [required-actions]
        linter_test.go:346: 2 errors are expected but actually got 5 errors:
            workflows/missing.yaml:4:3: no step in this workflow uses action "actions/checkout" which is required by the "required-actions" policy in actionlint.yaml. "actions/checkout@v5" at line:7,col:15 matches the action name but not the required ref [required-actions]
            workflows/missing.yaml:4:3: no step in this workflow uses action "my-org/scan@v2" which is required by the "required-actions" policy in actionlint.yaml [required-actions]
            workflows/nested.yaml:4:3: no step in this workflow uses action "actions/checkout" which is required by the "required-actions" policy in actionlint.yaml. "actions/checkout@v5" at line:8,col:19 matches the action name but not the required ref [required-actions]
            workflows/ref_mismatch.yaml:4:3: no step in this workflow uses action "actions/checkout" which is required by the "required-actions" policy in actionlint.yaml. "actions/checkout@v5" at line:7,col:15 matches the action name but not the required ref [required-actions]
            workflows/ref_mismatch.yaml:4:3: no step in this workflow uses action "my-org/scan@v2" which is required by the "required-actions" policy in actionlint.yaml. "my-org/scan@v1" at line:8,col:15 matches the action name but not the required ref [required-actions]
--- FAIL: TestRuleRequiredActionsMatchNameCaseInsensitively (0.00s)
    --- FAIL: TestRuleRequiredActionsMatchNameCaseInsensitively/lower_case_name_matches_upper_case_use (0.00s)
        rule_required_actions_test.go:74: wanted 0 errors but got 1: [:4:3: no step in this workflow uses action "actions/checkout" which is required by the "required-actions" policy in actionlint.yaml. "Actions/Checkout@v5" at line:7,col:15 matches the action name but not the required ref [required-actions]]
    --- FAIL: TestRuleRequiredActionsMatchNameCaseInsensitively/upper_case_name_matches_lower_case_pattern (0.00s)
        rule_required_actions_test.go:74: wanted 0 errors but got 1: [:4:3: no step in this workflow uses action "ACTIONS/CHECKOUT" which is required by the "required-actions" policy in actionlint.yaml. "Actions/Checkout@v5" at line:7,col:15 matches the action name but not the required ref [required-actions]]
--- FAIL: TestRuleRequiredActionsGlobPatterns (0.00s)
    --- FAIL: TestRuleRequiredActionsGlobPatterns/github/codeql-action/* (0.00s)
        rule_required_actions_test.go:106: wanted 0 errors but got 1: [:4:3: no step in this workflow uses action "github/codeql-action/*" which is required by the "required-actions" policy in actionlint.yaml. "github/codeql-action/analyze@v3" at line:8,col:15 matches the action name but not the required ref [required-actions]]
--- FAIL: TestRuleRequiredActionsNestedInParallelStep (0.00s)
    rule_required_actions_test.go:262: wanted no error for an action nested in a "parallel:" group but got [:4:3: no step in this workflow uses action "actions/checkout" which is required by the "required-actions" policy in actionlint.yaml. "actions/checkout@v5" at line:8,col:19 matches the action name but not the required ref [required-actions]]
FAIL
FAIL	actionlint.kjanat.dev	0.044s
FAIL

$ git diff -- rule_required_actions.go
diff --git a/rule_required_actions.go b/rule_required_actions.go
index 9d409cd..aed64c8 100644
--- a/rule_required_actions.go
+++ b/rule_required_actions.go
@@ -145,16 +145,6 @@ func (rule *RuleRequiredActions) report(required string, pos *Pos) {
 		}
 	}
 
-	if near != nil {
-		rule.Errorf(
-			pos,
-			"no step in this workflow uses action %q which is required by the \"required-actions\" policy in actionlint.yaml. %q at %s matches the action name but not the required ref",
-			required,
-			near.spec,
-			near.pos,
-		)
-		return
-	}
 
 	rule.Errorf(
 		pos,

$ go test -count=1 -run 'TestRuleRequiredActions|TestLinterLintProject/project/required_actions' .
--- FAIL: TestLinterLintProject (0.00s)
    --- FAIL: TestLinterLintProject/project/required_actions (0.00s)
        linter_test.go:326: Linting project at testdata/projects/required_actions
        linter_test.go:346: Checking 2 errors with "testdata/projects/required_actions.out"
        linter_test.go:346:   Error[0]: workflows/missing.yaml:4:3: no step in this workflow uses action "my-org/scan@v2" which is required by the "required-actions" policy in actionlint.yaml [required-actions]
        linter_test.go:346:   Error[1]: workflows/ref_mismatch.yaml:4:3: no step in this workflow uses action "my-org/scan@v2" which is required by the "required-actions" policy in actionlint.yaml [required-actions]
        linter_test.go:346: error message mismatch at 2th error does not match exactly
              want: "workflows/ref_mismatch.yaml:4:3: no step in this workflow uses action \"my-org/scan@v2\" which is required by the \"required-actions\" policy in actionlint.yaml. \"my-org/scan@v1\" at line:8,col:15 matches the action name but not the required ref [required-actions]"
              have: "workflows/ref_mismatch.yaml:4:3: no step in this workflow uses action \"my-org/scan@v2\" which is required by the \"required-actions\" policy in actionlint.yaml [required-actions]"
--- FAIL: TestRuleRequiredActionsTwoRefsOfSameAction (0.00s)
    rule_required_actions_test.go:164: wanted message "no step in this workflow uses action \"actions/checkout@v6\" which is required by the \"required-actions\" policy in actionlint.yaml. \"actions/checkout@v4\" at line:7,col:15 matches the action name but not the required ref" but got "no step in this workflow uses action \"actions/checkout@v6\" which is required by the \"required-actions\" policy in actionlint.yaml"
FAIL
FAIL	actionlint.kjanat.dev	0.022s
FAIL
```

</details>

<details><summary>Mutation: the nil guard</summary>

```console
$ git diff -- config.go
diff --git a/config.go b/config.go
index bf3ba71..7bb612f 100644
--- a/config.go
+++ b/config.go
@@ -161,9 +161,6 @@ func (cfg *Config) RequiresCommitHash() bool {
 // RequiredActions returns the actions which every workflow must use following the "required-actions"
 // policy. It returns nil when the receiver is nil or when the key is not set.
 func (cfg *Config) RequiredActions() []string {
-	if cfg == nil {
-		return nil
-	}
 	return cfg.Policy.RequiredActions
 }
 

$ go test -count=1 -run 'TestConfigPolicyNilConfig' .
--- FAIL: TestConfigPolicyNilConfig (0.00s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered, repanicked]
[signal SIGSEGV: segmentation violation code=0x1 addr=0x40 pc=0x784630]

goroutine 8 [running]:
testing.tRunner.func1.2({0x83af60, 0xbf9570})
	/usr/lib/go/src/testing/testing.go:1974 +0x232
testing.tRunner.func1()
	/usr/lib/go/src/testing/testing.go:1977 +0x349
panic({0x83af60?, 0xbf9570?})
	/usr/lib/go/src/runtime/panic.go:860 +0x13a
actionlint%2ekjanat%2edev.(*Config).RequiredActions(...)
	/home/kjanat/projects/actionlint/.worktrees/required-actions/config.go:164
actionlint%2ekjanat%2edev.TestConfigPolicyNilConfig(0x4833ba8b208?)
	/home/kjanat/projects/actionlint/.worktrees/required-actions/config_test.go:449 +0x10
testing.tRunner(0x4833ba8b208, 0x8de818)
	/usr/lib/go/src/testing/testing.go:2036 +0xea
created by testing.(*T).Run in goroutine 1
	/usr/lib/go/src/testing/testing.go:2101 +0x4c5
FAIL	actionlint.kjanat.dev	0.008s
FAIL
```

</details>

<details><summary>Mutation: the config gate in linter.go</summary>

```console
$ git diff -- linter.go
diff --git a/linter.go b/linter.go
index eb7c410..a4eb30a 100644
--- a/linter.go
+++ b/linter.go
@@ -590,7 +590,7 @@ func (l *Linter) check(
 		if cfg.RequiresCommitHash() {
 			rules = append(rules, NewRuleRequireCommitHash())
 		}
-		if len(cfg.RequiredActions()) > 0 {
+		if true {
 			rules = append(rules, NewRuleRequiredActions())
 		}
 		if l.shellcheck != "" {

$ go test -count=1 -run 'TestLinterFormatErrorMessage' .
--- FAIL: TestLinterFormatErrorMessageInSARIF (0.01s)
    linter_test.go:465: have: map[$schema:https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json runs:[map[results:[map[locations:[map[physicalLocation:map[artifactLocation:map[uri:testdata/format/test.yaml uriBaseId:%SRCROOT%] region:map[endColumn:%!s(float64=11) snippet:map[text:    branch: main
            ^~~~~~~] startColumn:%!s(float64=5) startLine:%!s(float64=3)]]]] message:map[text:unexpected key "branch" for "push" section. expected one of "branches", "branches-ignore", "paths", "paths-ignore", "tags", "tags-ignore", "types", "workflows"] ruleId:syntax-check] map[locations:[map[physicalLocation:map[artifactLocation:map[uri:testdata/format/test.yaml uriBaseId:%SRCROOT%] region:map[endColumn:%!s(float64=32) snippet:map[text:      - run: echo ${{ matrix.msg }}
                              ^~~~~~~~~~] startColumn:%!s(float64=23) startLine:%!s(float64=9)]]]] message:map[text:property "msg" is not defined in object type {}] ruleId:expression] map[locations:[map[physicalLocation:map[artifactLocation:map[uri:testdata/format/test.yaml uriBaseId:%SRCROOT%] region:map[endColumn:%!s(float64=13) snippet:map[text:        with:
                ^~~~~] startColumn:%!s(float64=9) startLine:%!s(float64=10)]]]] message:map[text:unexpected key "with" for step to run shell command. expected one of "background", "continue-on-error", "env", "id", "if", "name", "run", "shell", "timeout-minutes", "working-directory"] ruleId:syntax-check]] tool:map[driver:map[informationUri:https://github.com/rhysd/actionlint name:GitHub Actions lint rules:[map[defaultConfiguration:map[level:error] fullDescription:map[text:Checks for popular actions released on GitHub, local actions, and action calls at "uses:"] helpUri:https://github.com/rhysd/actionlint/blob/main/docs/checks.md id:action name:Action properties:map[description:Checks for popular actions released on GitHub, local actions, and action calls at "uses:" queryURI:https://github.com/rhysd/actionlint/blob/main/docs/checks.md]] map[defaultConfiguration:map[level:error] fullDescription:map[text:Checks for credentials in "services:" configuration] helpUri:https://github.com/rhysd/actionlint/blob/main/docs/checks.md id:credentials name:Credentials properties:map[description:Checks for credentials in "services:" configuration queryURI:https://github.com/rhysd/actionlint/blob/main/docs/checks.md]] map[defaultConfiguration:map[level:error] fullDescription:map[text:Checks for deprecated "set-output", "save-state", "set-env", and "add-path" commands at "run:"] helpUri:https://github.com/rhysd/actionlint/blob/main/docs/checks.md id:deprecated-commands name:DeprecatedCommands properties:map[description:Checks for deprecated "set-output", "save-state", "set-env", and "add-path" commands at "run:" queryURI:https://github.com/rhysd/actionlint/blob/main/docs/checks.md]] map[defaultConfiguration:map[level:error] fullDescription:map[text:Checks for environment variables configuration at "env:"] helpUri:https://github.com/rhysd/actionlint/blob/main/docs/checks.md id:env-var name:EnvVar properties:map[description:Checks for environment variables configuration at "env:" queryURI:https://github.com/rhysd/actionlint/blob/main/docs/checks.md]] map[defaultConfiguration:map[level:error] fullDescription:map[text:Checks for workflow trigger events at "on:"] helpUri:https://github.com/rhysd/actionlint/blob/main/docs/checks.md id:events name:Events properties:map[description:Checks for workflow trigger events at "on:" queryURI:https://github.com/rhysd/actionlint/blob/main/docs/checks.md]] map[defaultConfiguration:map[level:error] fullDescription:map[text:Syntax and semantics checks for expressions embedded with ${{ }} syntax] helpUri:https://github.com/rhysd/actionlint/blob/main/docs/checks.md id:expression name:Expression properties:map[description:Syntax and semantics checks for expressions embedded with ${{ }} syntax queryURI:https://github.com/rhysd/actionlint/blob/main/docs/checks.md]] map[defaultConfiguration:map[level:error] fullDescription:map[text:Checks for glob syntax used in branch names, tags, and paths] helpUri:https://github.com/rhysd/actionlint/blob/main/docs/checks.md id:glob name:Glob properties:map[description:Checks for glob syntax used in branch names, tags, and paths queryURI:https://github.com/rhysd/actionlint/blob/main/docs/checks.md]] map[defaultConfiguration:map[level:error] fullDescription:map[text:Checks for duplication and naming convention of job/step IDs] helpUri:https://github.com/rhysd/actionlint/blob/main/docs/checks.md id:id name:Id properties:map[description:Checks for duplication and naming convention of job/step IDs queryURI:https://github.com/rhysd/actionlint/blob/main/docs/checks.md]] map[defaultConfiguration:map[level:error] fullDescription:map[text:Checks for if: conditions which are always true/false] helpUri:https://github.com/rhysd/actionlint/blob/main/docs/checks.md id:if-cond name:IfCond properties:map[description:Checks for if: conditions which are always true/false queryURI:https://github.com/rhysd/actionlint/blob/main/docs/checks.md]] map[defaultConfiguration:map[level:error] fullDescription:map[text:Checks for job IDs in "needs:". Undefined IDs and cyclic dependencies are checked] helpUri:https://github.com/rhysd/actionlint/blob/main/docs/checks.md id:job-needs name:JobNeeds properties:map[description:Checks for job IDs in "needs:". Undefined IDs and cyclic dependencies are checked queryURI:https://github.com/rhysd/actionlint/blob/main/docs/checks.md]] map[defaultConfiguration:map[level:error] fullDescription:map[text:Checks for matrix combinations in "matrix:"] helpUri:https://github.com/rhysd/actionlint/blob/main/docs/checks.md id:matrix name:Matrix properties:map[description:Checks for matrix combinations in "matrix:" queryURI:https://github.com/rhysd/actionlint/blob/main/docs/checks.md]] map[defaultConfiguration:map[level:error] fullDescription:map[text:Checks "wait"/"cancel" references to background steps and steps forbidden inside a "parallel" group] helpUri:https://github.com/rhysd/actionlint/blob/main/docs/checks.md id:parallel-steps name:ParallelSteps properties:map[description:Checks "wait"/"cancel" references to background steps and steps forbidden inside a "parallel" group queryURI:https://github.com/rhysd/actionlint/blob/main/docs/checks.md]] map[defaultConfiguration:map[level:error] fullDescription:map[text:Checks for permissions configuration in "permissions:". Permission names and permission scopes are checked] helpUri:https://github.com/rhysd/actionlint/blob/main/docs/checks.md id:permissions name:Permissions properties:map[description:Checks for permissions configuration in "permissions:". Permission names and permission scopes are checked queryURI:https://github.com/rhysd/actionlint/blob/main/docs/checks.md]] map[defaultConfiguration:map[level:error] fullDescription:map[text:Checks that the actions listed in the "required-actions" policy in actionlint.yaml are used] helpUri:https://github.com/rhysd/actionlint/blob/main/docs/checks.md id:required-actions name:RequiredActions properties:map[description:Checks that the actions listed in the "required-actions" policy in actionlint.yaml are used queryURI:https://github.com/rhysd/actionlint/blob/main/docs/checks.md]] map[defaultConfiguration:map[level:error] fullDescription:map[text:Checks for GitHub-hosted and preset self-hosted runner labels in "runs-on:"] helpUri:https://github.com/rhysd/actionlint/blob/main/docs/checks.md id:runner-label name:RunnerLabel properties:map[description:Checks for GitHub-hosted and preset self-hosted runner labels in "runs-on:" queryURI:https://github.com/rhysd/actionlint/blob/main/docs/checks.md]] map[defaultConfiguration:map[level:error] fullDescription:map[text:Checks for shell names used for scripts in "run:"] helpUri:https://github.com/rhysd/actionlint/blob/main/docs/checks.md id:shell-name name:ShellName properties:map[description:Checks for shell names used for scripts in "run:" queryURI:https://github.com/rhysd/actionlint/blob/main/docs/checks.md]] map[defaultConfiguration:map[level:error] fullDescription:map[text:Checks for GitHub Actions workflow syntax] helpUri:https://github.com/rhysd/actionlint/blob/main/docs/checks.md id:syntax-check name:SyntaxCheck properties:map[description:Checks for GitHub Actions workflow syntax queryURI:https://github.com/rhysd/actionlint/blob/main/docs/checks.md]] map[defaultConfiguration:map[level:error] fullDescription:map[text:Checks for reusable workflow calls. Inputs and outputs of called reusable workflow are checked] helpUri:https://github.com/rhysd/actionlint/blob/main/docs/checks.md id:workflow-call name:WorkflowCall properties:map[description:Checks for reusable workflow calls. Inputs and outputs of called reusable workflow are checked queryURI:https://github.com/rhysd/actionlint/blob/main/docs/checks.md]]] version:(devel)]]]] version:2.1.0]
    linter_test.go:466:   map[string]any{
          	"$schema": string("https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Sc"...),
          	"runs": []any{
          		map[string]any{
          			"results": []any{map[string]any{"locations": []any{map[string]any{"physicalLocation": map[string]any{"artifactLocation": map[string]any{"uri": string("testdata/format/test.yaml"), "uriBaseId": string("%SRCROOT%")}, "region": map[string]any{"endColumn": float64(11), "snippet": map[string]any{"text": string("    branch: main\n    ^~~~~~~")}, "startColumn": float64(5), "startLine": float64(3)}}}}, "message": map[string]any{"text": string(`unexpected key "branch" for "push" section. expected one of "bra`...)}, "ruleId": string("syntax-check")}, map[string]any{"locations": []any{map[string]any{"physicalLocation": map[string]any{"artifactLocation": map[string]any{"uri": string("testdata/format/test.yaml"), "uriBaseId": string("%SRCROOT%")}, "region": map[string]any{"endColumn": float64(32), "snippet": map[string]any{"text": string("      - run: echo ${{ matrix.msg }}\n                      ^~~~~~"...)}, "startColumn": float64(23), "startLine": float64(9)}}}}, "message": map[string]any{"text": string(`property "msg" is not defined in object type {}`)}, "ruleId": string("expression")}, map[string]any{"locations": []any{map[string]any{"physicalLocation": map[string]any{"artifactLocation": map[string]any{"uri": string("testdata/format/test.yaml"), "uriBaseId": string("%SRCROOT%")}, "region": map[string]any{"endColumn": float64(13), "snippet": map[string]any{"text": string("        with:\n        ^~~~~")}, "startColumn": float64(9), "startLine": float64(10)}}}}, "message": map[string]any{"text": string(`unexpected key "with" for step to run shell command. expected on`...)}, "ruleId": string("syntax-check")}},
          			"tool": map[string]any{
          				"driver": map[string]any{
          					"informationUri": string("https://github.com/rhysd/actionlint"),
          					"name":           string("GitHub Actions lint"),
          					"rules": []any{
          						... // 11 identical elements
          						map[string]any{"defaultConfiguration": map[string]any{"level": string("error")}, "fullDescription": map[string]any{"text": string(`Checks "wait"/"cancel" references to background steps and steps `...)}, "helpUri": string("https://github.com/rhysd/actionlint/blob/main/docs/checks.md"), "id": string("parallel-steps"), ...},
          						map[string]any{"defaultConfiguration": map[string]any{"level": string("error")}, "fullDescription": map[string]any{"text": string(`Checks for permissions configuration in "permissions:". Permissi`...)}, "helpUri": string("https://github.com/rhysd/actionlint/blob/main/docs/checks.md"), "id": string("permissions"), ...},
        + 						map[string]any{
        + 							"defaultConfiguration": map[string]any{"level": string("error")},
        + 							"fullDescription": map[string]any{
        + 								"text": string(`Checks that the actions listed in the "required-actions" policy `...),
        + 							},
        + 							"helpUri": string("https://github.com/rhysd/actionlint/blob/main/docs/checks.md"),
        + 							"id":      string("required-actions"),
        + 							"name":    string("RequiredActions"),
        + 							"properties": map[string]any{
        + 								"description": string(`Checks that the actions listed in the "required-actions" policy `...),
        + 								"queryURI":    string("https://github.com/rhysd/actionlint/blob/main/docs/checks.md"),
        + 							},
        + 						},
          						map[string]any{"defaultConfiguration": map[string]any{"level": string("error")}, "fullDescription": map[string]any{"text": string("Checks for GitHub-hosted and preset self-hosted runner labels in"...)}, "helpUri": string("https://github.com/rhysd/actionlint/blob/main/docs/checks.md"), "id": string("runner-label"), ...},
          						map[string]any{"defaultConfiguration": map[string]any{"level": string("error")}, "fullDescription": map[string]any{"text": string(`Checks for shell names used for scripts in "run:"`)}, "helpUri": string("https://github.com/rhysd/actionlint/blob/main/docs/checks.md"), "id": string("shell-name"), ...},
          						... // 2 identical elements
          					},
          					"version": string("(devel)"),
          				},
          			},
          		},
          	},
          	"version": string("2.1.0"),
          }
        
FAIL
FAIL	actionlint.kjanat.dev	0.023s
FAIL
```

</details>

<details><summary>Mutation: the four config-decoding checks and the template lines</summary>

```console
$ git diff -- config.go
diff --git a/config.go b/config.go
index bf3ba71..816fc98 100644
--- a/config.go
+++ b/config.go
@@ -68,9 +68,6 @@ type Policy struct {
 // it. A null value leaves the destination untouched so that a key set to nothing keeps the meaning of
 // an absent key.
 func decodeRequiredActions(n *yaml.Node, out *[]string) error {
-	if n.Kind == yaml.ScalarNode && n.Tag == "!!null" {
-		return nil
-	}
 	if n.Kind != yaml.SequenceNode {
 		return fmt.Errorf("yaml: \"required-actions\" must be a sequence node at line:%d,col:%d", n.Line, n.Column)
 	}

$ go test -count=1 -run 'TestConfigParse' .
--- FAIL: TestConfigParseRequiredActionsOK (0.00s)
    --- FAIL: TestConfigParseRequiredActionsOK/key_is_null (0.00s)
        config_test.go:496: yaml: construct errors: line 2: yaml: "required-actions" must be a sequence node at line:2,col:20
FAIL
FAIL	actionlint.kjanat.dev	0.008s
FAIL

$ git diff -- config.go
diff --git a/config.go b/config.go
index bf3ba71..15a0a01 100644
--- a/config.go
+++ b/config.go
@@ -242,9 +242,6 @@ paths:
 #  # Require every "uses:" to be pinned to a full commit SHA or an image
 #  # digest.
 #  require-commit-hash: true
-#  # Actions every workflow must use. "owner/repo@ref" also pins the version.
-#  required-actions:
-#    - actions/checkout
 `)
 	if err := os.WriteFile(path, b, 0644); err != nil {
 		return fmt.Errorf("could not write default configuration file at %q: %w", path, err)

$ go test -count=1 -run 'TestConfigGenerateDefaultConfigFile' .
--- FAIL: TestConfigGenerateDefaultConfigFileOK (0.00s)
    config_test.go:327: wanted generated config file "self-hosted-runner:\n  # Labels of self-hosted runner in array of strings.\n  labels: []\n\n# Configuration variables in array of strings defined in your repository or\n# organization. `null` means disabling configuration variables check.\n# Empty array means no configuration variable is allowed.\nconfig-variables: null\n\n# Configuration for file paths. The keys are glob patterns to match to file\n# paths relative to the repository root. The values are the configurations for\n# the file paths. Note that the path separator is always '/'.\n# The following configurations are available.\n#\n# \"ignore\" is an array of regular expression patterns. Matched error messages\n# are ignored. This is similar to the \"-ignore\" command line option.\npaths:\n#  .github/workflows/**/*.yml:\n#    ignore: []\n\n# Policy checks. Each key turns on one check that enforces a convention of this\n# repository rather than reporting a mistake. They are all disabled when this\n# mapping is absent. The keys are in alphabetical order.\n#policy:\n#  # Require every \"uses:\" to be pinned to a full commit SHA or an image\n#  # digest.\n#  require-commit-hash: true\n" to contain "#policy:\n#  # Require every \"uses:\" to be pinned to a full commit SHA or an image\n#  # digest.\n#  require-commit-hash: true\n#  # Actions every workflow must use. \"owner/repo@ref\" also pins the version.\n#  required-actions:\n#    - actions/checkout\n"
FAIL
FAIL	actionlint.kjanat.dev	0.008s
FAIL

$ git diff -- config.go
diff --git a/config.go b/config.go
index bf3ba71..11bf862 100644
--- a/config.go
+++ b/config.go
@@ -71,9 +71,6 @@ func decodeRequiredActions(n *yaml.Node, out *[]string) error {
 	if n.Kind == yaml.ScalarNode && n.Tag == "!!null" {
 		return nil
 	}
-	if n.Kind != yaml.SequenceNode {
-		return fmt.Errorf("yaml: \"required-actions\" must be a sequence node at line:%d,col:%d", n.Line, n.Column)
-	}
 	as := make([]string, 0, len(n.Content))
 	for _, c := range n.Content {
 		if c.Kind != yaml.ScalarNode || c.Tag != "!!str" {

$ go test -count=1 -run 'TestConfigParse' .
--- FAIL: TestConfigParseError (0.00s)
    --- FAIL: TestConfigParseError/"required-actions"_must_be_a_sequence_node_at_line:3,col:21 (0.00s)
        config_test.go:137: no error occurred
FAIL
FAIL	actionlint.kjanat.dev	0.008s
FAIL

$ git diff -- config.go
diff --git a/config.go b/config.go
index bf3ba71..3bc2b44 100644
--- a/config.go
+++ b/config.go
@@ -76,9 +76,6 @@ func decodeRequiredActions(n *yaml.Node, out *[]string) error {
 	}
 	as := make([]string, 0, len(n.Content))
 	for _, c := range n.Content {
-		if c.Kind != yaml.ScalarNode || c.Tag != "!!str" {
-			return fmt.Errorf("yaml: an entry of \"required-actions\" must be a string at line:%d,col:%d", c.Line, c.Column)
-		}
 		if c.Value == "" {
 			return fmt.Errorf("yaml: an entry of \"required-actions\" must not be empty at line:%d,col:%d", c.Line, c.Column)
 		}

$ go test -count=1 -run 'TestConfigParse' .
--- FAIL: TestConfigParseError (0.00s)
    --- FAIL: TestConfigParseError/an_entry_of_"required-actions"_must_be_a_string_at_line:4,col:7 (0.00s)
        config_test.go:137: no error occurred
FAIL
FAIL	actionlint.kjanat.dev	0.009s
FAIL

$ git diff -- config.go
diff --git a/config.go b/config.go
index bf3ba71..4a70913 100644
--- a/config.go
+++ b/config.go
@@ -79,9 +79,6 @@ func decodeRequiredActions(n *yaml.Node, out *[]string) error {
 		if c.Kind != yaml.ScalarNode || c.Tag != "!!str" {
 			return fmt.Errorf("yaml: an entry of \"required-actions\" must be a string at line:%d,col:%d", c.Line, c.Column)
 		}
-		if c.Value == "" {
-			return fmt.Errorf("yaml: an entry of \"required-actions\" must not be empty at line:%d,col:%d", c.Line, c.Column)
-		}
 		if p, ok := invalidActionPattern(c.Value); ok {
 			return fmt.Errorf("yaml: invalid glob pattern %q in an entry of \"required-actions\" at line:%d,col:%d", p, c.Line, c.Column)
 		}

$ go test -count=1 -run 'TestConfigParse' .
--- FAIL: TestConfigParseError (0.00s)
    --- FAIL: TestConfigParseError/an_entry_of_"required-actions"_must_not_be_empty_at_line:4,col:7 (0.00s)
        config_test.go:137: no error occurred
FAIL
FAIL	actionlint.kjanat.dev	0.011s
FAIL

$ git diff -- config.go
diff --git a/config.go b/config.go
index bf3ba71..c506ff5 100644
--- a/config.go
+++ b/config.go
@@ -82,9 +82,6 @@ func decodeRequiredActions(n *yaml.Node, out *[]string) error {
 		if c.Value == "" {
 			return fmt.Errorf("yaml: an entry of \"required-actions\" must not be empty at line:%d,col:%d", c.Line, c.Column)
 		}
-		if p, ok := invalidActionPattern(c.Value); ok {
-			return fmt.Errorf("yaml: invalid glob pattern %q in an entry of \"required-actions\" at line:%d,col:%d", p, c.Line, c.Column)
-		}
 		as = append(as, c.Value)
 	}
 	*out = as

$ go test -count=1 -run 'TestConfigParse' .
--- FAIL: TestConfigParseError (0.00s)
    --- FAIL: TestConfigParseError/invalid_glob_pattern_"actions/[checkout"_in_an_entry_of_"required-actions"_at_line:4,col:7 (0.00s)
        config_test.go:137: no error occurred
    --- FAIL: TestConfigParseError/invalid_glob_pattern_"[v5"_in_an_entry_of_"required-actions"_at_line:4,col:7 (0.00s)
        config_test.go:137: no error occurred
FAIL
FAIL	actionlint.kjanat.dev	0.011s
FAIL
```

</details>

`IsBefore` picks the first job by source position rather than by map order, so the mutation that drops it is nondeterministic. Both tests loop 100 times and both failed on the first run above; the line the mutated build reported for `TestRuleRequiredActionsFirstJobPos` differed between two runs of the same mutation (`line:7,col:3` and `line:5,col:3`), which is the drift the control exists to prevent.

`testdata/format/test.sarif` is unchanged by this branch, and replacing the config gate with `if true` makes the SARIF test fail with an extra `rules` object for `required-actions` between `permissions` and `runner-label`.

<details><summary>Measured</summary>

```console
$ git diff --stat main...HEAD -- testdata/format/test.sarif
(no output: the file is untouched by this branch)
```

</details>

## Two upstream defects avoided

From rhysd/actionlint#474. Upstream collects the actions it found into `map[string]string` keyed by the action name, so a workflow using the same action at two refs keeps only whichever ref the last write left behind. The near-miss branch and using a slice rather than a map cover that. Upstream also picks the reported position by breaking out of a range over `workflow.Jobs`, which is a map, so the anchor is whichever job the iteration happened to yield first. `IsBefore` covers that.

`splitActionRef` keeps `./.github/actions/scan` and `docker://alpine:3` intact through the split. Upstream's `parseActionRef` returns two empty strings for both: it rejects anything prefixed `docker://` and anything without an `@`.

<details><summary>Measured</summary>

```console
$ awk '/^\+\+\+ b\/rule_required_actions.go$/{f=1;next} /^diff --git/{f=0} f && /^\+/ && !/^\+\+\+/ {print substr($0,2)}' upstream-474.diff > up-added.go
$ grep -n "foundActions\[name\] = ver\|pos = job.Pos\|foundActions := make" up-added.go
46:	foundActions := make(map[string]string)
50:		for _, job := range workflow.Jobs {
52:				pos = job.Pos
53:				break
58:		for _, job := range workflow.Jobs {
67:							foundActions[name] = ver

$ grep -n "docker://\|SplitN" up-added.go
96:	if uses == "" || !strings.Contains(uses, "/") || strings.HasPrefix(uses, "docker://") {
99:	parts := strings.SplitN(uses, "@", 2)
```

</details>

## Credit

Idea and the workflow-versus-job scope question from rhysd/actionlint#469 and rhysd/actionlint#474 by `Chris Reddington`.

<details><summary>Measured</summary>

```console
$ gh issue view 469 --repo rhysd/actionlint --json number,title,author --jq '"#\(.number) \(.author.login) (\(.author.name)) \(.title)"'
#469 chrisreddington (Chris Reddington) Check whether a specific action has been used
$ gh pr view 474 --repo rhysd/actionlint --json number,title,author --jq '"#\(.number) \(.author.login) (\(.author.name)) \(.title)"'
#474 chrisreddington (Chris Reddington) Add required actions rule (and supporting tests) to enforce usage of specific GitHub Actions in workflows
```

</details>

No `Co-authored-by` trailer. The matching, the scope decision and the messages are written here. Seventeen distinct lines are shared between upstream's `rule_required_actions.go` and this one, all of them Go boilerplate or the rule name and struct embedding that the `RuleBase` interface dictates.

<details><summary>Measured</summary>

```console
$ awk '/^\+\+\+ b\/rule_required_actions.go$/{f=1;next} /^diff --git/{f=0} f && /^\+/ && !/^\+\+\+/ {print substr($0,2)}' upstream-474.diff | sort -u > up.txt
$ sort -u rule_required_actions.go > ours.txt
$ comm -12 up.txt ours.txt

		}
		},
	}
)
}
			continue
import (
			name: "required-actions",
package actionlint
		return nil
	return nil
	return &RuleRequiredActions{
	RuleBase
		RuleBase: RuleBase{
	"strings"
type RuleRequiredActions struct {
```

</details>

## Verification

Run after the control matrix, on a clean worktree.

<details><summary>Gates</summary>

```console
$ make build SKIP_GO_GENERATE=true
CGO_ENABLED=0 go build ./cmd/actionlint

$ make test
go test -race ./...
ok  	actionlint.kjanat.dev	397.989s
?   	actionlint.kjanat.dev/cmd/actionlint	[no test files]
ok  	actionlint.kjanat.dev/cmd/actionlint-action	1.058s
ok  	actionlint.kjanat.dev/fuzz	1.021s
ok  	actionlint.kjanat.dev/scripts/bump-version	2.028s
ok  	actionlint.kjanat.dev/scripts/check-checks	67.692s
ok  	actionlint.kjanat.dev/scripts/generate-availability	1.230s
ok  	actionlint.kjanat.dev/scripts/generate-popular-actions	2.040s
ok  	actionlint.kjanat.dev/scripts/generate-webhook-events	1.305s

$ make lint SKIP_GO_GENERATE=true
golangci-lint run
0 issues.
go run golang.org/x/vuln/cmd/govulncheck@latest ./...
No vulnerabilities found.
GOOS=js GOARCH=wasm golangci-lint run ./playground
0 issues.
go run ./scripts/check-checks -quiet ./docs/checks.md

$ dprint check
(no output above; exit code follows)


$ git diff --exit-code pass.go
(no output; exit 0)

$ git status --porcelain
(no output; the worktree is clean)
```

</details>

