### PR TITLE
Add the "require-job-timeout" policy check

### DIFF
--- a/config.go
+++ b/config.go
@@ -58,6 +58,8 @@ type Policy struct {
 	// RequireCommitHash requires every "uses:" to be pinned to a full commit SHA, or to an image digest
 	// when it names a Docker image. Nil means the key was not set.
 	RequireCommitHash *bool `yaml:"require-commit-hash"`
+	// RequireJobTimeout requires every job to set "timeout-minutes". Nil means the key was not set.
+	RequireJobTimeout *JobTimeoutPolicy `yaml:"require-job-timeout"`
 	// RequiredActions is the actions every workflow must use. Each entry is written like a "uses:"
 	// value and both of its halves are glob patterns. Nil means the key was not set. An empty non-nil
 	// value requires no action, which disables the check.
@@ -102,6 +104,8 @@ func (p *Policy) UnmarshalYAML(n *yaml.Node) error {
 		switch k.Value {
 		case "require-commit-hash":
 			err = v.Decode(&p.RequireCommitHash)
+		case "require-job-timeout":
+			err = v.Decode(&p.RequireJobTimeout)
 		case "required-actions":
 			err = decodeRequiredActions(v, &p.RequiredActions)
 		default:
@@ -110,6 +114,61 @@ func (p *Policy) UnmarshalYAML(n *yaml.Node) error {
 		if err != nil {
 			return err
 		}
+	}
+	return nil
+}
+
+// JobTimeoutPolicy is the value of the "require-job-timeout" policy in the configuration file. The
+// value is a boolean which turns the check on and off, or a mapping which turns it on and sets the
+// largest allowed number of minutes in its "max-minutes" key.
+type JobTimeoutPolicy struct {
+	enabled    bool
+	maxMinutes float64
+}
+
+// RequireJobTimeout creates a JobTimeoutPolicy which turns the check on. The argument is the largest
+// allowed number of minutes, where a value which is not larger than zero sets no upper limit.
+func RequireJobTimeout(maxMinutes float64) *JobTimeoutPolicy {
+	return &JobTimeoutPolicy{enabled: true, maxMinutes: maxMinutes}
+}
+
+// Enabled returns whether the check is turned on. It returns false when the receiver is nil.
+func (p *JobTimeoutPolicy) Enabled() bool {
+	return p != nil && p.enabled
+}
+
+// MaxMinutes returns the largest allowed "timeout-minutes:" value in minutes. The second return
+// value is false when the policy sets no upper limit.
+func (p *JobTimeoutPolicy) MaxMinutes() (float64, bool) {
+	if !p.Enabled() || p.maxMinutes <= 0 {
+		return 0, false
+	}
+	return p.maxMinutes, true
+}
+
+// UnmarshalYAML implements yaml.Unmarshaler.
+func (p *JobTimeoutPolicy) UnmarshalYAML(n *yaml.Node) error {
+	switch n.Kind {
+	case yaml.ScalarNode:
+		if err := n.Decode(&p.enabled); err != nil {
+			return fmt.Errorf("yaml: \"require-job-timeout\" must be a boolean or a mapping at line:%d,col:%d", n.Line, n.Column)
+		}
+	case yaml.MappingNode:
+		p.enabled = true
+		for i := 0; i+1 < len(n.Content); i += 2 {
+			k, v := n.Content[i], n.Content[i+1]
+			if k.Value != "max-minutes" {
+				return fmt.Errorf("yaml: unknown key %q in \"require-job-timeout\" at line:%d,col:%d", k.Value, k.Line, k.Column)
+			}
+			if err := v.Decode(&p.maxMinutes); err != nil {
+				return err
+			}
+			if p.maxMinutes <= 0 {
+				return fmt.Errorf("yaml: \"max-minutes\" in \"require-job-timeout\" must be greater than zero but got %v at line:%d,col:%d", p.maxMinutes, v.Line, v.Column)
+			}
+		}
+	default:
+		return fmt.Errorf("yaml: \"require-job-timeout\" must be a boolean or a mapping at line:%d,col:%d", n.Line, n.Column)
 	}
 	return nil
 }
@@ -156,6 +215,15 @@ func (cfg *Config) PathConfigs(path string) []PathConfig {
 // when the receiver is nil or when the key is not set.
 func (cfg *Config) RequiresCommitHash() bool {
 	return cfg != nil && cfg.Policy.RequireCommitHash != nil && *cfg.Policy.RequireCommitHash
+}
+
+// RequiresJobTimeout returns the "require-job-timeout" policy. It returns nil when the receiver is
+// nil or when the key is not set.
+func (cfg *Config) RequiresJobTimeout() *JobTimeoutPolicy {
+	if cfg == nil {
+		return nil
+	}
+	return cfg.Policy.RequireJobTimeout
 }
 
 // RequiredActions returns the actions which every workflow must use following the "required-actions"
@@ -242,6 +310,9 @@ paths:
 #  # Require every "uses:" to be pinned to a full commit SHA or an image
 #  # digest.
 #  require-commit-hash: true
+#  # Require "timeout-minutes" on every job. A mapping with "max-minutes" also
+#  # caps the value.
+#  require-job-timeout: true
 #  # Actions every workflow must use. "owner/repo@ref" also pins the version.
 #  required-actions:
 #    - actions/checkout

--- a/config.go
+++ b/config.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/bmatcuk/doublestar/v4"
@@ -160,9 +161,14 @@ func (p *JobTimeoutPolicy) UnmarshalYAML(n *yaml.Node) error {
 			if k.Value != "max-minutes" {
 				return fmt.Errorf("yaml: unknown key %q in \"require-job-timeout\" at line:%d,col:%d", k.Value, k.Line, k.Column)
 			}
-			if err := v.Decode(&p.maxMinutes); err != nil {
-				return err
+			// Decoding through the YAML library reads a leading zero as YAML 1.1 octal, so
+			// "max-minutes: 017" would become 15. The workflow parser reads numbers from the raw
+			// text with strconv, and so does this.
+			f, err := strconv.ParseFloat(v.Value, 64)
+			if err != nil || v.Kind != yaml.ScalarNode {
+				return fmt.Errorf("yaml: \"max-minutes\" in \"require-job-timeout\" must be a number but got %q at line:%d,col:%d", v.Value, v.Line, v.Column)
 			}
+			p.maxMinutes = f
 			if p.maxMinutes <= 0 {
 				return fmt.Errorf("yaml: \"max-minutes\" in \"require-job-timeout\" must be greater than zero but got %v at line:%d,col:%d", p.maxMinutes, v.Line, v.Column)
 			}

--- a/config_test.go
+++ b/config_test.go
@@ -322,7 +322,15 @@ func TestConfigGenerateDefaultConfigFileOK(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := "#policy:\n#  # Require every \"uses:\" to be pinned to a full commit SHA or an image\n#  # digest.\n#  require-commit-hash: true\n#  # Actions every workflow must use. \"owner/repo@ref\" also pins the version.\n#  required-actions:\n#    - actions/checkout\n"
+	want := "#policy:\n#  # Require every \"uses:\" to be pinned to a full commit SHA or an image\n#  # digest.\n#  require-commit-hash: true\n"
+	if !strings.Contains(string(b), want) {
+		t.Fatalf("wanted generated config file %q to contain %q", string(b), want)
+	}
+	want = "#  # Actions every workflow must use. \"owner/repo@ref\" also pins the version.\n#  required-actions:\n#    - actions/checkout\n"
+	if !strings.Contains(string(b), want) {
+		t.Fatalf("wanted generated config file %q to contain %q", string(b), want)
+	}
+	want = "#  # Require \"timeout-minutes\" on every job. A mapping with \"max-minutes\" also\n#  # caps the value.\n#  require-job-timeout: true\n"
 	if !strings.Contains(string(b), want) {
 		t.Fatalf("wanted generated config file %q to contain %q", string(b), want)
 	}
@@ -500,6 +508,141 @@ func TestConfigParseRequiredActionsOK(t *testing.T) {
 			}
 			if diff := cmp.Diff(tc.want, c.RequiredActions()); diff != "" {
 				t.Fatal(diff)
+			}
+		})
+	}
+}
+
+func TestConfigParseRequireJobTimeout(t *testing.T) {
+	tests := []struct {
+		what        string
+		input       string
+		wantSet     bool
+		wantEnabled bool
+		wantMax     float64
+		wantHasMax  bool
+	}{
+		{
+			what:    "key is not set",
+			input:   "policy: {}\n",
+			wantSet: false,
+		},
+		{
+			what:    "key is null",
+			input:   "policy:\n  require-job-timeout:\n",
+			wantSet: false,
+		},
+		{
+			what:        "key is false",
+			input:       "policy:\n  require-job-timeout: false\n",
+			wantSet:     true,
+			wantEnabled: false,
+		},
+		{
+			what:        "key is true",
+			input:       "policy:\n  require-job-timeout: true\n",
+			wantSet:     true,
+			wantEnabled: true,
+		},
+		{
+			what:        "key is an empty mapping",
+			input:       "policy:\n  require-job-timeout: {}\n",
+			wantSet:     true,
+			wantEnabled: true,
+		},
+		{
+			what:        "mapping sets max-minutes",
+			input:       "policy:\n  require-job-timeout:\n    max-minutes: 60\n",
+			wantSet:     true,
+			wantEnabled: true,
+			wantMax:     60,
+			wantHasMax:  true,
+		},
+		{
+			what:        "max-minutes is a fraction",
+			input:       "policy:\n  require-job-timeout: {max-minutes: 30.5}\n",
+			wantSet:     true,
+			wantEnabled: true,
+			wantMax:     30.5,
+			wantHasMax:  true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.what, func(t *testing.T) {
+			c, err := ParseConfig([]byte(tc.input))
+			if err != nil {
+				t.Fatal(err)
+			}
+			p := c.Policy.RequireJobTimeout
+			if tc.wantSet != (p != nil) {
+				t.Fatalf("policy is %v but wanted set=%v", p, tc.wantSet)
+			}
+			if p.Enabled() != tc.wantEnabled {
+				t.Fatalf("Enabled() is %v but wanted %v", p.Enabled(), tc.wantEnabled)
+			}
+			limit, ok := p.MaxMinutes()
+			if ok != tc.wantHasMax || limit != tc.wantMax {
+				t.Fatalf("MaxMinutes() is (%v, %v) but wanted (%v, %v)", limit, ok, tc.wantMax, tc.wantHasMax)
+			}
+			if got := c.RequiresJobTimeout(); got != p {
+				t.Fatalf("RequiresJobTimeout() is %v but wanted %v", got, p)
+			}
+		})
+	}
+}
+
+func TestConfigParseRequireJobTimeoutError(t *testing.T) {
+	tests := []struct {
+		what  string
+		input string
+		want  string
+	}{
+		{
+			what:  "value is a number",
+			input: "policy:\n  require-job-timeout: 60\n",
+			want:  `"require-job-timeout" must be a boolean or a mapping at line:2,col:24`,
+		},
+		{
+			what:  "value is a string",
+			input: "policy:\n  require-job-timeout: hello\n",
+			want:  `"require-job-timeout" must be a boolean or a mapping at line:2,col:24`,
+		},
+		{
+			what:  "value is a sequence",
+			input: "policy:\n  require-job-timeout:\n    - 60\n",
+			want:  `"require-job-timeout" must be a boolean or a mapping at line:3,col:5`,
+		},
+		{
+			what:  "unknown key in the mapping",
+			input: "policy:\n  require-job-timeout:\n    max_minutes: 60\n",
+			want:  `unknown key "max_minutes" in "require-job-timeout" at line:3,col:5`,
+		},
+		{
+			what:  "max-minutes is zero",
+			input: "policy:\n  require-job-timeout:\n    max-minutes: 0\n",
+			want:  `"max-minutes" in "require-job-timeout" must be greater than zero but got 0 at line:3,col:18`,
+		},
+		{
+			what:  "max-minutes is negative",
+			input: "policy:\n  require-job-timeout:\n    max-minutes: -5\n",
+			want:  `"max-minutes" in "require-job-timeout" must be greater than zero but got -5 at line:3,col:18`,
+		},
+		{
+			what:  "max-minutes is not a number",
+			input: "policy:\n  require-job-timeout:\n    max-minutes: hello\n",
+			want:  "cannot construct !!str `hello` into float64",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.what, func(t *testing.T) {
+			_, err := ParseConfig([]byte(tc.input))
+			if err == nil {
+				t.Fatal("no error occurred")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("wanted error message %q to contain %q", err.Error(), tc.want)
 			}
 		})
 	}

--- a/config_test.go
+++ b/config_test.go
@@ -566,6 +566,14 @@ func TestConfigParseRequireJobTimeout(t *testing.T) {
 			wantMax:     30.5,
 			wantHasMax:  true,
 		},
+		{
+			what:        "max-minutes has a leading zero",
+			input:       "policy:\n  require-job-timeout:\n    max-minutes: 017\n",
+			wantSet:     true,
+			wantEnabled: true,
+			wantMax:     17,
+			wantHasMax:  true,
+		},
 	}
 
 	for _, tc := range tests {
@@ -631,7 +639,12 @@ func TestConfigParseRequireJobTimeoutError(t *testing.T) {
 		{
 			what:  "max-minutes is not a number",
 			input: "policy:\n  require-job-timeout:\n    max-minutes: hello\n",
-			want:  "cannot construct !!str `hello` into float64",
+			want:  `"max-minutes" in "require-job-timeout" must be a number but got "hello" at line:3,col:18`,
+		},
+		{
+			what:  "max-minutes is a mapping",
+			input: "policy:\n  require-job-timeout:\n    max-minutes:\n      a: 1\n",
+			want:  `"max-minutes" in "require-job-timeout" must be a number but got "" at line:4,col:7`,
 		},
 	}
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -86,6 +86,26 @@ policy:
   require-commit-hash: true
 ```
 
+### require-job-timeout
+
+This check reports a job which sets no `timeout-minutes:`. Such a job is cancelled after GitHub's default of 360
+minutes. A job which calls a reusable workflow with `uses:` cannot set the key, so the check passes over it.
+
+```yaml
+policy:
+  require-job-timeout: true
+```
+
+The value can also be a mapping. Its `max-minutes` key is the largest allowed number of minutes, and it must be
+greater than zero. With it, a job whose `timeout-minutes:` is larger than that number is reported as well. A value
+written with `${{ }}` is not compared because actionlint cannot read it.
+
+```yaml
+policy:
+  require-job-timeout:
+    max-minutes: 60
+```
+
 ### required-actions
 
 This check reports a workflow which does not use an action this repository requires. An entry is written like a `uses:`

--- a/linter.go
+++ b/linter.go
@@ -590,6 +590,9 @@ func (l *Linter) check(
 		if cfg.RequiresCommitHash() {
 			rules = append(rules, NewRuleRequireCommitHash())
 		}
+		if p := cfg.RequiresJobTimeout(); p.Enabled() {
+			rules = append(rules, NewRuleRequireJobTimeout(p))
+		}
 		if len(cfg.RequiredActions()) > 0 {
 			rules = append(rules, NewRuleRequiredActions())
 		}

--- a/rule_require_job_timeout.go
+++ b/rule_require_job_timeout.go
@@ -1,0 +1,57 @@
+package actionlint
+
+// RuleRequireJobTimeout is a rule to check that every job sets "timeout-minutes:". The
+// "require-job-timeout" policy in the configuration file enables it, and its "max-minutes" key also
+// caps the value.
+// https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idtimeout-minutes
+type RuleRequireJobTimeout struct {
+	RuleBase
+	policy *JobTimeoutPolicy
+}
+
+// NewRuleRequireJobTimeout creates a new RuleRequireJobTimeout instance with the given policy.
+func NewRuleRequireJobTimeout(policy *JobTimeoutPolicy) *RuleRequireJobTimeout {
+	return &RuleRequireJobTimeout{
+		RuleBase: RuleBase{
+			name: "require-job-timeout",
+			desc: "Checks that every job sets \"timeout-minutes:\" within the configured maximum",
+		},
+		policy: policy,
+	}
+}
+
+// VisitJobPre is callback when visiting Job node before visiting its children.
+func (rule *RuleRequireJobTimeout) VisitJobPre(n *Job) error {
+	if !rule.policy.Enabled() {
+		return nil
+	}
+
+	// A job which calls a reusable workflow cannot set "timeout-minutes:".
+	// https://docs.github.com/en/actions/reference/workflows-and-actions/reusing-workflow-configurations#supported-keywords-for-jobs-that-call-a-reusable-workflow
+	if n.WorkflowCall != nil || n.Steps == nil {
+		return nil
+	}
+
+	if n.TimeoutMinutes == nil {
+		rule.Errorf(
+			n.Pos,
+			"%q is not set in job %q. it is required because \"require-job-timeout\" is enabled in the \"policy\" configuration. a job which does not set it is cancelled after the default of 360 minutes",
+			"timeout-minutes",
+			n.ID.Value,
+		)
+		return nil
+	}
+
+	limit, ok := rule.policy.MaxMinutes()
+	if ok && n.TimeoutMinutes.Expression == nil && n.TimeoutMinutes.Value > limit {
+		rule.Errorf(
+			n.TimeoutMinutes.Pos,
+			"%q is %v in job %q. it must not be larger than %v because \"max-minutes\" of \"require-job-timeout\" is set in the \"policy\" configuration",
+			"timeout-minutes",
+			n.TimeoutMinutes.Value,
+			n.ID.Value,
+			limit,
+		)
+	}
+	return nil
+}

--- a/rule_require_job_timeout_test.go
+++ b/rule_require_job_timeout_test.go
@@ -1,0 +1,149 @@
+package actionlint
+
+import "testing"
+
+func TestRuleRequireJobTimeout(t *testing.T) {
+	jobPos := &Pos{Line: 4, Col: 3}
+	valuePos := &Pos{Line: 6, Col: 22}
+	missing := ":4:3: \"timeout-minutes\" is not set in job \"test\". it is required because \"require-job-timeout\" is enabled in the \"policy\" configuration. a job which does not set it is cancelled after the default of 360 minutes [require-job-timeout]"
+
+	newJob := func(timeout *Float) *Job {
+		return &Job{
+			ID:             &String{Value: "test", Pos: jobPos},
+			Steps:          []*Step{{Pos: &Pos{Line: 7, Col: 7}}},
+			TimeoutMinutes: timeout,
+			Pos:            jobPos,
+		}
+	}
+	minutes := func(v float64) *Float {
+		return &Float{Value: v, Pos: valuePos}
+	}
+
+	tests := []struct {
+		what   string
+		policy *JobTimeoutPolicy
+		job    *Job
+		want   []string
+	}{
+		{
+			what:   "no policy",
+			policy: nil,
+			job:    newJob(nil),
+		},
+		{
+			what:   "policy is disabled",
+			policy: &JobTimeoutPolicy{},
+			job:    newJob(nil),
+		},
+		{
+			what:   "policy is disabled with a maximum",
+			policy: &JobTimeoutPolicy{maxMinutes: 30},
+			job:    newJob(minutes(45)),
+		},
+		{
+			what:   "timeout is missing",
+			policy: RequireJobTimeout(0),
+			job:    newJob(nil),
+			want:   []string{missing},
+		},
+		{
+			what:   "timeout is set",
+			policy: RequireJobTimeout(0),
+			job:    newJob(minutes(45)),
+		},
+		{
+			what:   "no maximum is configured",
+			policy: RequireJobTimeout(0),
+			job:    newJob(minutes(4320)),
+		},
+		{
+			what:   "timeout is below the maximum",
+			policy: RequireJobTimeout(30),
+			job:    newJob(minutes(15)),
+		},
+		{
+			what:   "timeout is equal to the maximum",
+			policy: RequireJobTimeout(30),
+			job:    newJob(minutes(30)),
+		},
+		{
+			what:   "timeout is above the maximum",
+			policy: RequireJobTimeout(30),
+			job:    newJob(minutes(45)),
+			want: []string{
+				":6:22: \"timeout-minutes\" is 45 in job \"test\". it must not be larger than 30 because \"max-minutes\" of \"require-job-timeout\" is set in the \"policy\" configuration [require-job-timeout]",
+			},
+		},
+		{
+			what:   "maximum is a fraction",
+			policy: RequireJobTimeout(30.5),
+			job:    newJob(minutes(45)),
+			want: []string{
+				":6:22: \"timeout-minutes\" is 45 in job \"test\". it must not be larger than 30.5 because \"max-minutes\" of \"require-job-timeout\" is set in the \"policy\" configuration [require-job-timeout]",
+			},
+		},
+		{
+			what:   "timeout is missing while a maximum is configured",
+			policy: RequireJobTimeout(30),
+			job:    newJob(nil),
+			want:   []string{missing},
+		},
+		{
+			what:   "timeout is an expression",
+			policy: RequireJobTimeout(30),
+			job: newJob(&Float{
+				Value:      45,
+				Expression: &String{Value: "matrix.timeout", Pos: valuePos},
+				Pos:        valuePos,
+			}),
+		},
+		{
+			what:   "job calls a reusable workflow",
+			policy: RequireJobTimeout(30),
+			job: &Job{
+				ID: &String{Value: "test", Pos: jobPos},
+				WorkflowCall: &WorkflowCall{
+					Uses: &String{Value: "./.github/workflows/ci.yaml", Pos: &Pos{Line: 5, Col: 11}},
+				},
+				Steps: []*Step{{Pos: &Pos{Line: 7, Col: 7}}},
+				Pos:   jobPos,
+			},
+		},
+		{
+			what:   "job has no steps",
+			policy: RequireJobTimeout(30),
+			job: &Job{
+				ID:  &String{Value: "test", Pos: jobPos},
+				Pos: jobPos,
+			},
+		},
+		{
+			what:   "job has an empty steps section",
+			policy: RequireJobTimeout(30),
+			job: &Job{
+				ID:    &String{Value: "test", Pos: jobPos},
+				Steps: []*Step{},
+				Pos:   jobPos,
+			},
+			want: []string{missing},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.what, func(t *testing.T) {
+			r := NewRuleRequireJobTimeout(tc.policy)
+			if err := r.VisitJobPre(tc.job); err != nil {
+				t.Fatal(err)
+			}
+			errs := r.Errs()
+			if len(errs) != len(tc.want) {
+				t.Fatalf("wanted %d errors but have %d: %v", len(tc.want), len(errs), errs)
+			}
+			for i, want := range tc.want {
+				if have := errs[i].Error(); have != want {
+					t.Fatalf("wanted error %q but have %q", want, have)
+				}
+			}
+		})
+	}
+}

--- a/testdata/projects/require_job_timeout.out
+++ b/testdata/projects/require_job_timeout.out
@@ -1,0 +1,2 @@
+workflows/test.yaml:5:3: "timeout-minutes" is not set in job "missing". it is required because "require-job-timeout" is enabled in the "policy" configuration. a job which does not set it is cancelled after the default of 360 minutes [require-job-timeout]
+workflows/test.yaml:24:22: "timeout-minutes" is 45 in job "too-long". it must not be larger than 30 because "max-minutes" of "require-job-timeout" is set in the "policy" configuration [require-job-timeout]

--- a/testdata/projects/require_job_timeout/actionlint.yaml
+++ b/testdata/projects/require_job_timeout/actionlint.yaml
@@ -1,0 +1,3 @@
+policy:
+  require-job-timeout:
+    max-minutes: 30

--- a/testdata/projects/require_job_timeout/workflows/reusable.yaml
+++ b/testdata/projects/require_job_timeout/workflows/reusable.yaml
@@ -1,0 +1,8 @@
+on: workflow_call
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - run: echo 'hello'

--- a/testdata/projects/require_job_timeout/workflows/test.yaml
+++ b/testdata/projects/require_job_timeout/workflows/test.yaml
@@ -1,0 +1,38 @@
+on: push
+
+jobs:
+  # ERROR: "timeout-minutes" is not set
+  missing:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo 'hello'
+  # OK: below the maximum
+  ok:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - run: echo 'hello'
+  # OK: equal to the maximum
+  edge:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - run: echo 'hello'
+  # ERROR: above the maximum
+  too-long:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - run: echo 'hello'
+  # OK: the value cannot be read from an expression
+  matrix-expr:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        timeout: [10, 20]
+    timeout-minutes: ${{ matrix.timeout }}
+    steps:
+      - run: echo 'hello'
+  # OK: a job calling a reusable workflow cannot set "timeout-minutes"
+  call:
+    uses: ./workflows/reusable.yaml

--- a/testdata/projects/require_job_timeout_disabled/actionlint.yaml
+++ b/testdata/projects/require_job_timeout_disabled/actionlint.yaml
@@ -1,0 +1,2 @@
+policy:
+  require-job-timeout: false

--- a/testdata/projects/require_job_timeout_disabled/workflows/test.yaml
+++ b/testdata/projects/require_job_timeout_disabled/workflows/test.yaml
@@ -1,0 +1,7 @@
+on: push
+
+jobs:
+  no-timeout:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo 'hello'


### PR DESCRIPTION
A job that sets no `timeout-minutes:` is cancelled after GitHub's default of 360 minutes. A hung job therefore burns six hours of runner time before anything stops it. `policy.require-job-timeout` reports those jobs, and its mapping form also caps how many minutes a job may ask for.

<details><summary>Measured</summary>

```console
$ curl -sSL "https://raw.githubusercontent.com/github/docs/main/content/actions/reference/workflows-and-actions/workflow-syntax.md" -o /tmp/gh-workflow-syntax.md && grep -n -B4 -A10 "jobs.<job_id>.timeout-minutes" /tmp/gh-workflow-syntax.md
1091-The group above is equivalent to declaring each step with `background: true` followed by a `wait` step.
1092-
1093-{% endif %}
1094-
1095:## `jobs.<job_id>.timeout-minutes`
1096-
1097-The maximum number of minutes to let a job run before {% data variables.product.prodname_dotcom %} automatically cancels it. Default: 360
1098-
1099-If the timeout exceeds the job execution time limit for the runner, the job will be canceled when the execution time limit is met instead. For more information about job execution time limits, see [AUTOTITLE](/actions/concepts/billing-and-usage#usage-limits-and-policy) for {% data variables.product.prodname_dotcom %}-hosted runners and [AUTOTITLE](/actions/reference/limits) for self-hosted runner usage limits.
1100-
1101-> [!NOTE]
1102-> {% data reusables.actions.github-token-expiration %} For self-hosted runners, the token may be the limiting factor if the job timeout is greater than 24 hours. For more information on the `GITHUB_TOKEN`, see [AUTOTITLE](/actions/tutorials/authenticate-with-github_token).
1103-
1104-## `jobs.<job_id>.strategy`
```

</details>

Requires #40, which lands the `policy` mapping's scaffolding, and #39 under that.

<details><summary>Measured</summary>

```console
$ gh pr list --state all --json number,title,baseRefName,headRefName,state --jq '.[] | select(.number == 39 or .number == 40 or .number == 44) | [.number, .state, .headRefName, "->", .baseRefName, .title] | @tsv'
44	OPEN	require-job-timeout	->	require-commit-hash	Add the "require-job-timeout" policy check
40	OPEN	require-commit-hash	->	policy-rules-charter	Add the "require-commit-hash" policy check
39	OPEN	policy-rules-charter	->	main	Document the split between correctness checks and policy checks
```

</details>

```yaml
policy:
  require-job-timeout: true
```

```yaml
policy:
  require-job-timeout:
    max-minutes: 60
```

```
workflows/test.yaml:5:3: "timeout-minutes" is not set in job "missing". it is required because "require-job-timeout" is enabled in the "policy" configuration. a job which does not set it is cancelled after the default of 360 minutes
workflows/test.yaml:24:22: "timeout-minutes" is 45 in job "too-long". it must not be larger than 30 because "max-minutes" of "require-job-timeout" is set in the "policy" configuration
```

A job that calls a reusable workflow is passed over, because it cannot set the key at all. The project fixture holds six jobs: missing, below the maximum, equal to it, above it, an expression, and a call job.

<details><summary>Measured</summary>

```console
$ go test -count=1 -run 'TestLinterLintProject/project/require_job_timeout' -v .
=== RUN   TestLinterLintProject
=== RUN   TestLinterLintProject/project/require_job_timeout
    linter_test.go:326: Linting project at testdata/projects/require_job_timeout
    linter_test.go:346: Checking 2 errors with "testdata/projects/require_job_timeout.out"
    linter_test.go:346:   Error[0]: workflows/test.yaml:5:3: "timeout-minutes" is not set in job "missing". it is required because "require-job-timeout" is enabled in the "policy" configuration. a job which does not set it is cancelled after the default of 360 minutes [require-job-timeout]
    linter_test.go:346:   Error[1]: workflows/test.yaml:24:22: "timeout-minutes" is 45 in job "too-long". it must not be larger than 30 because "max-minutes" of "require-job-timeout" is set in the "policy" configuration [require-job-timeout]
=== RUN   TestLinterLintProject/project/require_job_timeout_disabled
    linter_test.go:326: Linting project at testdata/projects/require_job_timeout_disabled
    linter_test.go:346: Checking 0 errors with "testdata/projects/require_job_timeout_disabled.out"
--- PASS: TestLinterLintProject (0.00s)
    --- PASS: TestLinterLintProject/project/require_job_timeout (0.00s)
    --- PASS: TestLinterLintProject/project/require_job_timeout_disabled (0.00s)
PASS
ok  	actionlint.kjanat.dev	0.005s
```

`timeout-minutes` is not among the keywords GitHub allows in a call job:

```console
$ curl -sSL "https://raw.githubusercontent.com/github/docs/main/content/actions/reference/workflows-and-actions/reusing-workflow-configurations.md" -o /tmp/gh-reuse.md && grep -n -A16 "Supported keywords for jobs that call a reusable workflow" /tmp/gh-reuse.md
68:### Supported keywords for jobs that call a reusable workflow
69-
70-When you call a reusable workflow, you can only use the following keywords in the job containing the call:
71-
72-* [`jobs.<job_id>.name`](/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idname)
73-* [`jobs.<job_id>.uses`](/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_iduses)
74-* [`jobs.<job_id>.with`](/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idwith)
75-* [`jobs.<job_id>.with.<input_id>`](/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idwithinput_id)
76-* [`jobs.<job_id>.secrets`](/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idsecrets)
77-* [`jobs.<job_id>.secrets.<secret_id>`](/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idsecretssecret_id)
78-* [`jobs.<job_id>.secrets.inherit`](/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idsecretsinherit)
79-* [`jobs.<job_id>.strategy`](/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idstrategy)
80-* [`jobs.<job_id>.needs`](/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idneeds)
81-* [`jobs.<job_id>.if`](/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idif)
82-* [`jobs.<job_id>.concurrency`](/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idconcurrency)
83-* [`jobs.<job_id>.permissions`](/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idpermissions)
```

</details>

## A leading zero in `max-minutes` was read as octal

Verification turned this up and a second commit fixes it. Decoding through the YAML library resolved a leading-zero integer as YAML 1.1 octal, so `max-minutes: 017` became a limit of 15 minutes and `0x10` became 16. Neither is what the author wrote, and neither is what GitHub reads: the workflow parser takes numbers from the raw text with `strconv`, so `timeout-minutes: 017` in a workflow is 17.

`max-minutes` is now read the same way, which makes the two agree. A value `strconv` cannot read becomes an error naming the key, the value and its position, like the two errors beside it.

The measurement below is from before the fix. `TestConfigParseRequireJobTimeout/max-minutes_has_a_leading_zero` now pins 17, and restoring the decode makes it fail with `MaxMinutes() is (15, true) but wanted (17, true)`.

<details><summary>Measured</summary>

A standalone Go program outside the repository, with a `replace` pointing at this worktree:

```console
$ GOFLAGS=-mod=mod go run .
--- max-minutes 60 ---
input: "policy:\n  require-job-timeout:\n    max-minutes: 60\n"
policy set: true; Enabled(): true; MaxMinutes(): (60, true)
--- max-minutes 017 ---
input: "policy:\n  require-job-timeout:\n    max-minutes: 017\n"
policy set: true; Enabled(): true; MaxMinutes(): (15, true)
--- max-minutes 010 ---
input: "policy:\n  require-job-timeout:\n    max-minutes: 010\n"
policy set: true; Enabled(): true; MaxMinutes(): (8, true)
--- max-minutes 08 ---
input: "policy:\n  require-job-timeout:\n    max-minutes: 08\n"
policy set: true; Enabled(): true; MaxMinutes(): (8, true)
--- max-minutes 0o17 ---
input: "policy:\n  require-job-timeout:\n    max-minutes: 0o17\n"
policy set: true; Enabled(): true; MaxMinutes(): (15, true)
--- max-minutes 0x10 ---
input: "policy:\n  require-job-timeout:\n    max-minutes: 0x10\n"
policy set: true; Enabled(): true; MaxMinutes(): (16, true)
```

</details>

## Four defects in the upstream branch

From rhysd/actionlint#581, which conflicts with `main` and predates large changes to the rule and configuration API, so it was rebuilt rather than rebased.

<details><summary>Measured</summary>

```console
$ gh pr view 581 --repo rhysd/actionlint --json mergeable,mergeStateStatus,baseRefName,headRefName,createdAt
{"baseRefName":"main","createdAt":"2025-10-11T16:13:27Z","headRefName":"feat/timeout-minutes","mergeStateStatus":"DIRTY","mergeable":"CONFLICTING"}
```

</details>

**The maximum was unreachable unless the presence check was also on.** Two separate keys, with the cap only consulted after the presence check had passed. Here one key carries both, so `{max-minutes: 60}` means "required, and at most 60".

**A zero maximum could not be told apart from an unset one.** Both meant "no cap", silently.

**The reusable-workflow guard looked at `steps` rather than at what the AST records.** It now reads `WorkflowCall` as well.

**A `timeout-minutes` written with `${{ }}` escaped the comparison by accident.** The skip is now explicit.

<details><summary>Measured</summary>

```console
$ gh api repos/rhysd/actionlint/pulls/581/files --jq '.[] | select(.filename == "config.go" or .filename == "rule_timeout_check.go") | "--- " + .filename + " ---\n" + .patch'
--- config.go ---
@@ -51,6 +51,11 @@ type PathConfig struct {
 	Ignore IgnorePatterns `yaml:"ignore"`
 }
 
+type TimeoutMinutesConfig struct {
+	Required   bool    `yaml:"required"`
+	MaxMinutes float64 `yaml:"max"`
+}
+
 // Config is configuration of actionlint. This struct instance is parsed from "actionlint.yaml"
 // file usually put in ".github" directory.
 type Config struct {
@@ -67,6 +72,10 @@ type Config struct {
 	// Paths is a "paths" mapping in the configuration file. The keys are glob patterns to match file paths.
 	// And the values are corresponding configurations applied to the file paths.
 	Paths map[string]PathConfig `yaml:"paths"`
+	// TimeoutMinutes is an object where Required set true requires a timeout-minutes value to be present.
+	// Optionally, the MaxMinutes field can be set to enforce an upper limit on the timeout-minutes value.
+	// This is used in timeout-check rule.
+	TimeoutMinutes TimeoutMinutesConfig `yaml:"timeout-minutes"`
 }
 
 // PathConfigs returns a list of all PathConfig values matching to the given file path. The path must
@@ -153,6 +162,13 @@ config-variables: null
 paths:
 #  .github/workflows/**/*.yml:
 #    ignore: []
+
+# timeout-minutes is an object where 'required' set true requires a timeout-minutes value to be present.
+# Optionally, the 'max' field can be set to enforce an upper limit on the timeout-minutes value.
+# This is used in timeout-check rule. 
+timeout-minutes:
+  required: false
+  max: 60
 `)
 	if err := os.WriteFile(path, b, 0644); err != nil {
 		return fmt.Errorf("could not write default configuration file at %q: %w", path, err)
--- rule_timeout_check.go ---
@@ -0,0 +1,44 @@
+package actionlint
+
+type RuleTimeoutCheck struct {
+	RuleBase
+}
+
+func NewRuleTimeoutCheck() *RuleTimeoutCheck {
+	return &RuleTimeoutCheck{
+		RuleBase: RuleBase{
+			name: "timeout-check",
+			desc: "Checks that timeout-minutes is set per job, with optional max limit",
+		},
+	}
+}
+
+func (rule *RuleTimeoutCheck) VisitJobPre(n *Job) error {
+	if rule.config == nil || !rule.Config().TimeoutMinutes.Required {
+		// No need to check anything
+		return nil
+	}
+
+	if n.Steps == nil {
+		// This must be using a reusable workflow which does not support timeout-minutes
+		return nil
+	}
+
+	if n.TimeoutMinutes == nil {
+		rule.Error(
+			n.Pos,
+			"You must have a timeout-minutes set to avoid overspend.",
+		)
+	}
+
+	if n.TimeoutMinutes != nil &&
+		rule.config.TimeoutMinutes.MaxMinutes != 0 &&
+		n.TimeoutMinutes.Value > rule.config.TimeoutMinutes.MaxMinutes {
+		rule.Errorf(
+			n.Pos,
+			"Your timeout-minutes is greater than %d minutes.",
+			int(rule.config.TimeoutMinutes.MaxMinutes),
+		)
+	}
+	return nil
+}
```

`Required` and `max` are two keys, and the `Required` gate stands in front of the maximum, so `{required: false, max: 60}` enforces nothing. `MaxMinutes != 0` leaves `max: 0` indistinguishable from an absent `max`. The call-job guard reads `n.Steps`. And the comparison has no `Expression` branch.

</details>

`max-minutes: 0` and `max-minutes: -5` are now errors, with line and column:

<details><summary>Measured</summary>

```console
$ GOFLAGS=-mod=mod go run .
--- 4-space value indent ---
input: "policy:\n  require-job-timeout:\n    max-minutes: 0\n"
error: yaml: construct errors: line 3: yaml: "max-minutes" in "require-job-timeout" must be greater than zero but got 0 at line:3,col:18
--- 3-space value indent ---
input: "policy:\n  require-job-timeout:\n   max-minutes: 0\n"
error: yaml: construct errors: line 3: yaml: "max-minutes" in "require-job-timeout" must be greater than zero but got 0 at line:3,col:17
--- 2-space value indent ---
input: "policy:\n require-job-timeout:\n  max-minutes: 0\n"
error: yaml: construct errors: line 3: yaml: "max-minutes" in "require-job-timeout" must be greater than zero but got 0 at line:3,col:16
--- flow mapping on line 3 ---
input: "policy:\n  require-job-timeout:\n    {max-minutes: 0}\n"
error: yaml: construct errors: line 3: yaml: "max-minutes" in "require-job-timeout" must be greater than zero but got 0 at line:3,col:19
--- not a number ---
input: "policy:\n  require-job-timeout:\n    max-minutes: hello\n"
error: yaml: construct errors: line 3: cannot construct !!str `hello` into float64
```

</details>

That message is not in the charter — this branch adds it, because without it a repository writing `max-minutes: 0` would think it had set a cap and would have set nothing. That is the same shape as the first defect above wearing different clothes.

<details><summary>Measured</summary>

The charter, a working document that does not live in the repository, names two error texts for this key. This one is not among them.

```console
$ grep -n "require-job-timeout" CHARTER.md
18:  require-job-timeout: true               # D3, ook toegestaan: {max-minutes: 60}
63:`RequireCommitHash` (D1) < `RequireJobTimeout` (D3) < `RequiredActions` (D2).
64:(`-` is 0x2D, `d` is 0x64, dus `require-commit-hash` < `require-job-timeout` < `required-actions`.)
75:	// RequireJobTimeout requires every job to set "timeout-minutes". Nil means the key was not set.
76:	RequireJobTimeout *JobTimeoutPolicy `yaml:"require-job-timeout"`
126:func RequireJobTimeout(maxMinutes float64) *JobTimeoutPolicy
141:- `yaml: "require-job-timeout" must be a boolean or a mapping at line:%d,col:%d`
142:- `yaml: unknown key %q in "require-job-timeout" at line:%d,col:%d`
228:#  # Require "timeout-minutes" on every job. A mapping with "max-minutes" also caps the value.
229:#  require-job-timeout: true
```

</details>

## Nineteen mutations, three of which survive

Every control this branch adds was switched off in turn, the target tests run, and the control restored. Sixteen of the nineteen mutations produced a failure. Three did not, and all three are reported rather than quietly left.

The target of every run:

```
go test -count=1 -run 'TestRuleRequireJobTimeout|TestConfigParseRequireJobTimeout|TestConfigParseRequireJobTimeoutError|TestLinterLintProject/project/require_job_timeout' .
```

<details><summary>Mutation</summary>

| # | control | mutation | exit |
| --- | --- | --- | --- |
| M01 | `if !rule.policy.Enabled()` | `if false` | 1 |
| M02 | `n.WorkflowCall != nil \|\| n.Steps == nil` | `n.Steps == nil` | 1 |
| M03 | `n.WorkflowCall != nil \|\| n.Steps == nil` | `n.WorkflowCall != nil` | 1 |
| M04 | `if n.TimeoutMinutes == nil` | `if false` | 1 |
| M05 | `n.Pos` in the missing-timeout error | `n.ID.Pos` | **0** |
| M06 | `ok &&` | `(ok \|\| !ok) &&` | 1 |
| M07 | `n.TimeoutMinutes.Expression == nil &&` | removed | 1 |
| M08 | `Value > limit` | `Value >= limit` | 1 |
| M09 | `n.TimeoutMinutes.Pos` in the over-limit error | `n.Pos` | 1 |
| M10 | `return p != nil && p.enabled` | `return p.enabled` | 1 |
| M11 | `if !p.Enabled() \|\| p.maxMinutes <= 0` | `if p.maxMinutes <= 0` | 1 |
| M12 | `p.maxMinutes <= 0` in `MaxMinutes` | `p.maxMinutes < 0` | 1 |
| M13 | `n.Decode(&p.enabled); err != nil` | `… err != nil && false` | 1 |
| M14 | `p.enabled = true` in the mapping branch | removed | 1 |
| M15 | `if k.Value != "max-minutes"` | `if false && …` | 1 |
| M16 | `p.maxMinutes <= 0` in `UnmarshalYAML` | `p.maxMinutes < 0` | 1 |
| M17 | the `default:` branch's error | `return nil` | 1 |
| M18 | `for i := 0; i+1 < len(n.Content)` in `Policy.UnmarshalYAML`, which #40 landed | `for i := 0; i < len(n.Content)` | **0** |
| M19 | the same bound in `JobTimeoutPolicy.UnmarshalYAML` | `for i := 0; i < len(n.Content)` | **0** |

M18 is not a control this branch adds. The first `perl` match landed on that loop, so the bound in `JobTimeoutPolicy.UnmarshalYAML` was run separately as M19. Both survive, and both are reported.

The whole run, with the diff, the failing subtest and the post-restore `git status` for every row:

```console
$ bash mutate.sh 2>&1 | tee mutations.log
[M01-enabled-early-return] file=rule_require_job_timeout.go
diff --git a/rule_require_job_timeout.go b/rule_require_job_timeout.go
index a1474fc..e981da0 100644
--- a/rule_require_job_timeout.go
+++ b/rule_require_job_timeout.go
@@ -25 +25 @@ func (rule *RuleRequireJobTimeout) VisitJobPre(n *Job) error {
-	if !rule.policy.Enabled() {
+	if false {
--- FAIL: TestRuleRequireJobTimeout (0.00s)
    --- FAIL: TestRuleRequireJobTimeout/no_policy (0.00s)
        rule_require_job_timeout_test.go:140: wanted 0 errors but have 1: [:4:3: "timeout-minutes" is not set in job "test". it is required because "require-job-timeout" is enabled in the "policy" configuration. a job which does not set it is cancelled after the default of 360 minutes [require-job-timeout]]
    --- FAIL: TestRuleRequireJobTimeout/policy_is_disabled (0.00s)
        rule_require_job_timeout_test.go:140: wanted 0 errors but have 1: [:4:3: "timeout-minutes" is not set in job "test". it is required because "require-job-timeout" is enabled in the "policy" configuration. a job which does not set it is cancelled after the default of 360 minutes [require-job-timeout]]
FAIL
FAIL	actionlint.kjanat.dev	0.013s
FAIL
[M01-enabled-early-return] go test exit=1
[M01-enabled-early-return] tree clean after restore: 0 modified files
[M02-drop-workflowcall-half] file=rule_require_job_timeout.go
diff --git a/rule_require_job_timeout.go b/rule_require_job_timeout.go
index a1474fc..901ad46 100644
--- a/rule_require_job_timeout.go
+++ b/rule_require_job_timeout.go
@@ -31 +31 @@ func (rule *RuleRequireJobTimeout) VisitJobPre(n *Job) error {
-	if n.WorkflowCall != nil || n.Steps == nil {
+	if n.Steps == nil {
--- FAIL: TestRuleRequireJobTimeout (0.00s)
    --- FAIL: TestRuleRequireJobTimeout/job_calls_a_reusable_workflow (0.00s)
        rule_require_job_timeout_test.go:140: wanted 0 errors but have 1: [:4:3: "timeout-minutes" is not set in job "test". it is required because "require-job-timeout" is enabled in the "policy" configuration. a job which does not set it is cancelled after the default of 360 minutes [require-job-timeout]]
FAIL
FAIL	actionlint.kjanat.dev	0.011s
FAIL
[M02-drop-workflowcall-half] go test exit=1
[M02-drop-workflowcall-half] tree clean after restore: 0 modified files
[M03-drop-steps-half] file=rule_require_job_timeout.go
diff --git a/rule_require_job_timeout.go b/rule_require_job_timeout.go
index a1474fc..ab8b607 100644
--- a/rule_require_job_timeout.go
+++ b/rule_require_job_timeout.go
@@ -31 +31 @@ func (rule *RuleRequireJobTimeout) VisitJobPre(n *Job) error {
-	if n.WorkflowCall != nil || n.Steps == nil {
+	if n.WorkflowCall != nil {
--- FAIL: TestRuleRequireJobTimeout (0.00s)
    --- FAIL: TestRuleRequireJobTimeout/job_has_no_steps (0.00s)
        rule_require_job_timeout_test.go:140: wanted 0 errors but have 1: [:4:3: "timeout-minutes" is not set in job "test". it is required because "require-job-timeout" is enabled in the "policy" configuration. a job which does not set it is cancelled after the default of 360 minutes [require-job-timeout]]
FAIL
FAIL	actionlint.kjanat.dev	0.015s
FAIL
[M03-drop-steps-half] go test exit=1
[M03-drop-steps-half] tree clean after restore: 0 modified files
[M04-drop-missing-check] file=rule_require_job_timeout.go
diff --git a/rule_require_job_timeout.go b/rule_require_job_timeout.go
index a1474fc..0677d95 100644
--- a/rule_require_job_timeout.go
+++ b/rule_require_job_timeout.go
@@ -35 +35 @@ func (rule *RuleRequireJobTimeout) VisitJobPre(n *Job) error {
-	if n.TimeoutMinutes == nil {
+	if false {
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x77485a]

goroutine 68 [running]:
actionlint%2ekjanat%2edev.(*RuleRequireJobTimeout).VisitJobPre(0x40e2bd6cdc0?, 0x40e2bd9c540?)
	/home/kjanat/projects/actionlint/.worktrees/require-job-timeout/rule_require_job_timeout.go:46 +0x7a
actionlint%2ekjanat%2edev.(*Visitor).visitJob(0x40e2bf13d90, 0x40e2bd9c540)
	/home/kjanat/projects/actionlint/.worktrees/require-job-timeout/pass.go:98 +0xc8
actionlint%2ekjanat%2edev.(*Visitor).Visit(0x40e2bf13d90, 0x40e2bd6c9b0)
	/home/kjanat/projects/actionlint/.worktrees/require-job-timeout/pass.go:68 +0x177
actionlint%2ekjanat%2edev.(*Linter).check(0x40e2bd9c480, {0x40e2c03aba6, 0x13}, {0x40e2c01a000, 0x350, 0x351}, 0x40e2bd68450, 0x40e2bfeda70, 0x40e2c3c2240, 0x40e2bd6c8c0)
	/home/kjanat/projects/actionlint/.worktrees/require-job-timeout/linter.go:636 +0x163c
actionlint%2ekjanat%2edev.(*Linter).LintFiles.func1()
	/home/kjanat/projects/actionlint/.worktrees/require-job-timeout/linter.go:389 +0x19c
golang.org/x/sync/errgroup.(*Group).Go.func1()
	/home/kjanat/go/pkg/mod/golang.org/x/sync@v0.22.0/errgroup/errgroup.go:93 +0x50
created by golang.org/x/sync/errgroup.(*Group).Go in goroutine 66
	/home/kjanat/go/pkg/mod/golang.org/x/sync@v0.22.0/errgroup/errgroup.go:78 +0x95
FAIL	actionlint.kjanat.dev	0.012s
FAIL
[M04-drop-missing-check] go test exit=1
[M04-drop-missing-check] tree clean after restore: 0 modified files
[M05-missing-error-position] file=rule_require_job_timeout.go
diff --git a/rule_require_job_timeout.go b/rule_require_job_timeout.go
index a1474fc..bdd5bda 100644
--- a/rule_require_job_timeout.go
+++ b/rule_require_job_timeout.go
@@ -37 +37 @@ func (rule *RuleRequireJobTimeout) VisitJobPre(n *Job) error {
-			n.Pos,
+			n.ID.Pos,
ok  	actionlint.kjanat.dev	0.011s
[M05-missing-error-position] go test exit=0
[M05-missing-error-position] tree clean after restore: 0 modified files
[M06-drop-ok] file=rule_require_job_timeout.go
diff --git a/rule_require_job_timeout.go b/rule_require_job_timeout.go
index a1474fc..b58b13e 100644
--- a/rule_require_job_timeout.go
+++ b/rule_require_job_timeout.go
@@ -46 +46 @@ func (rule *RuleRequireJobTimeout) VisitJobPre(n *Job) error {
-	if ok && n.TimeoutMinutes.Expression == nil && n.TimeoutMinutes.Value > limit {
+	if (ok || !ok) && n.TimeoutMinutes.Expression == nil && n.TimeoutMinutes.Value > limit {
--- FAIL: TestRuleRequireJobTimeout (0.00s)
    --- FAIL: TestRuleRequireJobTimeout/timeout_is_set (0.00s)
        rule_require_job_timeout_test.go:140: wanted 0 errors but have 1: [:6:22: "timeout-minutes" is 45 in job "test". it must not be larger than 0 because "max-minutes" of "require-job-timeout" is set in the "policy" configuration [require-job-timeout]]
    --- FAIL: TestRuleRequireJobTimeout/no_maximum_is_configured (0.00s)
        rule_require_job_timeout_test.go:140: wanted 0 errors but have 1: [:6:22: "timeout-minutes" is 4320 in job "test". it must not be larger than 0 because "max-minutes" of "require-job-timeout" is set in the "policy" configuration [require-job-timeout]]
FAIL
FAIL	actionlint.kjanat.dev	0.012s
FAIL
[M06-drop-ok] go test exit=1
[M06-drop-ok] tree clean after restore: 0 modified files
[M07-drop-expression-guard] file=rule_require_job_timeout.go
diff --git a/rule_require_job_timeout.go b/rule_require_job_timeout.go
index a1474fc..a0e23c8 100644
--- a/rule_require_job_timeout.go
+++ b/rule_require_job_timeout.go
@@ -46 +46 @@ func (rule *RuleRequireJobTimeout) VisitJobPre(n *Job) error {
-	if ok && n.TimeoutMinutes.Expression == nil && n.TimeoutMinutes.Value > limit {
+	if ok && n.TimeoutMinutes.Value > limit {
--- FAIL: TestRuleRequireJobTimeout (0.00s)
    --- FAIL: TestRuleRequireJobTimeout/timeout_is_an_expression (0.00s)
        rule_require_job_timeout_test.go:140: wanted 0 errors but have 1: [:6:22: "timeout-minutes" is 45 in job "test". it must not be larger than 30 because "max-minutes" of "require-job-timeout" is set in the "policy" configuration [require-job-timeout]]
FAIL
FAIL	actionlint.kjanat.dev	0.011s
FAIL
[M07-drop-expression-guard] go test exit=1
[M07-drop-expression-guard] tree clean after restore: 0 modified files
[M08-gt-to-gte] file=rule_require_job_timeout.go
diff --git a/rule_require_job_timeout.go b/rule_require_job_timeout.go
index a1474fc..7b59f7a 100644
--- a/rule_require_job_timeout.go
+++ b/rule_require_job_timeout.go
@@ -46 +46 @@ func (rule *RuleRequireJobTimeout) VisitJobPre(n *Job) error {
-	if ok && n.TimeoutMinutes.Expression == nil && n.TimeoutMinutes.Value > limit {
+	if ok && n.TimeoutMinutes.Expression == nil && n.TimeoutMinutes.Value >= limit {
--- FAIL: TestLinterLintProject (0.00s)
    --- FAIL: TestLinterLintProject/project/require_job_timeout (0.00s)
        linter_test.go:326: Linting project at testdata/projects/require_job_timeout
        linter_test.go:346: Checking 3 errors with "testdata/projects/require_job_timeout.out"
        linter_test.go:346:   Error[0]: workflows/test.yaml:5:3: "timeout-minutes" is not set in job "missing". it is required because "require-job-timeout" is enabled in the "policy" configuration. a job which does not set it is cancelled after the default of 360 minutes [require-job-timeout]
        linter_test.go:346:   Error[1]: workflows/test.yaml:18:22: "timeout-minutes" is 30 in job "edge". it must not be larger than 30 because "max-minutes" of "require-job-timeout" is set in the "policy" configuration [require-job-timeout]
        linter_test.go:346:   Error[2]: workflows/test.yaml:24:22: "timeout-minutes" is 45 in job "too-long". it must not be larger than 30 because "max-minutes" of "require-job-timeout" is set in the "policy" configuration [require-job-timeout]
        linter_test.go:346: 2 errors are expected but actually got 3 errors:
            workflows/test.yaml:5:3: "timeout-minutes" is not set in job "missing". it is required because "require-job-timeout" is enabled in the "policy" configuration. a job which does not set it is cancelled after the default of 360 minutes [require-job-timeout]
            workflows/test.yaml:18:22: "timeout-minutes" is 30 in job "edge". it must not be larger than 30 because "max-minutes" of "require-job-timeout" is set in the "policy" configuration [require-job-timeout]
            workflows/test.yaml:24:22: "timeout-minutes" is 45 in job "too-long". it must not be larger than 30 because "max-minutes" of "require-job-timeout" is set in the "policy" configuration [require-job-timeout]
--- FAIL: TestRuleRequireJobTimeout (0.00s)
    --- FAIL: TestRuleRequireJobTimeout/timeout_is_equal_to_the_maximum (0.00s)
        rule_require_job_timeout_test.go:140: wanted 0 errors but have 1: [:6:22: "timeout-minutes" is 30 in job "test". it must not be larger than 30 because "max-minutes" of "require-job-timeout" is set in the "policy" configuration [require-job-timeout]]
FAIL
FAIL	actionlint.kjanat.dev	0.011s
FAIL
[M08-gt-to-gte] go test exit=1
[M08-gt-to-gte] tree clean after restore: 0 modified files
[M09-over-error-position] file=rule_require_job_timeout.go
diff --git a/rule_require_job_timeout.go b/rule_require_job_timeout.go
index a1474fc..e2570ca 100644
--- a/rule_require_job_timeout.go
+++ b/rule_require_job_timeout.go
@@ -48 +48 @@ func (rule *RuleRequireJobTimeout) VisitJobPre(n *Job) error {
-			n.TimeoutMinutes.Pos,
+			n.Pos,
--- FAIL: TestLinterLintProject (0.00s)
    --- FAIL: TestLinterLintProject/project/require_job_timeout (0.00s)
        linter_test.go:326: Linting project at testdata/projects/require_job_timeout
        linter_test.go:346: Checking 2 errors with "testdata/projects/require_job_timeout.out"
        linter_test.go:346:   Error[0]: workflows/test.yaml:5:3: "timeout-minutes" is not set in job "missing". it is required because "require-job-timeout" is enabled in the "policy" configuration. a job which does not set it is cancelled after the default of 360 minutes [require-job-timeout]
        linter_test.go:346:   Error[1]: workflows/test.yaml:22:3: "timeout-minutes" is 45 in job "too-long". it must not be larger than 30 because "max-minutes" of "require-job-timeout" is set in the "policy" configuration [require-job-timeout]
        linter_test.go:346: error message mismatch at 2th error does not match exactly
              want: "workflows/test.yaml:24:22: \"timeout-minutes\" is 45 in job \"too-long\". it must not be larger than 30 because \"max-minutes\" of \"require-job-timeout\" is set in the \"policy\" configuration [require-job-timeout]"
              have: "workflows/test.yaml:22:3: \"timeout-minutes\" is 45 in job \"too-long\". it must not be larger than 30 because \"max-minutes\" of \"require-job-timeout\" is set in the \"policy\" configuration [require-job-timeout]"
--- FAIL: TestRuleRequireJobTimeout (0.00s)
    --- FAIL: TestRuleRequireJobTimeout/timeout_is_above_the_maximum (0.00s)
        rule_require_job_timeout_test.go:144: wanted error ":6:22: \"timeout-minutes\" is 45 in job \"test\". it must not be larger than 30 because \"max-minutes\" of \"require-job-timeout\" is set in the \"policy\" configuration [require-job-timeout]" but have ":4:3: \"timeout-minutes\" is 45 in job \"test\". it must not be larger than 30 because \"max-minutes\" of \"require-job-timeout\" is set in the \"policy\" configuration [require-job-timeout]"
    --- FAIL: TestRuleRequireJobTimeout/maximum_is_a_fraction (0.00s)
        rule_require_job_timeout_test.go:144: wanted error ":6:22: \"timeout-minutes\" is 45 in job \"test\". it must not be larger than 30.5 because \"max-minutes\" of \"require-job-timeout\" is set in the \"policy\" configuration [require-job-timeout]" but have ":4:3: \"timeout-minutes\" is 45 in job \"test\". it must not be larger than 30.5 because \"max-minutes\" of \"require-job-timeout\" is set in the \"policy\" configuration [require-job-timeout]"
FAIL
FAIL	actionlint.kjanat.dev	0.011s
FAIL
[M09-over-error-position] go test exit=1
[M09-over-error-position] tree clean after restore: 0 modified files
[M10-enabled-drop-nil-check] file=config.go
diff --git a/config.go b/config.go
index b5eb3b0..a47653f 100644
--- a/config.go
+++ b/config.go
@@ -104 +104 @@ func (p *JobTimeoutPolicy) Enabled() bool {
-	return p != nil && p.enabled
+	return p.enabled
--- FAIL: TestConfigParseRequireJobTimeout (0.00s)
    --- FAIL: TestConfigParseRequireJobTimeout/key_is_not_set (0.00s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered, repanicked]
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x78446b]

goroutine 9 [running]:
testing.tRunner.func1.2({0x83ae40, 0xbf9570})
	/usr/lib/go/src/testing/testing.go:1974 +0x232
testing.tRunner.func1()
	/usr/lib/go/src/testing/testing.go:1977 +0x349
panic({0x83ae40?, 0xbf9570?})
	/usr/lib/go/src/runtime/panic.go:860 +0x13a
actionlint%2ekjanat%2edev.(*JobTimeoutPolicy).Enabled(...)
	/home/kjanat/projects/actionlint/.worktrees/require-job-timeout/config.go:104
actionlint%2ekjanat%2edev.TestConfigParseRequireJobTimeout.func1(0x2530d097b448)
	/home/kjanat/projects/actionlint/.worktrees/require-job-timeout/config_test.go:481 +0x12b
testing.tRunner(0x2530d097b448, 0x2530d086b200)
	/usr/lib/go/src/testing/testing.go:2036 +0xea
created by testing.(*T).Run in goroutine 8
	/usr/lib/go/src/testing/testing.go:2101 +0x4c5
FAIL	actionlint.kjanat.dev	0.007s
FAIL
[M10-enabled-drop-nil-check] go test exit=1
[M10-enabled-drop-nil-check] tree clean after restore: 0 modified files
[M11-maxminutes-drop-enabled] file=config.go
diff --git a/config.go b/config.go
index b5eb3b0..ac2c0c6 100644
--- a/config.go
+++ b/config.go
@@ -110 +110 @@ func (p *JobTimeoutPolicy) MaxMinutes() (float64, bool) {
-	if !p.Enabled() || p.maxMinutes <= 0 {
+	if p.maxMinutes <= 0 {
--- FAIL: TestConfigParseRequireJobTimeout (0.00s)
    --- FAIL: TestConfigParseRequireJobTimeout/key_is_not_set (0.00s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered, repanicked]
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x7844fc]

goroutine 9 [running]:
testing.tRunner.func1.2({0x83ae40, 0xbf9570})
	/usr/lib/go/src/testing/testing.go:1974 +0x232
testing.tRunner.func1()
	/usr/lib/go/src/testing/testing.go:1977 +0x349
panic({0x83ae40?, 0xbf9570?})
	/usr/lib/go/src/runtime/panic.go:860 +0x13a
actionlint%2ekjanat%2edev.(*JobTimeoutPolicy).MaxMinutes(...)
	/home/kjanat/projects/actionlint/.worktrees/require-job-timeout/config.go:110
actionlint%2ekjanat%2edev.TestConfigParseRequireJobTimeout.func1(0x3d1cecefd448)
	/home/kjanat/projects/actionlint/.worktrees/require-job-timeout/config_test.go:484 +0x1dc
testing.tRunner(0x3d1cecefd448, 0x3d1cecded200)
	/usr/lib/go/src/testing/testing.go:2036 +0xea
created by testing.(*T).Run in goroutine 8
	/usr/lib/go/src/testing/testing.go:2101 +0x4c5
FAIL	actionlint.kjanat.dev	0.007s
FAIL
[M11-maxminutes-drop-enabled] go test exit=1
[M11-maxminutes-drop-enabled] tree clean after restore: 0 modified files
[M12-maxminutes-le-to-lt] file=config.go
diff --git a/config.go b/config.go
index b5eb3b0..7b4aafd 100644
--- a/config.go
+++ b/config.go
@@ -110 +110 @@ func (p *JobTimeoutPolicy) MaxMinutes() (float64, bool) {
-	if !p.Enabled() || p.maxMinutes <= 0 {
+	if !p.Enabled() || p.maxMinutes < 0 {
--- FAIL: TestConfigParseRequireJobTimeout (0.00s)
    --- FAIL: TestConfigParseRequireJobTimeout/key_is_true (0.00s)
        config_test.go:486: MaxMinutes() is (0, true) but wanted (0, false)
    --- FAIL: TestConfigParseRequireJobTimeout/key_is_an_empty_mapping (0.00s)
        config_test.go:486: MaxMinutes() is (0, true) but wanted (0, false)
--- FAIL: TestRuleRequireJobTimeout (0.00s)
    --- FAIL: TestRuleRequireJobTimeout/timeout_is_set (0.00s)
        rule_require_job_timeout_test.go:140: wanted 0 errors but have 1: [:6:22: "timeout-minutes" is 45 in job "test". it must not be larger than 0 because "max-minutes" of "require-job-timeout" is set in the "policy" configuration [require-job-timeout]]
    --- FAIL: TestRuleRequireJobTimeout/no_maximum_is_configured (0.00s)
        rule_require_job_timeout_test.go:140: wanted 0 errors but have 1: [:6:22: "timeout-minutes" is 4320 in job "test". it must not be larger than 0 because "max-minutes" of "require-job-timeout" is set in the "policy" configuration [require-job-timeout]]
FAIL
FAIL	actionlint.kjanat.dev	0.011s
FAIL
[M12-maxminutes-le-to-lt] go test exit=1
[M12-maxminutes-le-to-lt] tree clean after restore: 0 modified files
[M13-scalar-decode-error] file=config.go
diff --git a/config.go b/config.go
index b5eb3b0..328a414 100644
--- a/config.go
+++ b/config.go
@@ -120 +120 @@ func (p *JobTimeoutPolicy) UnmarshalYAML(n *yaml.Node) error {
-		if err := n.Decode(&p.enabled); err != nil {
+		if err := n.Decode(&p.enabled); err != nil && false {
--- FAIL: TestConfigParseRequireJobTimeoutError (0.00s)
    --- FAIL: TestConfigParseRequireJobTimeoutError/value_is_a_number (0.00s)
        config_test.go:542: no error occurred
    --- FAIL: TestConfigParseRequireJobTimeoutError/value_is_a_string (0.00s)
        config_test.go:542: no error occurred
FAIL
FAIL	actionlint.kjanat.dev	0.011s
FAIL
[M13-scalar-decode-error] go test exit=1
[M13-scalar-decode-error] tree clean after restore: 0 modified files
[M14-mapping-sets-enabled] file=config.go
diff --git a/config.go b/config.go
index b5eb3b0..97fc25c 100644
--- a/config.go
+++ b/config.go
@@ -124 +124 @@ func (p *JobTimeoutPolicy) UnmarshalYAML(n *yaml.Node) error {
-		p.enabled = true
+		_ = 0
--- FAIL: TestConfigParseRequireJobTimeout (0.00s)
    --- FAIL: TestConfigParseRequireJobTimeout/key_is_an_empty_mapping (0.00s)
        config_test.go:482: Enabled() is false but wanted true
    --- FAIL: TestConfigParseRequireJobTimeout/mapping_sets_max-minutes (0.00s)
        config_test.go:482: Enabled() is false but wanted true
    --- FAIL: TestConfigParseRequireJobTimeout/max-minutes_is_a_fraction (0.00s)
        config_test.go:482: Enabled() is false but wanted true
--- FAIL: TestLinterLintProject (0.00s)
    --- FAIL: TestLinterLintProject/project/require_job_timeout (0.00s)
        linter_test.go:326: Linting project at testdata/projects/require_job_timeout
        linter_test.go:346: Checking 0 errors with "testdata/projects/require_job_timeout.out"
        linter_test.go:346: 2 errors are expected but actually got 0 errors:
FAIL
FAIL	actionlint.kjanat.dev	0.011s
FAIL
[M14-mapping-sets-enabled] go test exit=1
[M14-mapping-sets-enabled] tree clean after restore: 0 modified files
[M15-unknown-key-check] file=config.go
diff --git a/config.go b/config.go
index b5eb3b0..01d2353 100644
--- a/config.go
+++ b/config.go
@@ -127 +127 @@ func (p *JobTimeoutPolicy) UnmarshalYAML(n *yaml.Node) error {
-			if k.Value != "max-minutes" {
+			if false && k.Value != "max-minutes" {
--- FAIL: TestConfigParseRequireJobTimeoutError (0.00s)
    --- FAIL: TestConfigParseRequireJobTimeoutError/unknown_key_in_the_mapping (0.00s)
        config_test.go:542: no error occurred
FAIL
FAIL	actionlint.kjanat.dev	0.012s
FAIL
[M15-unknown-key-check] go test exit=1
[M15-unknown-key-check] tree clean after restore: 0 modified files
[M16-zero-max-check] file=config.go
diff --git a/config.go b/config.go
index b5eb3b0..62107dc 100644
--- a/config.go
+++ b/config.go
@@ -133 +133 @@ func (p *JobTimeoutPolicy) UnmarshalYAML(n *yaml.Node) error {
-			if p.maxMinutes <= 0 {
+			if p.maxMinutes < 0 {
--- FAIL: TestConfigParseRequireJobTimeoutError (0.00s)
    --- FAIL: TestConfigParseRequireJobTimeoutError/max-minutes_is_zero (0.00s)
        config_test.go:542: no error occurred
FAIL
FAIL	actionlint.kjanat.dev	0.011s
FAIL
[M16-zero-max-check] go test exit=1
[M16-zero-max-check] tree clean after restore: 0 modified files
[M17-default-case] file=config.go
diff --git a/config.go b/config.go
index b5eb3b0..93a67d4 100644
--- a/config.go
+++ b/config.go
@@ -138 +138 @@ func (p *JobTimeoutPolicy) UnmarshalYAML(n *yaml.Node) error {
-		return fmt.Errorf("yaml: \"require-job-timeout\" must be a boolean or a mapping at line:%d,col:%d", n.Line, n.Column)
+		return nil
--- FAIL: TestConfigParseRequireJobTimeoutError (0.00s)
    --- FAIL: TestConfigParseRequireJobTimeoutError/value_is_a_sequence (0.00s)
        config_test.go:542: no error occurred
FAIL
FAIL	actionlint.kjanat.dev	0.011s
FAIL
[M17-default-case] go test exit=1
[M17-default-case] tree clean after restore: 0 modified files
[M18-loop-bound] file=config.go
diff --git a/config.go b/config.go
index b5eb3b0..fe3dadd 100644
--- a/config.go
+++ b/config.go
@@ -70 +70 @@ func (p *Policy) UnmarshalYAML(n *yaml.Node) error {
-	for i := 0; i+1 < len(n.Content); i += 2 {
+	for i := 0; i < len(n.Content); i += 2 {
ok  	actionlint.kjanat.dev	0.011s
[M18-loop-bound] go test exit=0
[M18-loop-bound] tree clean after restore: 0 modified files
```

M19, the bound in `JobTimeoutPolicy.UnmarshalYAML`, was run separately because the expression above matched `Policy.UnmarshalYAML` first:

```console
$ perl -0pi -e 's/for i := 0; i\+1 < len\(n\.Content\); i \+= 2 \{\n\t\t\tk, v := n\.Content\[i\], n\.Content\[i\+1\]/for i := 0; i < len(n.Content); i += 2 {\n\t\t\tk, v := n.Content[i], n.Content[i+1]/' config.go
$ git --no-pager diff --unified=0 -- config.go
diff --git a/config.go b/config.go
index b5eb3b0..447e6fa 100644
--- a/config.go
+++ b/config.go
@@ -125 +125 @@ func (p *JobTimeoutPolicy) UnmarshalYAML(n *yaml.Node) error {
-		for i := 0; i+1 < len(n.Content); i += 2 {
+		for i := 0; i < len(n.Content); i += 2 {
$ go test -count=1 -run 'TestRuleRequireJobTimeout|TestConfigParseRequireJobTimeout|TestConfigParseRequireJobTimeoutError|TestLinterLintProject/project/require_job_timeout' .
ok  	actionlint.kjanat.dev	0.012s
```

</details>

**The position of the missing-timeout error is unguarded (M05).** `parse.go:1571` is `ret := &Job{ID: id, Pos: id.Pos}`, so `n.Pos` and `n.ID.Pos` are the same value and there is no behaviour to test. No artificial difference was invented to make a test pass.

<details><summary>Measured</summary>

```console
$ awk 'NR>=1569 && NR<=1572 {printf "%d\t%s\n", NR, $0}' parse.go
1569	// https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#jobsjob_id
1570	func (p *parser) parseJob(id *String, n *yaml.Node) *Job {
1571		ret := &Job{ID: id, Pos: id.Pos}
1572		call := &WorkflowCall{}
```

</details>

**The loop bound in `JobTimeoutPolicy.UnmarshalYAML` is unguarded (M19).** A `yaml.MappingNode` always carries an even number of `Content` entries, so `i+1 < len(n.Content)` and `i < len(n.Content)` cannot differ for a node the composer produced. It is a defensive bound, and the same bound in `Policy.UnmarshalYAML`, which #40 landed, survives the same mutation.

**The `WorkflowCall != nil` half of the guard was decoration until the test row changed.** The cause runs deep: `parse.go:1624` sets a steps-only key for `steps`, and `parse.go:1699-1709` sets `WorkflowCall` only when no such key was seen, so in a parsed AST `WorkflowCall != nil` always implies `Steps == nil`. With the row carrying `Steps: nil`, as the specification wrote it, M02 passes. The row now carries non-nil `Steps`, and M02 fails.

<details><summary>Measured</summary>

```console
$ awk 'NR>=1622 && NR<=1630 {printf "%d\t%s\n", NR, $0}' parse.go
1622		case "if":
1623			ret.If = p.parseString(v, false)
1624		case "steps":
1625			ret.Steps = p.parseSteps(v)
1626			stepsOnlyKey = k
1627		case "timeout-minutes":
1628			ret.TimeoutMinutes = p.parseTimeoutMinutes(v)
1629			stepsOnlyKey = k

$ awk 'NR>=1699 && NR<=1710 {printf "%d\t%s\n", NR, $0}' parse.go
1699		if call.Uses != nil {
1700			if stepsOnlyKey != nil {
1701				p.errorfAt(
1702					stepsOnlyKey.Pos,
1703					"when a reusable workflow is called with \"uses\", %q is not available. only following keys are allowed: \"name\", \"uses\", \"with\", \"secrets\", \"needs\", \"if\", and \"permissions\" in job %q",
1704					stepsOnlyKey.Value,
1705					id.Value,
1706				)
1707			} else {
1708				ret.WorkflowCall = call
1709			}
1710		} else {
```

</details>

<details><summary>Before the fix</summary>

With `Steps: nil` on the call-job row, as the specification described it, M02 survives:

```console
$ perl -ni -e 'print unless $. == 108' rule_require_job_timeout_test.go
$ perl -0pi -e 's/if n\.WorkflowCall != nil \|\| n\.Steps == nil \{/if n.Steps == nil {/' rule_require_job_timeout.go
$ git --no-pager diff --unified=2 -- rule_require_job_timeout_test.go rule_require_job_timeout.go
diff --git a/rule_require_job_timeout.go b/rule_require_job_timeout.go
index a1474fc..901ad46 100644
--- a/rule_require_job_timeout.go
+++ b/rule_require_job_timeout.go
@@ -29,5 +29,5 @@ func (rule *RuleRequireJobTimeout) VisitJobPre(n *Job) error {
 	// A job which calls a reusable workflow cannot set "timeout-minutes:".
 	// https://docs.github.com/en/actions/reference/workflows-and-actions/reusing-workflow-configurations#supported-keywords-for-jobs-that-call-a-reusable-workflow
-	if n.WorkflowCall != nil || n.Steps == nil {
+	if n.Steps == nil {
 		return nil
 	}
diff --git a/rule_require_job_timeout_test.go b/rule_require_job_timeout_test.go
index 38cecc9..7c68931 100644
--- a/rule_require_job_timeout_test.go
+++ b/rule_require_job_timeout_test.go
@@ -106,5 +106,4 @@ func TestRuleRequireJobTimeout(t *testing.T) {
 					Uses: &String{Value: "./.github/workflows/ci.yaml", Pos: &Pos{Line: 5, Col: 11}},
 				},
-				Steps: []*Step{{Pos: &Pos{Line: 7, Col: 7}}},
 				Pos:   jobPos,
 			},

$ go test -count=1 -run 'TestRuleRequireJobTimeout' .
ok  	actionlint.kjanat.dev	0.004s
```

With the row as it now stands, the same mutation falls over:

```console
$ go test -count=1 -run 'TestRuleRequireJobTimeout' .
--- FAIL: TestRuleRequireJobTimeout (0.00s)
    --- FAIL: TestRuleRequireJobTimeout/job_calls_a_reusable_workflow (0.00s)
        rule_require_job_timeout_test.go:140: wanted 0 errors but have 1: [:4:3: "timeout-minutes" is not set in job "test". it is required because "require-job-timeout" is enabled in the "policy" configuration. a job which does not set it is cancelled after the default of 360 minutes [require-job-timeout]]
FAIL
FAIL	actionlint.kjanat.dev	0.004s
FAIL
```

</details>

**The `Expression == nil` check was decoration until the test row changed.** `parse.go:413-422` returns a `Float` that carries only `Expression` and `Pos`, so `Value` stays at zero, and `max-minutes` must exceed zero, so `Value > limit` is never true for a value written with `${{ }}`. With `Value: 0` on the row, mirroring what the parser produces, M07 passes. The row now reads `&Float{Value: 45, Expression: …}`, and M07 fails.

<details><summary>Measured</summary>

```console
$ awk 'NR>=407 && NR<=422 {printf "%d\t%s\n", NR, $0}' parse.go
407	func (p *parser) parseFloat(n *yaml.Node) *Float {
408		if n.Kind != yaml.ScalarNode || (n.Tag != "!!float" && n.Tag != "!!int" && n.Tag != "!!str") {
409			p.errorf(n, "expected scalar node for float value but found %s node with %q tag", nodeKindName(n.Kind), n.Tag)
410			return nil
411		}
412	
413		if n.Tag == "!!str" {
414			e := p.parseExpression(n, "float number literal")
415			if e == nil {
416				return nil
417			}
418			return &Float{
419				Expression: e,
420				Pos:        posAt(n),
421			}
422		}
```

</details>

<details><summary>Before the fix</summary>

```console
$ perl -0pi -e 's/\t\t\t\tValue:      45,\n/\t\t\t\tValue:      0,\n/' rule_require_job_timeout_test.go
$ perl -0pi -e 's/n\.TimeoutMinutes\.Expression == nil && n\.TimeoutMinutes\.Value > limit/n.TimeoutMinutes.Value > limit/' rule_require_job_timeout.go
$ git --no-pager diff --unified=2 -- rule_require_job_timeout_test.go rule_require_job_timeout.go
diff --git a/rule_require_job_timeout.go b/rule_require_job_timeout.go
index a1474fc..a0e23c8 100644
--- a/rule_require_job_timeout.go
+++ b/rule_require_job_timeout.go
@@ -44,5 +44,5 @@ func (rule *RuleRequireJobTimeout) VisitJobPre(n *Job) error {
 
 	limit, ok := rule.policy.MaxMinutes()
-	if ok && n.TimeoutMinutes.Expression == nil && n.TimeoutMinutes.Value > limit {
+	if ok && n.TimeoutMinutes.Value > limit {
 		rule.Errorf(
 			n.TimeoutMinutes.Pos,
diff --git a/rule_require_job_timeout_test.go b/rule_require_job_timeout_test.go
index 38cecc9..b7fcc81 100644
--- a/rule_require_job_timeout_test.go
+++ b/rule_require_job_timeout_test.go
@@ -93,5 +93,5 @@ func TestRuleRequireJobTimeout(t *testing.T) {
 			policy: RequireJobTimeout(30),
 			job: newJob(&Float{
-				Value:      45,
+				Value:      0,
 				Expression: &String{Value: "matrix.timeout", Pos: valuePos},
 				Pos:        valuePos,

$ go test -count=1 -run 'TestRuleRequireJobTimeout' .
ok  	actionlint.kjanat.dev	0.004s
```

</details>

The project fixture, which goes through the parser, passes with M02, M03 and M07 applied. Only the unit-test rows hold those three guards.

<details><summary>Measured</summary>

```console
$ go test -count=1 -run 'TestLinterLintProject/project/require_job_timeout' .
ok  	actionlint.kjanat.dev	0.005s
```

</details>

One further control was deleted for doing nothing: `RequireJobTimeout` clamped a negative maximum to zero while `MaxMinutes()` already rejects anything `<= 0`. M12 turns that rejection into `< 0` and four subtests fall over.

<details><summary>Mutation</summary>

```console
$ git --no-pager diff --unified=0 -- config.go
@@ -110 +110 @@ func (p *JobTimeoutPolicy) MaxMinutes() (float64, bool) {
-	if !p.Enabled() || p.maxMinutes <= 0 {
+	if !p.Enabled() || p.maxMinutes < 0 {
$ go test -count=1 -run 'TestRuleRequireJobTimeout|TestConfigParseRequireJobTimeout|TestConfigParseRequireJobTimeoutError|TestLinterLintProject/project/require_job_timeout' .
--- FAIL: TestConfigParseRequireJobTimeout (0.00s)
    --- FAIL: TestConfigParseRequireJobTimeout/key_is_true (0.00s)
        config_test.go:486: MaxMinutes() is (0, true) but wanted (0, false)
    --- FAIL: TestConfigParseRequireJobTimeout/key_is_an_empty_mapping (0.00s)
        config_test.go:486: MaxMinutes() is (0, true) but wanted (0, false)
--- FAIL: TestRuleRequireJobTimeout (0.00s)
    --- FAIL: TestRuleRequireJobTimeout/timeout_is_set (0.00s)
        rule_require_job_timeout_test.go:140: wanted 0 errors but have 1: [:6:22: "timeout-minutes" is 45 in job "test". it must not be larger than 0 because "max-minutes" of "require-job-timeout" is set in the "policy" configuration [require-job-timeout]]
    --- FAIL: TestRuleRequireJobTimeout/no_maximum_is_configured (0.00s)
        rule_require_job_timeout_test.go:140: wanted 0 errors but have 1: [:6:22: "timeout-minutes" is 4320 in job "test". it must not be larger than 0 because "max-minutes" of "require-job-timeout" is set in the "policy" configuration [require-job-timeout]]
FAIL
FAIL	actionlint.kjanat.dev	0.011s
FAIL
```

</details>

## The state table, in full

| YAML | result |
| --- | --- |
| key absent, or `null` | not set, inherits |
| `false` | explicitly off |
| `true` | on, no cap |
| `{}` | same as `true` |
| `{max-minutes: 60}` | on, capped at 60 |

<details><summary>Measured</summary>

```console
$ GOFLAGS=-mod=mod go run .
--- key absent ---
input: "policy: {}\n"
policy set: false; Enabled(): false; MaxMinutes(): (0, false)
--- key null ---
input: "policy:\n  require-job-timeout:\n"
policy set: false; Enabled(): false; MaxMinutes(): (0, false)
--- key explicit null ---
input: "policy:\n  require-job-timeout: null\n"
policy set: false; Enabled(): false; MaxMinutes(): (0, false)
--- key ~ ---
input: "policy:\n  require-job-timeout: ~\n"
policy set: false; Enabled(): false; MaxMinutes(): (0, false)
--- false ---
input: "policy:\n  require-job-timeout: false\n"
policy set: true; Enabled(): false; MaxMinutes(): (0, false)
--- true ---
input: "policy:\n  require-job-timeout: true\n"
policy set: true; Enabled(): true; MaxMinutes(): (0, false)
--- empty mapping ---
input: "policy:\n  require-job-timeout: {}\n"
policy set: true; Enabled(): true; MaxMinutes(): (0, false)
--- max-minutes 60 ---
input: "policy:\n  require-job-timeout:\n    max-minutes: 60\n"
policy set: true; Enabled(): true; MaxMinutes(): (60, true)
```

</details>

`null` never reaches `UnmarshalYAML` at all: `internal/libyaml/constructor.go:866-869` returns from `prepare()` on a null tag before the unmarshaler is dispatched, and `constructNull` then nils the pointer.

<details><summary>Measured</summary>

```console
$ awk 'NR>=859 && NR<=899 {printf "%d\t%s\n", NR, $0}' "$(go env GOMODCACHE)/go.yaml.in/yaml/v4@v4.0.0-rc.6/internal/libyaml/constructor.go"
859	// prepare initializes and dereferences pointers and calls UnmarshalYAML
860	// if a value is found to implement it.
861	// It returns the initialized and dereferenced out value, whether
862	// construction was already done by UnmarshalYAML, and if so whether
863	// its types constructed appropriately.
864	//
865	// If n holds a null value, prepare returns before doing anything.
866	func (c *Constructor) prepare(n *Node, out reflect.Value) (newout reflect.Value, constructed, good bool) {
867		if n.ShortTag() == nullTag {
868			return out, false, false
869		}
870		again := true
871		for again {
872			again = false
873			if out.Kind() == reflect.Pointer {
874				if out.IsNil() {
875					out.Set(reflect.New(out.Type().Elem()))
876				}
877				out = out.Elem()
878				again = true
879			}
880			if out.CanAddr() {
881				// Try yaml.Unmarshaler (from root package) first
882				if called, good := c.tryCallYAMLConstructor(n, out); called {
883					return out, true, good
884				}
885	
886				outi := out.Addr().Interface()
887				// Check for libyaml.constructor
888				if u, ok := outi.(constructor); ok {
889					good = c.callConstructor(n, u)
890					return out, true, good
891				}
892				if u, ok := outi.(legacyConstructor); ok {
893					good = c.callLegacyConstructor(n, u)
894					return out, true, good
895				}
896			}
897		}
898		return out, false, false
899	}

$ awk 'NR>=425 && NR<=428 {printf "%d\t%s\n", NR, $0}' "$(go env GOMODCACHE)/go.yaml.in/yaml/v4@v4.0.0-rc.6/internal/libyaml/constructor.go"
425	// constructNull constructs a !!null tagged value into various Go types.
426	func (c *Constructor) constructNull(n *Node, resolved any, out reflect.Value) bool {
427		return c.null(out)
428	}

$ awk 'NR>=1062 && NR<=1073 {printf "%d\t%s\n", NR, $0}' "$(go env GOMODCACHE)/go.yaml.in/yaml/v4@v4.0.0-rc.6/internal/libyaml/constructor.go"
1062	// null constructs a null value by setting the target to its zero value.
1063	// Only works for nillable types (interface, pointer, map, slice).
1064	func (c *Constructor) null(out reflect.Value) bool {
1065		if out.CanAddr() {
1066			switch out.Kind() {
1067			case reflect.Interface, reflect.Pointer, reflect.Map, reflect.Slice:
1068				out.Set(reflect.Zero(out.Type()))
1069				return true
1070			}
1071		}
1072		return false
1073	}
```

</details>

## `testdata/format/test.sarif` is unchanged

Measured in both directions. The branch does not touch the file, and with the config gate in place the SARIF, format and project tests pass.

<details><summary>Measured</summary>

```console
$ git --no-pager diff main...HEAD --stat -- testdata/format/ | wc -l
0
$ go test -count=1 -run 'TestLinterFormatErrorMessageInSARIF|TestLinterFormatErrorMessageOK|TestLinterLintProject' .
ok  	actionlint.kjanat.dev	0.025s
```

</details>

Replacing the gate with an unconditional registration fails `TestLinterFormatErrorMessageInSARIF`, three `TestLinterFormatErrorMessageOK` subtests, and thirty-two of the thirty-four project fixtures.

<details><summary>Mutation</summary>

```console
$ git --no-pager diff --unified=2 -- linter.go
diff --git a/linter.go b/linter.go
index b44dab1..5ba59b3 100644
--- a/linter.go
+++ b/linter.go
@@ -591,7 +591,5 @@ func (l *Linter) check(
 			rules = append(rules, NewRuleRequireCommitHash())
 		}
-		if p := cfg.RequiresJobTimeout(); p.Enabled() {
-			rules = append(rules, NewRuleRequireJobTimeout(p))
-		}
+		rules = append(rules, NewRuleRequireJobTimeout(RequireJobTimeout(0)))
 		if l.shellcheck != "" {
 			r, err := NewRuleShellcheck(l.shellcheck, proc)

$ go test -count=1 -run 'TestLinterFormatErrorMessageInSARIF|TestLinterFormatErrorMessageOK|TestLinterLintProject' -v . > unconditional.log 2>&1
$ grep "^--- FAIL\|^    --- FAIL" unconditional.log
--- FAIL: TestLinterLintProject (0.02s)
    --- FAIL: TestLinterLintProject/project/broken_local_action (0.00s)
    --- FAIL: TestLinterLintProject/project/config_variables (0.00s)
    --- FAIL: TestLinterLintProject/project/deprecated_inputs (0.00s)
    --- FAIL: TestLinterLintProject/project/docker_specific_inputs (0.00s)
    --- FAIL: TestLinterLintProject/project/example_workflow_call_outputs_downstream_jobs (0.00s)
    --- FAIL: TestLinterLintProject/project/issue-136 (0.00s)
    --- FAIL: TestLinterLintProject/project/issue173 (0.00s)
    --- FAIL: TestLinterLintProject/project/issue550_args_input (0.00s)
    --- FAIL: TestLinterLintProject/project/local_action_branding (0.00s)
    --- FAIL: TestLinterLintProject/project/local_action_case_insensitive (0.00s)
    --- FAIL: TestLinterLintProject/project/local_action_empty (0.00s)
    --- FAIL: TestLinterLintProject/project/local_action_invalid (0.00s)
    --- FAIL: TestLinterLintProject/project/local_action_invalid_runners (0.00s)
    --- FAIL: TestLinterLintProject/project/local_action_yaml_1.1_boolean (0.00s)
    --- FAIL: TestLinterLintProject/project/local_composite_action (0.00s)
    --- FAIL: TestLinterLintProject/project/local_docker_action (0.00s)
    --- FAIL: TestLinterLintProject/project/local_javascript_action (0.00s)
    --- FAIL: TestLinterLintProject/project/paths_config (0.00s)
    --- FAIL: TestLinterLintProject/project/recursive_workflow_call (0.00s)
    --- FAIL: TestLinterLintProject/project/require_commit_hash (0.00s)
    --- FAIL: TestLinterLintProject/project/require_job_timeout (0.00s)
    --- FAIL: TestLinterLintProject/project/require_job_timeout_disabled (0.00s)
    --- FAIL: TestLinterLintProject/project/self_repository_uses_root_action (0.00s)
    --- FAIL: TestLinterLintProject/project/user_defined_runner_label (0.00s)
    --- FAIL: TestLinterLintProject/project/workflow_call_inherit_secrets (0.00s)
    --- FAIL: TestLinterLintProject/project/workflow_call_input_type_check (0.00s)
    --- FAIL: TestLinterLintProject/project/workflow_call_missing_required (0.00s)
    --- FAIL: TestLinterLintProject/project/workflow_call_not_found (0.00s)
    --- FAIL: TestLinterLintProject/project/workflow_call_ok (0.00s)
    --- FAIL: TestLinterLintProject/project/workflow_call_undefined (0.00s)
    --- FAIL: TestLinterLintProject/project/workflow_call_upper_case (0.00s)
    --- FAIL: TestLinterLintProject/project/yaml_anchor_in_action (0.00s)
--- FAIL: TestLinterFormatErrorMessageOK (0.00s)
    --- FAIL: TestLinterFormatErrorMessageOK/test.json (0.00s)
    --- FAIL: TestLinterFormatErrorMessageOK/test.jsonl (0.00s)
    --- FAIL: TestLinterFormatErrorMessageOK/test.md (0.00s)
--- FAIL: TestLinterFormatErrorMessageInSARIF (0.00s)
FAIL
FAIL	actionlint.kjanat.dev	0.029s
FAIL

$ grep -c "^    --- FAIL: TestLinterLintProject/project/" unconditional.log
32
$ grep -c "^    --- PASS: TestLinterLintProject/project/" unconditional.log
2
```

</details>

## One deviation from the charter

**The third error message**, described above.

`RequireJobTimeout(max float64)` does not compile clean either, but the charter already carries that rule at lines 144-146 and attributes the measurement to this branch, so it is no longer a deviation. The measurement itself still holds: `.golangci.toml` enables `predeclared`, and it rejects `max` as a parameter name. Renamed to `maxMinutes`; no suppression was added.

<details><summary>Measured</summary>

```console
$ awk 'NR>=144 && NR<=146 {printf "%d\t%s\n", NR, $0}' CHARTER.md
144	`float64`, want de AST gebruikt `TimeoutMinutes *Float`. De parameter heet `maxMinutes` en niet `max`:
145	`.golangci.toml` heeft `predeclared` aan en weigert `max` als parameternaam. Gemeten door D3, `make lint`
146	faalde erop.
```

</details>

<details><summary>Mutation</summary>

```console
$ git --no-pager diff --unified=2 -- config.go
diff --git a/config.go b/config.go
index b5eb3b0..517b923 100644
--- a/config.go
+++ b/config.go
@@ -96,6 +96,6 @@ type JobTimeoutPolicy struct {
 // RequireJobTimeout creates a JobTimeoutPolicy which turns the check on. The argument is the largest
 // allowed number of minutes, where a value which is not larger than zero sets no upper limit.
-func RequireJobTimeout(maxMinutes float64) *JobTimeoutPolicy {
-	return &JobTimeoutPolicy{enabled: true, maxMinutes: maxMinutes}
+func RequireJobTimeout(max float64) *JobTimeoutPolicy {
+	return &JobTimeoutPolicy{enabled: true, maxMinutes: max}
 }

$ golangci-lint run ./...
config.go:98:24: param max has same name as predeclared identifier (predeclared)
func RequireJobTimeout(max float64) *JobTimeoutPolicy {
                       ^
1 issues:
* predeclared: 1
```

</details>

## Credit

Ported from rhysd/actionlint#581 by `Tom North`, with a `Co-authored-by` trailer using the GitHub noreply address, since the address on those commits is `tom.north@Toms-MacBook-Pro.local` and does not route anywhere. The idea and the key's purpose are theirs; the configuration shape, the guards and the messages are written here.

<details><summary>Measured</summary>

```console
$ gh pr view 581 --repo rhysd/actionlint --json author,commits
{"author":{"id":"MDQ6VXNlcjE3NDU2NDQ1","is_bot":false,"login":"TomNorth","name":"Tom North"},"commits":[{"authoredDate":"2025-10-11T15:28:48Z","authors":[{"email":"tom.north@Toms-MacBook-Pro.local","id":"","login":"","name":"Tom North"}],"committedDate":"2025-10-11T15:28:48Z","messageBody":"","messageHeadline":"feat: Add configurable timeout-minutes rule","oid":"854b3a5b3c08b0fe6e8d9d5e0c53f84749c0a0cd"},{"authoredDate":"2025-10-11T15:52:20Z","authors":[{"email":"tom.north@Toms-MacBook-Pro.local","id":"","login":"","name":"Tom North"}],"committedDate":"2025-10-11T15:52:20Z","messageBody":"","messageHeadline":"chore: update docs for timeout-check","oid":"85c18ef31b4f25ed435492813a01496750083d97"},{"authoredDate":"2025-10-12T11:49:24Z","authors":[{"email":"tom.north@Toms-MacBook-Pro.local","id":"","login":"","name":"Tom North"}],"committedDate":"2025-10-12T11:49:24Z","messageBody":"","messageHeadline":"fix: comments to reflect field names","oid":"bf1d3da9ef60615dc711af1916b9bc6851463c8f"}]}
```

</details>

## Verification

<details><summary>Gates</summary>

```console
$ make build SKIP_GO_GENERATE=true
CGO_ENABLED=0 go build ./cmd/actionlint
```

```console
$ make test
go test -race ./...
ok  	actionlint.kjanat.dev	371.354s
?   	actionlint.kjanat.dev/cmd/actionlint	[no test files]
ok  	actionlint.kjanat.dev/cmd/actionlint-action	1.142s
ok  	actionlint.kjanat.dev/fuzz	1.031s
ok  	actionlint.kjanat.dev/scripts/bump-version	(cached)
ok  	actionlint.kjanat.dev/scripts/check-checks	88.226s
ok  	actionlint.kjanat.dev/scripts/generate-availability	(cached)
ok  	actionlint.kjanat.dev/scripts/generate-popular-actions	2.338s
ok  	actionlint.kjanat.dev/scripts/generate-webhook-events	(cached)
```

```console
$ make lint SKIP_GO_GENERATE=true
golangci-lint run
0 issues.
go run golang.org/x/vuln/cmd/govulncheck@latest ./...
No vulnerabilities found.
GOOS=js GOARCH=wasm golangci-lint run ./playground
0 issues.
go run ./scripts/check-checks -quiet ./docs/checks.md
```

```console
$ dprint check
$ echo $?
0
```

</details>

