### PR TITLE
Add a funding file

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: kjanat


### PR DESCRIPTION
Adds `.github/FUNDING.yml`, which GitHub reads to put a **Sponsor** button on the repository page and in the sidebar.

```yaml
github: kjanat
```

Independent of the distribution stack (#95–#99) — based on `master`, one new file, nothing else touched.

Two things worth knowing:

- The button only renders once **GitHub Sponsors is enabled for `kjanat`**. Until then the file is inert rather than broken — no error, just no button.
- `github:` is the only key here. The schema also accepts `patreon`, `open_collective`, `ko_fi`, `liberapay`, `custom` and others if you want to add more later; `github:` additionally takes a list (`[kjanat, other]`) for up to four accounts.

---
_Generated by [Claude Code](https://claude.ai/code/session_017VwuNH9jbpijabiAPctGNr)_ <-- expensive