### PR TITLE
Keep pull request checks hermetic

### DIFF
--- a/.github/workflows/download.yaml
+++ b/.github/workflows/download.yaml
@@ -2,13 +2,11 @@ name: Download script
 on:
   push:
     branches: [main, master]
-    paths: &paths
+    paths:
       - .github/workflows/download.yaml
       - .goreleaser.yaml
       - scripts/download-actionlint.bash
       - scripts/test-download-actionlint.bash
-  pull_request:
-    paths: *paths
   workflow_dispatch:
 
 permissions: { contents: read }

--- a/scripts/generate-availability/main_test.go
+++ b/scripts/generate-availability/main_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"errors"
 	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -139,12 +141,15 @@ func TestWriteError(t *testing.T) {
 }
 
 func TestFetchError(t *testing.T) {
+	notFound := httptest.NewServer(http.NotFoundHandler())
+	defer notFound.Close()
+
 	testCases := []struct {
 		what string
 		url  string
 		want string
 	}{
-		{"not found", "https://raw.githubusercontent.com/rhysd/actionlint/main/this-file-does-not-exist.txt", "request was not successful"},
+		{"not found", notFound.URL, "request was not successful"},
 		{"invalid url", "foo://bar", "could not fetch"},
 	}
 

--- a/scripts/generate-popular-actions/main_test.go
+++ b/scripts/generate-popular-actions/main_test.go
@@ -19,6 +19,65 @@ func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 	return f(req)
 }
 
+var testRemoteActionYAML = map[string]string{
+	"https://raw.githubusercontent.com/rhysd/action-setup-vim/v1.3.2/action.yml": `
+name: Setup Vim
+inputs:
+  configure-args: {}
+  neovim: {}
+  token: {}
+  version: {}
+outputs:
+  executable: {}
+`,
+	"https://raw.githubusercontent.com/rhysd/changelog-from-release/v2.2.2/action/action.yml": `
+name: Run changelog-from-release
+inputs:
+  commit: {}
+  file:
+    required: true
+  github_token:
+    required: true
+  push: {}
+  version: {}
+`,
+	"https://raw.githubusercontent.com/rhysd/action-setup-vim/v1.0.0/action.yml": `
+name: Setup Vim
+inputs:
+  github-token: {}
+  neovim: {}
+  version: {}
+outputs:
+  executable: {}
+runs:
+  using: node12
+  main: src/index.js
+`,
+	"https://raw.githubusercontent.com/rhysd/action-setup-vim/v1/action.yml": `
+name: Setup Vim
+`,
+}
+
+func newTestGen(stdout, stderr, debug io.Writer) *gen {
+	g := newGen(stdout, stderr, debug)
+	g.client = &http.Client{Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		body, ok := testRemoteActionYAML[req.URL.String()]
+		statusCode := http.StatusNotFound
+		status := "404 Not Found"
+		if ok {
+			statusCode = http.StatusOK
+			status = "200 OK"
+		}
+		return &http.Response{
+			StatusCode: statusCode,
+			Status:     status,
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Request:    req,
+		}, nil
+	})}
+	return g
+}
+
 // Normal cases
 
 func TestDefaultPopularActions(t *testing.T) {
@@ -230,10 +289,10 @@ func TestFetchRemoteYAML(t *testing.T) {
 		t.Run(tc.registry, func(t *testing.T) {
 			f := filepath.Join("testdata", "registry", tc.registry)
 			stdout := &bytes.Buffer{}
-			stderr := io.Discard
-			status := newGen(stdout, stderr, io.Discard).run([]string{"test", "-r", f})
+			stderr := &bytes.Buffer{}
+			status := newTestGen(stdout, stderr, io.Discard).run([]string{"test", "-r", f})
 			if status != 0 {
-				t.Fatal("exit status is non-zero:", status)
+				t.Fatalf("exit status is non-zero: %d: %s", status, stderr.Bytes())
 			}
 
 			b, err := os.ReadFile(filepath.Join("testdata", "go", tc.want))
@@ -253,10 +312,10 @@ func TestFetchRemoteYAML(t *testing.T) {
 func TestWriteOutdatedActionAsJSONL(t *testing.T) {
 	f := filepath.Join("testdata", "registry", "outdated.json")
 	stdout := &bytes.Buffer{}
-	stderr := io.Discard
-	status := newGen(stdout, stderr, io.Discard).run([]string{"test", "-r", f, "-f", "jsonl"})
+	stderr := &bytes.Buffer{}
+	status := newTestGen(stdout, stderr, io.Discard).run([]string{"test", "-r", f, "-f", "jsonl"})
 	if status != 0 {
-		t.Fatal("exit status is non-zero:", status)
+		t.Fatalf("exit status is non-zero: %d: %s", status, stderr.Bytes())
 	}
 
 	b, err := os.ReadFile(filepath.Join("testdata", "jsonl", "outdated.jsonl"))
@@ -320,10 +379,10 @@ func TestHelpOutput(t *testing.T) {
 func TestDetectNewRelease(t *testing.T) {
 	f := filepath.Join("testdata", "registry", "new_release.json")
 	stdout := &bytes.Buffer{}
-	stderr := io.Discard
-	status := newGen(stdout, stderr, io.Discard).run([]string{"test", "-d", "-r", f})
+	stderr := &bytes.Buffer{}
+	status := newTestGen(stdout, stderr, io.Discard).run([]string{"test", "-d", "-r", f})
 	if status != 2 {
-		t.Fatal("exit status is not 2:", status)
+		t.Fatalf("exit status is not 2: %d: %s", status, stderr.Bytes())
 	}
 	out := stdout.String()
 	want := "https://github.com/rhysd/action-setup-vim/tree/v1"
@@ -341,11 +400,11 @@ func TestDetectNoRelease(t *testing.T) {
 	for _, f := range files {
 		t.Run(f, func(t *testing.T) {
 			stdout := &bytes.Buffer{}
-			stderr := io.Discard
+			stderr := &bytes.Buffer{}
 			p := filepath.Join("testdata", "registry", f)
-			status := newGen(stdout, stderr, io.Discard).run([]string{"test", "-d", "-r", p})
+			status := newTestGen(stdout, stderr, io.Discard).run([]string{"test", "-d", "-r", p})
 			if status != 0 {
-				t.Fatal("exit status is non-zero:", status)
+				t.Fatalf("exit status is non-zero: %d: %s", status, stderr.Bytes())
 			}
 			out := stdout.String()
 			if out != "No new release was found\n" {
@@ -432,7 +491,7 @@ func TestCouldNotFetch(t *testing.T) {
 	stderr := &bytes.Buffer{}
 	f := filepath.Join("testdata", "registry", "repo_not_found.json")
 
-	status := newGen(io.Discard, stderr, io.Discard).run([]string{"test", "-r", f})
+	status := newTestGen(io.Discard, stderr, io.Discard).run([]string{"test", "-r", f})
 	if status == 0 {
 		t.Fatal("exit status is unexpectedly zero")
 	}

--- a/scripts/generate-popular-actions/main_test.go
+++ b/scripts/generate-popular-actions/main_test.go
@@ -20,15 +20,22 @@ func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 }
 
 var testRemoteActionYAML = map[string]string{
-	"https://raw.githubusercontent.com/rhysd/action-setup-vim/v1.3.2/action.yml": `
-name: Setup Vim
+	"https://raw.githubusercontent.com/kjanat/actions-shells/v0.1.0/action.yml": `
+name: Actions Shells
 inputs:
-  configure-args: {}
-  neovim: {}
-  token: {}
-  version: {}
+  doctor:
+    required: false
+    default: "false"
+  runtimes:
+    required: false
+    default: ""
 outputs:
-  executable: {}
+  bin-dir: {}
+  cli: {}
+  version: {}
+runs:
+  using: node24
+  main: setup.mjs
 `,
 	"https://raw.githubusercontent.com/rhysd/changelog-from-release/v2.2.2/action/action.yml": `
 name: Run changelog-from-release

--- a/scripts/generate-popular-actions/testdata/go/fetched.go
+++ b/scripts/generate-popular-actions/testdata/go/fetched.go
@@ -5,16 +5,16 @@ package actionlint
 // PopularActions is data set of known popular actions. Keys are specs (owner/repo@ref) of actions
 // and values are their metadata.
 var PopularActions = map[string]*ActionMetadata{
-	"rhysd/action-setup-vim@v1.3.2": {
-		Name: "Setup Vim",
+	"kjanat/actions-shells@v0.1.0": {
+		Name: "Actions Shells",
 		Inputs: ActionMetadataInputs{
-			"configure-args": {"configure-args", false, false, ""},
-			"neovim":         {"neovim", false, false, ""},
-			"token":          {"token", false, false, ""},
-			"version":        {"version", false, false, ""},
+			"doctor":   {"doctor", false, false, ""},
+			"runtimes": {"runtimes", false, false, ""},
 		},
 		Outputs: ActionMetadataOutputs{
-			"executable": {"executable"},
+			"bin-dir": {"bin-dir"},
+			"cli":     {"cli"},
+			"version": {"version"},
 		},
 	},
 	"rhysd/changelog-from-release/action@v2.2.2": {

--- a/scripts/generate-popular-actions/testdata/registry/fetch.json
+++ b/scripts/generate-popular-actions/testdata/registry/fetch.json
@@ -1,8 +1,8 @@
 [
     {
-      "slug": "rhysd/action-setup-vim",
-      "tags": ["v1.3.2"],
-      "next": "v2"
+      "slug": "kjanat/actions-shells",
+      "tags": ["v0.1.0"],
+      "next": "v0.2.0"
     },
     {
       "slug": "rhysd/changelog-from-release",

--- a/scripts/generate-webhook-events/main_test.go
+++ b/scripts/generate-webhook-events/main_test.go
@@ -5,6 +5,8 @@ import (
 	"go/parser"
 	"go/token"
 	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -119,11 +121,16 @@ func TestParseError(t *testing.T) {
 }
 
 func TestFetchURL(t *testing.T) {
-	b, err := fetch("https://github.com")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, "test response")
+	}))
+	defer server.Close()
+
+	b, err := fetch(server.URL)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(b) == 0 {
-		t.Fatal("Fetched source is empty")
+	if string(b) != "test response" {
+		t.Fatalf("fetched source is unexpected: %q", b)
 	}
 }

--- a/scripts/test-download-actionlint.bash
+++ b/scripts/test-download-actionlint.bash
@@ -18,18 +18,30 @@ pushd "${temp_dir}"
 # Normal cases
 set -e
 
-# Latest release
-out="$(bash "${script}" latest)"
-if [[ -n "${GITHUB_ACTION}" ]]; then
-	if [[ "${out}" != *"executable="* ]]; then
-		echo "'executable' step output is not set: '${out}'" >&2
+check_latest_version() {
+	local executable="$1"
+	local out first_line version
+
+	out="$("${executable}" -version)"
+	first_line="${out%%$'\n'*}"
+	version="${first_line#actionlint.kjanat.dev }"
+	if [[ ! "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] \
+		|| [[ "${out}" != *"https://github.com/kjanat/actionlint/releases/tag/v${version}"* ]]; then
+		echo "Output from ${executable} -version is unexpected: '${out}'" >&2
+		exit 1
 	fi
-fi
-out="$(./actionlint -version)"
-if [[ "${out}" != *'installed by downloading from release page'* ]]; then
-	echo "Output from ./actionlint -version is unexpected: '${out}'" >&2
+}
+
+# Latest release
+github_output="${temp_dir}/github-output"
+out="$(GITHUB_ACTION=true GITHUB_OUTPUT="${github_output}" bash "${script}" latest)"
+if ! grep -Fqx "executable=${temp_dir}/actionlint" "${github_output}"; then
+	echo "'executable' step output is not set correctly in ${github_output}:" >&2
+	cat "${github_output}" >&2
+	echo "Download script output: '${out}'" >&2
 	exit 1
 fi
+check_latest_version ./actionlint
 rm -f ./actionlint
 
 # Specify only version
@@ -44,11 +56,7 @@ rm -f ./actionlint
 # Specify only a download directory
 mkdir ./test1
 bash "${script}" latest ./test1
-out="$(./test1/actionlint -version)"
-if [[ "${out}" != *'installed by downloading from release page'* ]]; then
-	echo "Output from ./actionlint -version is unexpected: '${out}'" >&2
-	exit 1
-fi
+check_latest_version ./test1/actionlint
 rm -rf ./test1
 
 # Specify both version and a download directory


### PR DESCRIPTION
## Summary

- replace public GitHub requests in generator unit tests with deterministic in-memory or local HTTP responses
- keep the mutable latest-release download integration off pull requests while retaining default-branch and manual coverage
- validate the current GoReleaser version provenance and the download script's GITHUB_OUTPUT value

## Testing

- `go test -shuffle=on ./...`
- generator test packages repeated with `-count=50`
- `actionlint`
- `shellcheck ./scripts/*.bash`
- `./scripts/test-download-actionlint.bash`