### PR TITLE
Add a binary action with full Docker action parity

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -35,6 +35,23 @@ builds:
     goos: [freebsd]
     goarch: ["386", amd64]
 
+  # GoReleaser names the binary after ProjectName unless "binary" says otherwise,
+  # which would put an "actionlint" file inside the actionlint-action archive.
+  - <<: &action_build_defaults
+      main: ./cmd/actionlint-action
+      binary: actionlint-action
+      ldflags: -s -w -X main.version={{ .Version }}
+      env:
+        - CGO_ENABLED=0
+    id: action-nix
+    goos: [linux, darwin]
+    goarch: [amd64, arm64]
+
+  - <<: *action_build_defaults
+    id: action-windows
+    goos: [windows]
+    goarch: [amd64, arm64]
+
 sboms:
   - artifacts: archive
 
@@ -55,6 +72,18 @@ archives:
   - <<: *archives_defaults
     id: windows
     ids: [windows]
+    formats: [zip]
+
+  - <<: &action_archive_defaults
+      name_template: actionlint-action_{{ .Version }}_{{ .Os }}_{{ .Arch }}
+      files:
+        - LICENSE.txt
+    id: action-nix
+    ids: [action-nix]
+    formats: [tar.gz]
+  - <<: *action_archive_defaults
+    id: action-windows
+    ids: [action-windows]
     formats: [zip]
 
 homebrew_casks:

--- a/action/compat/action.yml
+++ b/action/compat/action.yml
@@ -1,0 +1,162 @@
+# yaml-language-server: $schema=https://www.schemastore.org/github-action.json
+---
+name: actionlint binary by @kjanat
+description: >-
+  Static-check GitHub Actions workflow files with actionlint on runners without
+  a Docker daemon.
+inputs:
+  files:
+    description: >-
+      Newline-separated workflow file paths. Empty checks every workflow in the
+      repository.
+    required: false
+    default: ""
+  format:
+    description: >-
+      Output format. Choose github, default, oneline, json, json-lines,
+      markdown, or sarif.
+    required: false
+    default: github
+  ignore:
+    description: >-
+      Newline-separated regular expressions for actionlint errors to ignore.
+    required: false
+    default: ""
+  config-file:
+    description: >-
+      Path to an actionlint configuration file, relative to working-directory.
+    required: false
+    default: ""
+  shellcheck:
+    description: >-
+      Run ShellCheck for shell scripts in workflow steps. Requires shellcheck on
+      PATH; this action installs nothing.
+    required: false
+    default: "true"
+  pyflakes:
+    description: >-
+      Run pyflakes for Python scripts in workflow steps. Requires pyflakes on
+      PATH; this action installs nothing.
+    required: false
+    default: "true"
+  working-directory:
+    description: Directory to lint, relative to the repository workspace.
+    required: false
+    default: .
+  output-file:
+    description: >-
+      Optional repository-relative file to receive the selected output format.
+    required: false
+    default: ""
+  fail-on-error:
+    description: >-
+      Fail the step when actionlint finds problems. Invalid options and fatal
+      errors always fail.
+    required: false
+    default: "true"
+  version:
+    description: Release version of the actionlint binary to download.
+    required: false
+    default: 1.13.0
+outputs:
+  exit-code:
+    description: >-
+      actionlint exit code: 0 for clean, 1 for problems, 2 for invalid options,
+      or 3 for failure.
+    value: ${{ steps.run.outputs.exit-code }}
+  result:
+    description: >-
+      Result name: success, problems-found, invalid-options, or failure.
+    value: ${{ steps.run.outputs.result }}
+  problems-found:
+    description: Whether actionlint found one or more problems.
+    value: ${{ steps.run.outputs.problems-found }}
+  problem-count:
+    description: >-
+      Number of problems found, or an empty string if actionlint could not
+      complete.
+    value: ${{ steps.run.outputs.problem-count }}
+  output:
+    description: Complete actionlint output in the selected format.
+    value: ${{ steps.run.outputs.output }}
+  output-file:
+    description: >-
+      Repository-relative output file path, or an empty string when output-file
+      was not set.
+    value: ${{ steps.run.outputs.output-file }}
+runs:
+  using: composite
+  steps:
+    - name: Download actionlint
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        GH_REPO: kjanat/actionlint
+        VERSION: ${{ inputs.version }}
+      run: |
+        set -euo pipefail
+
+        case "${RUNNER_OS}" in
+          Linux) asset_os=linux; asset_ext=tar.gz ;;
+          macOS) asset_os=darwin; asset_ext=tar.gz ;;
+          Windows) asset_os=windows; asset_ext=zip ;;
+          *) echo "::error title=actionlint::Unsupported runner OS: ${RUNNER_OS}"; exit 1 ;;
+        esac
+
+        case "${RUNNER_ARCH}" in
+          X64) asset_arch=amd64 ;;
+          ARM64) asset_arch=arm64 ;;
+          *) echo "::error title=actionlint::Unsupported runner architecture: ${RUNNER_ARCH}"; exit 1 ;;
+        esac
+
+        asset="actionlint-action_${VERSION}_${asset_os}_${asset_arch}.${asset_ext}"
+        sums="actionlint_${VERSION}_checksums.txt"
+        dir="${RUNNER_TEMP}/actionlint-action"
+
+        mkdir -p "${dir}"
+        gh release download "v${VERSION}" \
+          --pattern "${asset}" --pattern "${sums}" --dir "${dir}" --clobber
+
+        cd "${dir}"
+        if command -v sha256sum >/dev/null 2>&1; then
+          grep " ${asset}\$" "${sums}" | sha256sum --check --strict
+        else
+          grep " ${asset}\$" "${sums}" | shasum -a 256 --check
+        fi
+
+        if [ "${asset_ext}" = zip ]; then
+          unzip -o -j "${asset}" actionlint-action.exe
+          echo "ACTIONLINT_ACTION_BIN=${dir}/actionlint-action.exe" >> "${GITHUB_ENV}"
+        else
+          tar -xzf "${asset}" actionlint-action
+          echo "ACTIONLINT_ACTION_BIN=${dir}/actionlint-action" >> "${GITHUB_ENV}"
+        fi
+
+    - name: Run actionlint
+      id: run
+      shell: bash
+      env:
+        FILES: ${{ inputs.files }}
+        FORMAT: ${{ inputs.format }}
+        IGNORE: ${{ inputs.ignore }}
+        CONFIG_FILE: ${{ inputs.config-file }}
+        SHELLCHECK: ${{ inputs.shellcheck }}
+        PYFLAKES: ${{ inputs.pyflakes }}
+        WORKING_DIRECTORY: ${{ inputs.working-directory }}
+        OUTPUT_FILE: ${{ inputs.output-file }}
+        FAIL_ON_ERROR: ${{ inputs.fail-on-error }}
+      run: |
+        set -euo pipefail
+        "${ACTIONLINT_ACTION_BIN}" \
+          "${FILES}" \
+          "${FORMAT}" \
+          "${IGNORE}" \
+          "${CONFIG_FILE}" \
+          "${SHELLCHECK}" \
+          "${PYFLAKES}" \
+          "${WORKING_DIRECTORY}" \
+          "${OUTPUT_FILE}" \
+          "${FAIL_ON_ERROR}"
+branding:
+  icon: check-circle
+  color: blue

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -329,6 +329,20 @@ off:
 The other inputs are `version` for the actionlint release, `working-directory`,
 and `flags` for extra command line options such as `-ignore`. `v1` moves to each
 new release.
+
+When a step after it needs the problem count or the output itself, use
+`action/compat` instead. It downloads the release binary that backs the Docker
+action, so it carries the same inputs and the same outputs, at the cost of
+installing no external linters.
+
+```yaml
+- uses: kjanat/actionlint/action/compat@v1
+  id: lint
+  with: { format: sarif, output-file: actionlint.sarif }
+- run: echo "found ${COUNT} problems"
+  env: { COUNT: "${{ steps.lint.outputs.problem-count }}" }
+```
+
 `v1.13.0` is a versioned release tag, but only a full-length commit SHA provides
 an immutable action reference.
 

--- a/scripts/bump-version/targets.go
+++ b/scripts/bump-version/targets.go
@@ -45,6 +45,12 @@ var targets = []*target{
 		},
 	},
 	{
+		path: "action/compat/action.yml",
+		rules: []rule{
+			mustRule("downloaded release version", `(?m)^    default: (\d+\.\d+\.\d+)\r?$`, 1),
+		},
+	},
+	{
 		path: "action.yml",
 		rules: []rule{
 			mustRule("action Docker image tag", `image: docker://ghcr\.io/kjanat/actionlint:action-(\d+\.\d+\.\d+)`, 1),


### PR DESCRIPTION
Stacked on kjanat/actionlint#92, so the diff here is only the second action. Draft, because two open questions below decide whether it should exist in this shape at all.

`action/cli` from #92 runs the plain `actionlint` binary and therefore has no outputs. A workflow that wants to read the problem count, branch on the result name, or upload sarif has nothing to consume. This adds `action/compat`, which downloads `cmd/actionlint-action`, the same program the Docker image runs, and so carries all nine inputs and all six outputs.

## The bug that made this worth a separate PR

`goreleaser check` validates the config but builds nothing. Building a snapshot showed GoReleaser names a binary after `ProjectName` unless told otherwise, so the archive named `actionlint-action_*` contained a file called `actionlint`, and the action's `tar -xzf "${asset}" actionlint-action` would have failed on every runner.

<details><summary>Measured, before the binary key</summary>

```console
$ goreleaser release --snapshot --clean --skip=publish,sign,sbom,docker,homebrew
• building  paths=cmd/actionlint-action  binaries=actionlint  target=darwin_amd64_v1

$ tar -tzf dist/actionlint-action_1.13.0-SNAPSHOT-62bf65b7_linux_amd64.tar.gz
LICENSE.txt
actionlint
```

</details>

<details><summary>Measured, after</summary>

```console
$ tar -tzf dist/actionlint-action_1.13.0-SNAPSHOT-62bf65b7_linux_amd64.tar.gz
LICENSE.txt
actionlint-action

$ unzip -l dist/actionlint-action_1.13.0-SNAPSHOT-62bf65b7_windows_amd64.zip
     1099  2026-08-29 00:25   LICENSE.txt
  7421440  2026-09-01 16:32   actionlint-action.exe
```

All six action archives land in the existing `checksums.txt`, so the action's verification step has something to check against.

</details>

The `version` input pins which release to download, which is a third place that needs bumping at release time next to the Docker image tag. `scripts/bump-version/targets.go` now tracks it, so it fails the suite instead of drifting silently.

## Two open questions

**Should this exist at all, given the single-binary idea?** Folding the action wrapper into `cmd/actionlint` behind an explicit flag would remove the second binary, the four extra release archives, and the download logic in this action, since mise could then install it the way `action/cli` already does. That is the better end state. This PR is the version that works without touching the Go code.

**It cannot be tested before it ships.** The archives this action downloads do not exist until a release publishes them, so CI cannot exercise it on this branch. That is exactly how the naming bug above survived until a snapshot build.

## Not included

No CI job, for the reason above. The Docker action and `action/cli` keep their own coverage.
