### PR TITLE
Stop disabling the goreleaser pipe that reads the notes file

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -70,6 +70,3 @@ homebrew_casks:
     commit_author:
       name: "github-actions[bot]"
       email: "41898282+github-actions[bot]@users.noreply.github.com"
-
-changelog:
-  disable: true


### PR DESCRIPTION
v1.12.0 published with a body of one byte while the notes it was given sat in the run's artifact at 3770 bytes. Every release that relies on the `--release-notes` flag has the same defect, because the flag is inert.

In the blocks below, `$S` is a scratch directory outside the repository.

<details><summary>Measured</summary>

```console
$ gh api repos/kjanat/actionlint/releases/tags/v1.12.0 --jq '{published_at, body_len:(.body|length), body}'
{"body":"\n","body_len":1,"published_at":"2026-08-20T22:56:43Z"}

$ gh run download 32426355599 -n release-notes -D "$S/notes-artifact"

$ wc -c "$S/notes-artifact/release-notes.md"
3770 /tmp/claude-1000/-home-kjanat-projects-actionlint/9c6b3311-e368-4a1b-8108-3d6192c6adc2/scratchpad/notes-artifact/release-notes.md

$ head -2 "$S/notes-artifact/release-notes.md"
- Move the Go module to `actionlint.kjanat.dev`. The `go-import` and `go-source` meta tags that resolve it are served from the fork's GitHub Pages site, so `go install actionlint.kjanat.dev/cmd/actionlint@latest` resolves from this release onward. Library consumers must update their import paths.
- Rename the exported `InvalidGlobPattern` error type to `InvalidGlobPatternError`. It is returned by `ValidateRefGlob` and `ValidatePathGlob`, so consumers of those functions must update.

$ diff "$S/notes-artifact/release-notes.md" <(go run ./scripts/bump-version -notes v1.12.0); echo "exit=$?"
exit=0
```

</details>

`bump-version -notes` resolved the notes, the artifact carried them intact, and goreleaser was invoked with the flag pointing at them. Nothing in the workflow lost the file.

<details><summary>Measured, the workflow run</summary>

```console
$ gh run view --job 96608988942 --log | grep -n 'bump-version -notes'
251:Check changelog	UNKNOWN STEP	2026-08-20T22:54:45.8255378Z ##[group]Run go run ./scripts/bump-version -notes "${TAG}" > "${RUNNER_TEMP}/release-notes.md"
252:Check changelog	UNKNOWN STEP	2026-08-20T22:54:45.8256159Z ^[[36;1mgo run ./scripts/bump-version -notes "${TAG}" > "${RUNNER_TEMP}/release-notes.md"^[[0m

$ gh run view --job 96609069553 --log | grep -n 'goreleaser release'
337:binaries	UNKNOWN STEP	2026-08-20T22:55:17.3864000Z [command]/opt/hostedtoolcache/goreleaser-action/2.17.1/x64/goreleaser release --clean --release-notes=/home/runner/work/_temp/release-notes.md

$ gh run view --job 96609069553 --log | grep -c 'generating changelog'
0
```

</details>

`changelog.disable` is the cause. In goreleaser v2.17.1 the changelog pipe is the only place `ctx.ReleaseNotes` is filled from `ReleaseNotesFile`, and that pipe's `Skip` returns `Changelog.Disable`, so with the key set the file is never opened and the body stays empty. The missing `generating changelog` line above is that skip.

<details><summary>Measured, goreleaser v2.17.1</summary>

```console
$ curl -sSL -o "$S/changelog.go" "https://raw.githubusercontent.com/goreleaser/goreleaser/v2.17.1/internal/pipe/changelog/changelog.go"

$ awk 'NR>=41 && NR<=51 {printf "%d\t%s\n", NR, $0}' "$S/changelog.go"
41	type Pipe struct{}
42
43	func (Pipe) String() string { return "generating changelog" }
44
45	func (Pipe) Skip(ctx *context.Context) (bool, error) {
46		if ctx.Snapshot {
47			return true, nil
48		}
49
50		return tmpl.New(ctx).Bool(ctx.Config.Changelog.Disable)
51	}

$ awk 'NR>=65 && NR<=76 {printf "%d\t%s\n", NR, $0}' "$S/changelog.go"
65	// Run the pipe.
66	func (Pipe) Run(ctx *context.Context) error {
67		notes, err := loadContent(ctx, ctx.ReleaseNotesFile, ctx.ReleaseNotesTmpl)
68		if err != nil {
69			return err
70		}
71		ctx.ReleaseNotes = notes
72
73		if ctx.ReleaseNotesFile != "" || ctx.ReleaseNotesTmpl != "" {
74			return nil
75		}
76

$ grep -n "ReleaseNotesFile" "$S/changelog.go"
67:	notes, err := loadContent(ctx, ctx.ReleaseNotesFile, ctx.ReleaseNotesTmpl)
73:	if ctx.ReleaseNotesFile != "" || ctx.ReleaseNotesTmpl != "" {
```

</details>

Lines 73 to 75 are why removing the key does not bring a commit list back. With `--release-notes` present, `Run` reads the file and returns before `buildChangelog` is reached, so the body is the file and nothing else. The release workflow passes the flag on every release.

<details><summary>Measured, both configurations against the same binary</summary>

A throwaway Go project outside the repository, one `main.go`, one tag, and the goreleaser the release workflow also uses. Publishing is skipped; what is being read is whether the pipe runs at all.

Its configuration:

```yaml
version: 2

builds:
  - main: .
    goos: [linux]
    goarch: [amd64]

changelog:
  disable: true
```

Its `notes.md` holds one line, `- the notes file was read`.

```console
$ goreleaser --version | grep -e GitVersion -e GoVersion
GitVersion:    2.17.1
GoVersion:     go1.26.5

$ goreleaser release --clean --skip=publish,announce --release-notes=notes.md
  • starting release
  • skipping announce and publish...
  • cleaning distribution directory
  • loading environment variables
    • using token from  $GITHUB_TOKEN
  • getting and validating git state
    • couldn't find any tags before "v0.1.0"
    • using tags                                     previous=<unknown> current=v0.1.0
  • parsing tag
  • setting defaults
  • ensuring distribution directory
  • setting up metadata
  • writing release metadata
  • loading go mod information
  • build prerequisites
  • building binaries
    • building                                       paths=. binaries=grepro target=linux_amd64_v1
  • archives
    • archiving                                      name=dist/grepro_0.1.0_linux_amd64.tar.gz
  • calculating checksums
  • writing artifacts metadata
  • release succeeded after 0s
  • thanks for using GoReleaser!
```

The same project with the two lines removed, committed so the tree is clean, and the tag moved onto that commit:

```console
$ goreleaser release --clean --skip=publish,announce --release-notes=notes.md
  • starting release
  • skipping announce and publish...
  • cleaning distribution directory
  • loading environment variables
    • using token from  $GITHUB_TOKEN
  • getting and validating git state
    • couldn't find any tags before "v0.1.0"
    • using tags                                     previous=<unknown> current=v0.1.0
  • parsing tag
  • setting defaults
  • ensuring distribution directory
  • setting up metadata
  • writing release metadata
  • loading go mod information
  • build prerequisites
  • building binaries
    • building                                       paths=. binaries=grepro target=linux_amd64_v1
  • generating changelog
  • archives
    • archiving                                      name=dist/grepro_0.1.0_linux_amd64.tar.gz
  • calculating checksums
  • writing artifacts metadata
  • release succeeded after 0s
  • thanks for using GoReleaser!
```

`generating changelog` appears only in the second run. Neither run writes `dist/CHANGELOG.md`, because the early return at line 74 happens before the pipe writes one.

</details>

## The change

```diff
       email: "41898282+github-actions[bot]@users.noreply.github.com"
-
-changelog:
-  disable: true
```

## What this does not change

A release run that omits `--release-notes` now gets a commit list instead of an empty body. The workflow does not omit it.

v1.12.0's body was filled in with `gh release edit` once the defect was found, so that release is already correct and this branch does not touch it.

<details><summary>Measured</summary>

```console
$ gh api repos/kjanat/actionlint/releases/tags/v1.12.0 --jq '{body_len:(.body|length), first_line:(.body|split("\n")[0])}'
{"body_len":3789,"first_line":"## What's changed"}
```

</details>

## Verification

The diff touches no Go source, no test data and no documentation, so `make build`, `make test` and `make lint` read the same tree they read on `main`.

<details><summary>Gates</summary>

```console
$ dprint check; echo "exit=$?"
exit=0

$ git diff --stat origin/main
 .goreleaser.yaml | 3 ---
 1 file changed, 3 deletions(-)

$ git status --short
```

</details>
