### PR TITLE
Declare funding metadata in the root manifest

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   "description": "Static checker for GitHub Actions workflow files",
   "homepage": "https://actionlint.kjanat.dev",
   "repository": "https://github.com/kjanat/actionlint",
+  "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/kjanat"
+  },
   "license": "MIT",
   "type": "module",
   "workspaces": [


### PR DESCRIPTION
Follow-up to #101, which merged with only `.github/FUNDING.yml` — this commit raced that merge and did not make it in.

```json
"funding": {
  "type": "github",
  "url": "https://github.com/sponsors/kjanat"
}
```

## What it actually does

`npm fund`, run inside a clone, lists the root package's own funding URL first, above the dependency tree:

```
$ npm fund                                  # with the field
https://github.com/sponsors/kjanat
| `-- actionlint
+-- https://github.com/sponsors/puzrin
|   `-- pako@3.0.1
...

$ npm fund                                  # without it
actionlint
+-- https://github.com/sponsors/puzrin
|   `-- pako@3.0.1
```

`npm fund actionlint` opens that URL directly.

The audience is narrow — anyone working in a clone, not anyone installing anything, since the root package is `"private": true` and never published. It is not what drives the Sponsor button either; `.github/FUNDING.yml` does that. But it is not inert, which is what an earlier draft of this description claimed.

The copy that reaches users is in #95: the published facade `@kjanat/actionlint` carries the same block, and the eleven platform packages inherit it through the metadata they already take from the facade. That is what puts a Funding link on npmjs.com and surfaces it in a consumer's `npm fund`.

## On the shape

`type` is free-form in npm's schema — the documented examples are `individual` and `patreon`, and a bare string URL is equally valid. `github` is the conventional spelling for a Sponsors link; say the word if you would rather have `"funding": "https://github.com/sponsors/kjanat"`.