### PR TITLE
Restore Go 1.26 compatibility

### DIFF
--- a/.github/workflows/upkeep.yaml
+++ b/.github/workflows/upkeep.yaml
@@ -153,6 +153,49 @@ jobs:
             documentation
             type:maintenance
           assignees: ${{ github.repository_owner }}
+  go-toolchain:
+    name: Bump Go toolchain
+    if: (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && github.repository_owner == 'kjanat'
+    runs-on: ubuntu-latest
+    permissions: { contents: write, pull-requests: write }
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with: { persist-credentials: false }
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
+        with: { go-version-file: go.mod }
+      - name: Check the latest stable Go toolchain
+        id: version
+        run: |
+          set -euo pipefail
+          version="$(curl --fail --silent --show-error --location 'https://go.dev/VERSION?m=text' | sed -n '1p')"
+          if [[ ! "${version}" =~ ^go[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error title=Invalid Go version::go.dev returned '${version}'"
+            exit 1
+          fi
+          go mod edit -toolchain="${version}"
+          echo "version=${version}" >> "${GITHUB_OUTPUT}"
+      - name: Warn when the pull request will carry no CI
+        env: { UPKEEP_TOKEN: "${{ secrets.UPKEEP_TOKEN }}" }
+        run: |
+          if [[ -z "${UPKEEP_TOKEN}" ]]; then
+            echo '::warning title=No UPKEEP_TOKEN::GITHUB_TOKEN opens the pull request, and GitHub runs no workflows on it. Store a fine-grained token with contents and pull-requests write as the UPKEEP_TOKEN secret.'
+          fi
+      - uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        with:
+          token: ${{ secrets.UPKEEP_TOKEN || github.token }}
+          branch: ci/go-toolchain-version
+          delete-branch: true
+          add-paths: go.mod
+          commit-message: "Bump Go toolchain to ${{ steps.version.outputs.version }}"
+          title: "Bump Go toolchain to ${{ steps.version.outputs.version }}"
+          body: |
+            Updates the preferred Go toolchain in `go.mod` to `${{ steps.version.outputs.version }}`. The minimum supported Go version remains unchanged.
+
+            Created by [this Upkeep run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}).
+          labels: |
+            area:toolchain
+            type:maintenance
+          assignees: ${{ github.repository_owner }}
   shellcheck:
     name: Bump go-shellcheck
     if: (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && github.repository_owner == 'kjanat'

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Install `actionlint` command by downloading [the released binary][releases], usi
 go install actionlint.kjanat.dev/cmd/actionlint@latest
 ```
 
-<sub><u><em><code>actionlint.kjanat.dev</code> is only a <a href="https://pkg.go.dev/cmd/go#hdr-Fully_qualified_import_paths" title="Fully-qualified import paths">Go vanity import path</a>. The Go toolchain resolves it to <a href="https://github.com/kjanat/actionlint" title="https://github.com/kjanat/actionlint">this GitHub repository</a>, where the source, releases, and issue tracker live. Further reading available here: <a href="https://go.dev/ref/mod#goproxy-protocol" title="GOPROXY protocol">GOPROXY protocol</a></em></u></sub>
+<sub><em><code>actionlint.kjanat.dev</code> is only a <a href="https://pkg.go.dev/cmd/go#hdr-Fully_qualified_import_paths" title="Fully-qualified import paths">Go vanity import path</a>. The Go toolchain resolves it to <a href="https://github.com/kjanat/actionlint" title="https://github.com/kjanat/actionlint">this GitHub repository</a>, where the source, releases, and issue tracker live. Further reading available here: <a href="https://go.dev/ref/mod#goproxy-protocol" title="GOPROXY protocol">GOPROXY protocol</a>. Check for yourself: </em><code>curl https://proxy.golang.org/actionlint.kjanat.dev/@latest</code></sub>
 
 Basically all you need to do is run the `actionlint` command in your repository. actionlint automatically detects workflows and checks errors. actionlint focuses on finding out mistakes. It tries to catch errors as much as possible and make false positives as minimal as possible.
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module actionlint.kjanat.dev
 
-go 1.27
+go 1.26
+
+toolchain go1.27.1
 
 require (
 	github.com/bmatcuk/doublestar/v4 v4.10.0

--- a/rule_action.go
+++ b/rule_action.go
@@ -354,8 +354,10 @@ type RuleAction struct {
 // NewRuleAction creates new RuleAction instance.
 func NewRuleAction(cache *LocalActionsCache) *RuleAction {
 	return &RuleAction{
-		name:  "action",
-		desc:  "Checks for popular actions released on GitHub, local actions, and action calls at \"uses:\"",
+		RuleBase: RuleBase{
+			name: "action",
+			desc: "Checks for popular actions released on GitHub, local actions, and action calls at \"uses:\"",
+		},
 		cache: cache,
 	}
 }

--- a/rule_credentials.go
+++ b/rule_credentials.go
@@ -12,8 +12,10 @@ type RuleCredentials struct {
 // NewRuleCredentials creates new RuleCredentials instance
 func NewRuleCredentials() *RuleCredentials {
 	return &RuleCredentials{
-		name: "credentials",
-		desc: "Checks for credentials in \"services:\" configuration",
+		RuleBase: RuleBase{
+			name: "credentials",
+			desc: "Checks for credentials in \"services:\" configuration",
+		},
 	}
 }
 

--- a/rule_deprecated_commands.go
+++ b/rule_deprecated_commands.go
@@ -16,8 +16,10 @@ type RuleDeprecatedCommands struct {
 // NewRuleDeprecatedCommands creates a new RuleDeprecatedCommands instance.
 func NewRuleDeprecatedCommands() *RuleDeprecatedCommands {
 	return &RuleDeprecatedCommands{
-		name: "deprecated-commands",
-		desc: "Checks for deprecated \"set-output\", \"save-state\", \"set-env\", and \"add-path\" commands at \"run:\"",
+		RuleBase: RuleBase{
+			name: "deprecated-commands",
+			desc: "Checks for deprecated \"set-output\", \"save-state\", \"set-env\", and \"add-path\" commands at \"run:\"",
+		},
 	}
 }
 

--- a/rule_env_var.go
+++ b/rule_env_var.go
@@ -10,8 +10,10 @@ type RuleEnvVar struct {
 // NewRuleEnvVar creates new RuleEnvVar instance.
 func NewRuleEnvVar() *RuleEnvVar {
 	return &RuleEnvVar{
-		name: "env-var",
-		desc: "Checks for environment variables configuration at \"env:\"",
+		RuleBase: RuleBase{
+			name: "env-var",
+			desc: "Checks for environment variables configuration at \"env:\"",
+		},
 	}
 }
 

--- a/rule_events.go
+++ b/rule_events.go
@@ -20,8 +20,10 @@ type RuleEvents struct {
 // NewRuleEvents creates new RuleEvents instance.
 func NewRuleEvents() *RuleEvents {
 	return &RuleEvents{
-		name: "events",
-		desc: "Checks for workflow trigger events at \"on:\"",
+		RuleBase: RuleBase{
+			name: "events",
+			desc: "Checks for workflow trigger events at \"on:\"",
+		},
 	}
 }
 

--- a/rule_expression.go
+++ b/rule_expression.go
@@ -41,8 +41,10 @@ type RuleExpression struct {
 // NewRuleExpression creates new RuleExpression instance.
 func NewRuleExpression(actionsCache *LocalActionsCache, workflowCache *LocalReusableWorkflowCache) *RuleExpression {
 	return &RuleExpression{
-		name:             "expression",
-		desc:             "Syntax and semantics checks for expressions embedded with ${{ }} syntax",
+		RuleBase: RuleBase{
+			name: "expression",
+			desc: "Syntax and semantics checks for expressions embedded with ${{ }} syntax",
+		},
 		matrixTy:         nil,
 		stepsTy:          nil,
 		needsTy:          nil,

--- a/rule_glob.go
+++ b/rule_glob.go
@@ -9,8 +9,10 @@ type RuleGlob struct {
 // NewRuleGlob creates new RuleGlob instance.
 func NewRuleGlob() *RuleGlob {
 	return &RuleGlob{
-		name: "glob",
-		desc: "Checks for glob syntax used in branch names, tags, and paths",
+		RuleBase: RuleBase{
+			name: "glob",
+			desc: "Checks for glob syntax used in branch names, tags, and paths",
+		},
 	}
 }
 

--- a/rule_id.go
+++ b/rule_id.go
@@ -16,8 +16,10 @@ type RuleID struct {
 // NewRuleID creates a new RuleID instance.
 func NewRuleID() *RuleID {
 	return &RuleID{
-		name: "id",
-		desc: "Checks for duplication and naming convention of job/step IDs",
+		RuleBase: RuleBase{
+			name: "id",
+			desc: "Checks for duplication and naming convention of job/step IDs",
+		},
 	}
 }
 

--- a/rule_if_cond.go
+++ b/rule_if_cond.go
@@ -12,8 +12,10 @@ type RuleIfCond struct {
 // NewRuleIfCond creates new RuleIfCond instance.
 func NewRuleIfCond() *RuleIfCond {
 	return &RuleIfCond{
-		name: "if-cond",
-		desc: "Checks for if: conditions which are always true/false",
+		RuleBase: RuleBase{
+			name: "if-cond",
+			desc: "Checks for if: conditions which are always true/false",
+		},
 	}
 }
 

--- a/rule_job_needs.go
+++ b/rule_job_needs.go
@@ -37,8 +37,10 @@ type RuleJobNeeds struct {
 // NewRuleJobNeeds creates new RuleJobNeeds instance.
 func NewRuleJobNeeds() *RuleJobNeeds {
 	return &RuleJobNeeds{
-		name:  "job-needs",
-		desc:  "Checks for job IDs in \"needs:\". Undefined IDs and cyclic dependencies are checked",
+		RuleBase: RuleBase{
+			name: "job-needs",
+			desc: "Checks for job IDs in \"needs:\". Undefined IDs and cyclic dependencies are checked",
+		},
 		nodes: map[string]*jobNode{},
 	}
 }

--- a/rule_matrix.go
+++ b/rule_matrix.go
@@ -10,8 +10,10 @@ type RuleMatrix struct {
 // NewRuleMatrix creates new RuleMatrix instance.
 func NewRuleMatrix() *RuleMatrix {
 	return &RuleMatrix{
-		name: "matrix",
-		desc: "Checks for matrix combinations in \"matrix:\"",
+		RuleBase: RuleBase{
+			name: "matrix",
+			desc: "Checks for matrix combinations in \"matrix:\"",
+		},
 	}
 }
 

--- a/rule_parallel_steps.go
+++ b/rule_parallel_steps.go
@@ -23,8 +23,10 @@ type RuleParallelSteps struct {
 // NewRuleParallelSteps creates a new RuleParallelSteps instance.
 func NewRuleParallelSteps() *RuleParallelSteps {
 	return &RuleParallelSteps{
-		name: "parallel-steps",
-		desc: "Checks \"wait\"/\"cancel\" references to background steps and steps forbidden inside a \"parallel\" group",
+		RuleBase: RuleBase{
+			name: "parallel-steps",
+			desc: "Checks \"wait\"/\"cancel\" references to background steps and steps forbidden inside a \"parallel\" group",
+		},
 	}
 }
 

--- a/rule_permissions.go
+++ b/rule_permissions.go
@@ -34,8 +34,10 @@ type RulePermissions struct {
 // NewRulePermissions creates new RulePermissions instance.
 func NewRulePermissions() *RulePermissions {
 	return &RulePermissions{
-		name: "permissions",
-		desc: "Checks for permissions configuration in \"permissions:\". Permission names and permission scopes are checked",
+		RuleBase: RuleBase{
+			name: "permissions",
+			desc: "Checks for permissions configuration in \"permissions:\". Permission names and permission scopes are checked",
+		},
 	}
 }
 

--- a/rule_pyflakes.go
+++ b/rule_pyflakes.go
@@ -37,8 +37,10 @@ type RulePyflakes struct {
 
 func newRulePyflakes(cmd *externalCommand) *RulePyflakes {
 	return &RulePyflakes{
-		name:                  "pyflakes",
-		desc:                  "Checks for Python script when \"shell: python\" is configured using Pyflakes",
+		RuleBase: RuleBase{
+			name: "pyflakes",
+			desc: "Checks for Python script when \"shell: python\" is configured using Pyflakes",
+		},
 		cmd:                   cmd,
 		workflowShellIsPython: shellIsPythonKindUnspecified,
 		jobShellIsPython:      shellIsPythonKindUnspecified,

--- a/rule_require_commit_hash.go
+++ b/rule_require_commit_hash.go
@@ -24,8 +24,10 @@ type RuleRequireCommitHash struct {
 // NewRuleRequireCommitHash creates a new RuleRequireCommitHash instance.
 func NewRuleRequireCommitHash() *RuleRequireCommitHash {
 	return &RuleRequireCommitHash{
-		name: "require-commit-hash",
-		desc: "Checks that every \"uses:\" is pinned to a full-length commit SHA or an image digest",
+		RuleBase: RuleBase{
+			name: "require-commit-hash",
+			desc: "Checks that every \"uses:\" is pinned to a full-length commit SHA or an image digest",
+		},
 	}
 }
 

--- a/rule_require_job_timeout.go
+++ b/rule_require_job_timeout.go
@@ -12,8 +12,10 @@ type RuleRequireJobTimeout struct {
 // NewRuleRequireJobTimeout creates a new RuleRequireJobTimeout instance with the given policy.
 func NewRuleRequireJobTimeout(policy *JobTimeoutPolicy) *RuleRequireJobTimeout {
 	return &RuleRequireJobTimeout{
-		name:   "require-job-timeout",
-		desc:   "Checks that every job sets \"timeout-minutes:\" within the configured maximum",
+		RuleBase: RuleBase{
+			name: "require-job-timeout",
+			desc: "Checks that every job sets \"timeout-minutes:\" within the configured maximum",
+		},
 		policy: policy,
 	}
 }

--- a/rule_required_actions.go
+++ b/rule_required_actions.go
@@ -79,8 +79,10 @@ type RuleRequiredActions struct {
 // NewRuleRequiredActions creates a new RuleRequiredActions instance.
 func NewRuleRequiredActions() *RuleRequiredActions {
 	return &RuleRequiredActions{
-		name: "required-actions",
-		desc: "Checks that the actions listed in the \"required-actions\" policy in actionlint.yaml are used",
+		RuleBase: RuleBase{
+			name: "required-actions",
+			desc: "Checks that the actions listed in the \"required-actions\" policy in actionlint.yaml are used",
+		},
 	}
 }
 

--- a/rule_runner_label.go
+++ b/rule_runner_label.go
@@ -140,8 +140,10 @@ type RuleRunnerLabel struct {
 // NewRuleRunnerLabel creates new RuleRunnerLabel instance.
 func NewRuleRunnerLabel() *RuleRunnerLabel {
 	return &RuleRunnerLabel{
-		name:    "runner-label",
-		desc:    "Checks for GitHub-hosted and preset self-hosted runner labels in \"runs-on:\"",
+		RuleBase: RuleBase{
+			name: "runner-label",
+			desc: "Checks for GitHub-hosted and preset self-hosted runner labels in \"runs-on:\"",
+		},
 		compats: nil,
 	}
 }

--- a/rule_shell_name.go
+++ b/rule_shell_name.go
@@ -23,8 +23,10 @@ type RuleShellName struct {
 // NewRuleShellName creates new RuleShellName instance.
 func NewRuleShellName() *RuleShellName {
 	return &RuleShellName{
-		name:     "shell-name",
-		desc:     "Checks for shell names used for scripts in \"run:\"",
+		RuleBase: RuleBase{
+			name: "shell-name",
+			desc: "Checks for shell names used for scripts in \"run:\"",
+		},
 		platform: platformKindAny,
 	}
 }

--- a/rule_shellcheck.go
+++ b/rule_shellcheck.go
@@ -34,8 +34,10 @@ type RuleShellcheck struct {
 
 func newRuleShellcheck(cmd *externalCommand) *RuleShellcheck {
 	return &RuleShellcheck{
-		name:          "shellcheck",
-		desc:          "Checks for shell script sources in \"run:\" using shellcheck",
+		RuleBase: RuleBase{
+			name: "shellcheck",
+			desc: "Checks for shell script sources in \"run:\" using shellcheck",
+		},
 		cmd:           cmd,
 		workflowShell: "",
 		jobShell:      "",

--- a/rule_workflow_call.go
+++ b/rule_workflow_call.go
@@ -20,8 +20,10 @@ type RuleWorkflowCall struct {
 // the workflow which is relative to a project root directory or an absolute path.
 func NewRuleWorkflowCall(workflowPath string, cache *LocalReusableWorkflowCache) *RuleWorkflowCall {
 	return &RuleWorkflowCall{
-		name:                 "workflow-call",
-		desc:                 "Checks for reusable workflow calls. Inputs and outputs of called reusable workflow are checked",
+		RuleBase: RuleBase{
+			name: "workflow-call",
+			desc: "Checks for reusable workflow calls. Inputs and outputs of called reusable workflow are checked",
+		},
 		workflowCallEventPos: nil,
 		workflowPath:         workflowPath,
 		cache:                cache,


### PR DESCRIPTION
Go 1.27's promoted-field composite literals made v1.14.0 require Go 1.27 even though the source otherwise remains compatible with Go 1.26. This restores explicit `RuleBase` literals so downstream tool modules can stay on Go 1.26.

`go.mod` now declares Go 1.26 while preferring the Go 1.27.1 toolchain. The new scheduled/manual Upkeep job checks go.dev for newer stable toolchains and opens a focused `go.mod` pull request without changing the minimum supported Go version.

The installation note also makes the vanity import path explicit and includes a GOPROXY query readers can run themselves.

## Validation

- `GOTOOLCHAIN=local mise exec go@1.26.7 -- go test ./...`
- `GOTOOLCHAIN=go1.27.1 go test ./...`
- `go mod tidy -diff` with Go 1.26.7 and Go 1.27.1
- Repository-built actionlint on `.github/workflows/upkeep.yaml`
- `dprint check .github/workflows/upkeep.yaml README.md`
- `go run ./scripts/check-readme -quiet ./README.md`