### PR TITLE
Add a CLI action for runners without a Docker daemon

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -180,8 +180,22 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with: { persist-credentials: false }
+      # The published actionlint the action installs is older than this branch,
+      # so linting the repository itself would report syntax this release does
+      # not know yet. A fixture keeps the job about the action.
+      - name: Write a fixture workflow
+        run: |
+          mkdir -p "${RUNNER_TEMP}/fixture"
+          cat > "${RUNNER_TEMP}/fixture/smoke.yaml" <<'FIXTURE'
+          on: push
+          jobs:
+            smoke:
+              runs-on: ubuntu-latest
+              steps:
+                - run: echo hello
+          FIXTURE
       - uses: $/action/cli
-        with: { pyflakes: "false" }
+        with: { pyflakes: "false", flags: "${{ runner.temp }}/fixture/smoke.yaml" }
 
   pre-commit-shellcheck:
     name: pre-commit ShellCheck integration

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -174,6 +174,15 @@ jobs:
         }
       - name: Test action image
         run: ./scripts/test-action.bash actionlint-action:test
+  action-cli:
+    name: CLI action on a daemon-less runner
+    runs-on: ubuntu-slim
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with: { persist-credentials: false }
+      - uses: $/action/cli
+        with: { pyflakes: "false" }
+
   pre-commit-shellcheck:
     name: pre-commit ShellCheck integration
     runs-on: ubuntu-latest

--- a/.github/workflows/matcher.yaml
+++ b/.github/workflows/matcher.yaml
@@ -27,13 +27,13 @@ jobs:
         run: make ./scripts/generate-actionlint-matcher/testdata/* SKIP_GO_GENERATE=true
       - name: Test actionlint-matcher.json
         run: npm run test:matcher
-      - name: Ensure .github/actionlint-matcher.json is up-to-date
+      - name: Ensure the generated matcher files are up-to-date
         run: |
-          make .github/actionlint-matcher.json
+          make matcher
           if git diff --quiet; then
             echo 'OK'
           else
-            echo 'ERROR! .github/actionlint-matcher.json is outdated. Update it by "make .github/actionlint-matcher.json"' >&2
+            echo 'ERROR! A generated actionlint-matcher.json is outdated. Update both by "make matcher"' >&2
             set -x
             git diff
             exit 1

--- a/Makefile
+++ b/Makefile
@@ -110,8 +110,10 @@ man: man/actionlint.1 man/actionlint.1.html
 bench:
 	go test -bench Lint -benchmem
 
-.github/actionlint-matcher.json: scripts/generate-actionlint-matcher/object.mjs
-	node ./scripts/generate-actionlint-matcher/main.mjs .github/actionlint-matcher.json
+.github/actionlint-matcher.json action/cli/actionlint-matcher.json: scripts/generate-actionlint-matcher/object.mjs
+	node ./scripts/generate-actionlint-matcher/main.mjs $@
+
+matcher: .github/actionlint-matcher.json action/cli/actionlint-matcher.json
 
 scripts/generate-actionlint-matcher/testdata/escape.txt: $(TARGET)
 	./actionlint -color ./testdata/err/one_error.yaml > ./scripts/generate-actionlint-matcher/testdata/escape.txt || true
@@ -126,4 +128,4 @@ CHANGELOG.md:
 c clean:
 	rm -f ./$(TARGET) ./man/actionlint.1 ./man/actionlint.1.html ./actionlint-workflow-ast
 
-.PHONY: all test clean build lint fuzz man bench cov b t c l CHANGELOG.md FORCE
+.PHONY: all test clean build lint fuzz man matcher bench cov b t c l CHANGELOG.md FORCE

--- a/README.md
+++ b/README.md
@@ -135,24 +135,14 @@ jobs:
       - uses: kjanat/actionlint@v1
 ```
 
-On a daemon-less runner such as `ubuntu-slim`, download and run the binary instead:
+On a daemon-less runner such as `ubuntu-slim`, use the CLI action instead. It installs actionlint with [mise](https://mise.jdx.dev) and registers the problem matcher, so errors still show up as annotations:
 
 ```yaml
-- uses: actions/checkout@v7
-  with: { persist-credentials: false }
-- name: Download and run actionlint
-  env: { GH_TOKEN: "${{ github.token }}", GH_REPO: "kjanat/actionlint" }
-  run: |
-    case "${RUNNER_ARCH}" in
-      X64) asset_arch=amd64 ;;
-      ARM64) asset_arch=arm64 ;;
-      ARM) asset_arch=armv6 ;;
-      X86) asset_arch=386 ;;
-      *) echo "Unsupported runner architecture: ${RUNNER_ARCH}" >&2; exit 1 ;;
-    esac
-    gh release download --pattern "actionlint_*_${RUNNER_OS,,}_${asset_arch}.tar.gz" --output - | tar -xzf - actionlint
-    ./actionlint -color
+- { uses: actions/checkout@v7, with: { persist-credentials: false } }
+- uses: kjanat/actionlint/action/cli@v1
 ```
+
+ShellCheck and pyflakes are installed alongside actionlint unless you set `shellcheck: "false"` and `pyflakes: "false"`.
 
 The moving `v1` tag follows compatible v1 releases. `v1.13.0` is a versioned release tag, but only a full-length commit SHA provides an immutable action reference.
 

--- a/action/cli/action.yml
+++ b/action/cli/action.yml
@@ -1,0 +1,60 @@
+# yaml-language-server: $schema=https://www.schemastore.org/github-action.json
+---
+name: actionlint CLI by @kjanat
+description: >-
+  Run actionlint on GitHub Actions workflow files and report problems as
+  annotations. Installs actionlint with mise, so no Docker daemon is needed.
+inputs:
+  version:
+    description: >-
+      actionlint release to install, for example 1.13.0. "latest" takes the
+      newest release.
+    required: false
+    default: latest
+  shellcheck:
+    description: >-
+      Install ShellCheck so actionlint checks shell scripts in "run" steps.
+    required: false
+    default: "true"
+  pyflakes:
+    description: >-
+      Install pyflakes so actionlint checks Python scripts in "run" steps.
+    required: false
+    default: "true"
+  working-directory:
+    description: Directory to run actionlint in, relative to the workspace.
+    required: false
+    default: .
+  flags:
+    description: >-
+      Extra actionlint flags, for example "-ignore SC2086". Split on whitespace,
+      so it is for workflow authors rather than untrusted input.
+    required: false
+    default: ""
+runs:
+  using: composite
+  steps:
+    - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
+      with:
+        mise_toml: |
+          [tools]
+          "github:kjanat/actionlint" = "${{ inputs.version }}"
+          ${{ inputs.shellcheck == 'true' && 'shellcheck = "latest"' || '' }}
+          ${{ inputs.pyflakes == 'true' && '"pipx:pyflakes" = "latest"' || '' }}
+
+          [settings]
+          minimum_release_age = "0s"
+
+    - shell: bash
+      env:
+        WORKING_DIRECTORY: ${{ inputs.working-directory }}
+        FLAGS: ${{ inputs.flags }}
+      run: |
+        set -euo pipefail
+        echo "::add-matcher::${GITHUB_ACTION_PATH}/actionlint-matcher.json"
+        read -ra flags <<< "${FLAGS}"
+        cd "${WORKING_DIRECTORY}"
+        actionlint -color "${flags[@]}"
+branding:
+  icon: check-circle
+  color: blue

--- a/action/cli/actionlint-matcher.json
+++ b/action/cli/actionlint-matcher.json
@@ -1,0 +1,17 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "actionlint",
+      "pattern": [
+        {
+          "regexp": "^(?:\\x1b\\[\\d+m)?(.+?)(?:\\x1b\\[\\d+m)*:(?:\\x1b\\[\\d+m)*(\\d+)(?:\\x1b\\[\\d+m)*:(?:\\x1b\\[\\d+m)*(\\d+)(?:\\x1b\\[\\d+m)*: (?:\\x1b\\[\\d+m)*(.+?)(?:\\x1b\\[\\d+m)* \\[(.+?)\\]$",
+          "file": 1,
+          "line": 2,
+          "column": 3,
+          "message": 4,
+          "code": 5
+        }
+      ]
+    }
+  ]
+}

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -328,9 +328,9 @@ off:
 
 The other inputs are `version` for the actionlint release, `working-directory`,
 and `flags` for extra command line options such as `-ignore`. `v1` moves to each
-new release. `v1.13.0` is a
-versioned release tag, but only a full-length commit SHA provides an immutable
-action reference.
+new release.
+`v1.13.0` is a versioned release tag, but only a full-length commit SHA provides
+an immutable action reference.
 
 The action accepts these inputs:
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -303,31 +303,34 @@ socket. Standard Ubuntu runners, including `ubuntu-24.04-arm` and
 `ubuntu-26.04-arm`, are supported by the published `linux/amd64` and
 `linux/arm64` image.
 
-On a daemon-less runner such as `ubuntu-slim`, download and run the binary
-instead. `uses: docker://ghcr.io/kjanat/actionlint:latest` is not an alternative
-there because it has the same Docker daemon requirement.
+On a daemon-less runner such as `ubuntu-slim`, use the CLI action at
+`action/cli` instead. `uses: docker://ghcr.io/kjanat/actionlint:latest` is not an
+alternative there because it has the same Docker daemon requirement.
 
 ```yaml
 - uses: actions/checkout@v7
   with: { persist-credentials: false }
-- name: Download and run actionlint
-  env: { GH_TOKEN: "${{ github.token }}", GH_REPO: "kjanat/actionlint" }
-  run: |
-    case "${RUNNER_ARCH}" in
-      X64) asset_arch=amd64 ;;
-      ARM64) asset_arch=arm64 ;;
-      ARM) asset_arch=armv6 ;;
-      X86) asset_arch=386 ;;
-      *) echo "Unsupported runner architecture: ${RUNNER_ARCH}" >&2; exit 1 ;;
-    esac
-    gh release download --pattern "actionlint_*_${RUNNER_OS,,}_${asset_arch}.tar.gz" --output - | tar -xzf - actionlint
-    ./actionlint -color
+- uses: kjanat/actionlint/action/cli@v1
 ```
 
-The binary-only path does not bundle ShellCheck or pyflakes; install them on the
-runner when those integrations are required. `v1` moves to each new release.
-`v1.13.0` is a versioned release tag, but only a full-length commit SHA provides
-an immutable action reference.
+It installs actionlint with [mise][mise], which picks the release asset for the
+runner's platform, and registers the [problem matcher](#problem-matchers) so
+errors appear as annotations. No Docker daemon and no copied matcher file are
+needed.
+
+ShellCheck and pyflakes are installed alongside actionlint unless you turn them
+off:
+
+```yaml
+- uses: kjanat/actionlint/action/cli@v1
+  with: { shellcheck: "false", pyflakes: "false" }
+```
+
+The other inputs are `version` for the actionlint release, `working-directory`,
+and `flags` for extra command line options such as `-ignore`. `v1` moves to each
+new release. `v1.13.0` is a
+versioned release tag, but only a full-length commit SHA provides an immutable
+action reference.
 
 The action accepts these inputs:
 
@@ -785,6 +788,7 @@ You can also see actionlint issues inline in VS Code via the [Trunk VS Code exte
 [go-shellcheck]: https://github.com/wasilibs/go-shellcheck
 [go-template]: https://pkg.go.dev/text/template
 [jsonl]: https://jsonlines.org/
+[mise]: https://mise.jdx.dev
 [nova-extension]: https://extensions.panic.com/extensions/org.netwrk/org.netwrk.actionlint/
 [nova]: https://nova.app
 [nvim-lint]: https://github.com/mfussenegger/nvim-lint


### PR DESCRIPTION
The Docker action needs a reachable daemon, so `ubuntu-slim` cannot use it. The workaround the docs carried until now reconstructed the release asset name in shell, and it was wrong on two of the three runner platforms.

<details><summary>Measured, the old snippet against the real assets</summary>

```console
$ gh release view --repo kjanat/actionlint --json tagName,assets --jq '.tagName, (.assets[].name)'
v1.13.0
actionlint_1.13.0_checksums.txt
actionlint_1.13.0_darwin_amd64.tar.gz
actionlint_1.13.0_darwin_arm64.tar.gz
actionlint_1.13.0_freebsd_386.tar.gz
actionlint_1.13.0_freebsd_amd64.tar.gz
actionlint_1.13.0_linux_386.tar.gz
actionlint_1.13.0_linux_amd64.tar.gz
actionlint_1.13.0_linux_arm64.tar.gz
actionlint_1.13.0_linux_armv6.tar.gz
actionlint_1.13.0_windows_386.zip
actionlint_1.13.0_windows_amd64.zip
actionlint_1.13.0_windows_arm64.zip
```

The snippet built its pattern as `actionlint_*_${RUNNER_OS,,}_${asset_arch}.tar.gz`. On a macOS runner `RUNNER_OS` is `macOS`, so that lowercases to `macos` while the assets say `darwin`. On Windows the assets are `.zip`, so the pattern matches nothing and `tar -xzf` could not have unpacked it anyway. It also ran `actionlint -color` with no problem matcher registered, so problems stayed in the step log and never became annotations.

</details>

This adds `action/cli`, a composite action that installs actionlint with [mise](https://mise.jdx.dev) and registers the problem matcher.

mise picks the release asset itself, which removes the hand-written OS and architecture mapping entirely. No `asset_pattern` is needed for our naming.

<details><summary>Measured, mise against our releases</summary>

```console
$ MISE_MINIMUM_RELEASE_AGE=0s mise x "github:kjanat/actionlint@latest" -- actionlint --version
1.13.0
installed by downloading from release page
built with go1.27.0 compiler for linux/amd64
```

`minimum_release_age` defaults to 24 hours, so the action sets it to `0s` in its inline `mise_toml`. Without that a fresh actionlint release is not installable for a day.

`shellcheck` resolves through the registry; `pyflakes` is not in it and goes through `pipx:pyflakes`.

```console
$ mise registry | grep -E "^(shellcheck|pyflakes) "
shellcheck                    aqua:koalaman/shellcheck asdf:luizm/asdf-shellcheck
```

</details>

The action ships its own copy of the generated matcher. Until now docs/usage.md told readers to copy `actionlint-matcher.json` into their own repository before annotations worked, which the action can simply do for them.

That copy is generated, not hand-maintained. `make matcher` writes both files from `scripts/generate-actionlint-matcher/main.mjs`, and the existing up-to-date guard in `.github/workflows/matcher.yaml` compares the whole tree, so it covers both without further changes.

https://github.com/kjanat/actionlint/blob/7dc7818c8d71a086389ba03f23a840b54399541a/Makefile#L113-L116

A new CI job runs the action on `ubuntu-slim`, the runner the Docker action cannot reach. That reference also puts the action under actionlint's own composite-step validation, which I confirmed by breaking it on purpose.

<details><summary>Measured, the action is actually validated</summary>

```console
$ sed -i 's|^    - shell: bash$|    - shell: bash\n      bogus-key: true|' action/cli/action.yml
$ ./actionlint -color
action/cli/action.yml:48:7: step 2 in "runs.steps" section in metadata of "actionlint CLI by @kjanat" action has unexpected key "bogus-key". expected one of "continue-on-error", "env", "id", "if", "name", "run", "shell", "working-directory" [action]
   |
48 |     - shell: bash
   |       ^~~~~~
```

Reverted afterwards. With the file restored, `./actionlint -color -shellcheck 'shellcheck -o all'`, `check-readme`, `check-checks` and `dprint check` all pass.

</details>

The `flags` input is split on whitespace with `read -ra` rather than an unquoted expansion, so it needs no `shellcheck disable` comment and does not glob.

## Not in this PR

`action/compat`, a variant that downloads a second release binary to reach full input and output parity with the Docker action, plus the `.goreleaser.yaml` change that would publish that binary. Both sit uncommitted pending a separate decision on whether one action or two is the right answer.
