### PR TITLE
Add completion generation to Homebrew cask

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -62,6 +62,9 @@ homebrew_casks:
     directory: Casks
     binaries: [actionlint]
     manpages: [man/actionlint.1]
+    generate_completions_from_executable:
+      args: [-completion]
+      shells: [bash, zsh, fish, pwsh]
     homepage: https://actionlint.kjanat.dev
     description: Static checker for GitHub Actions workflow files
     dependencies:


### PR DESCRIPTION
Version requirements:
- Hombrew 6.0.0 https://brew.sh/2026/06/11/homebrew-6.0.0/
- GoReleaser 2.15 https://goreleaser.com/customization/publish/homebrew_casks/
- kjanat/actionlint 1.13.0 https://github.com/kjanat/actionlint/blob/master/CHANGELOG.md#v1130---2026-08-29

Cask docs
- https://docs.brew.sh/Cask-Cookbook#stanza-generate_completions_from_executable

Closes #112.

(written by hand and not tested)