### PR TITLE
Don't `-race` if (`CLAUDECODE`|`NO_RACE`) = 1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,16 @@ else
 	RACE = -race
 endif
 
+# The race detector makes the suite roughly twenty times slower, which is a poor
+# trade in an agent session that runs it after every edit. Setting NORACE=1 turns
+# it off, and CLAUDECODE=1 does the same, since Claude Code sets that itself.
+ifeq ($(CLAUDECODE),1)
+	RACE =
+endif
+ifeq ($(NORACE),1)
+	RACE =
+endif
+
 
 all: build test lint
 


### PR DESCRIPTION
`make test` is `go test -race ./...`. The race detector costs roughly twenty times the runtime, which is worth it in CI and wasted on a session that runs the suite after every edit, including edits to a document or a fixture that touch no concurrency.

`NORACE=1` drops the flag. `CLAUDECODE=1` does the same, because Claude Code sets that variable itself, so an agent gets the fast suite without having to remember anything.

<details><summary>Measured</summary>

The cost, same subset both ways:

```console
$ go test -count=1 -run 'TestLinterLintProject' .
ok  	actionlint.kjanat.dev	0.060s
$ go test -count=1 -race -run 'TestLinterLintProject' .
ok  	actionlint.kjanat.dev	1.325s
```

What the target expands to in each case:

```console
$ make -n test
go test  ./...
$ CLAUDECODE= make -n test
go test -race ./...
$ CLAUDECODE= NORACE=1 make -n test
go test  ./...
```

</details>

## CI keeps the race detector

`ci.yaml` never goes through the Makefile, so nothing about this reaches it.

<details><summary>Measured</summary>

```console
$ grep -n 'make test\|go test\|-race' .github/workflows/ci.yaml
49:      - run: go test -v ./...
72:      - run: go test -v -race -coverprofile coverage.txt -covermode=atomic ./...
75:      # Set -race for catching data races on dog fooding (#333)
76:      - run: go build -race ./cmd/actionlint
```

</details>

The variable also feeds `coverage.out`, so `make cov` follows the same rule.

## Verification

None beyond the expansions above. This changes one Make variable and no code, so the only thing to check is what the recipe becomes, which `make -n` prints without running anything.
