### PR TITLE
security: pin workflows (including own)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -94,7 +94,7 @@ jobs:
         with: { go-version-file: go.mod }
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with: { node-version-file: .node-version, package-manager-cache: false }
-      - uses: kjanat/runner@master
+      - uses: kjanat/runner@6e752d37c4b3de6bda86c89b2f5bc487097425cd # master
       - uses: $/.github/actions/setup-pandoc
       - name: Install JavaScript dependencies
         run: runner install --frozen
@@ -113,7 +113,7 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with: { go-version-file: go.mod }
       - uses: $/.github/actions/setup-pandoc
-      - uses: kjanat/runner@master
+      - uses: kjanat/runner@6e752d37c4b3de6bda86c89b2f5bc487097425cd # master
       - run: run make:man/actionlint.1
       - name: Install syft for SBOM generation
         uses: anchore/sbom-action/download-syft@3ad7283483fc7af8ff2b4ea19663c2d5ca935e26 # v0.24.2
@@ -141,7 +141,7 @@ jobs:
       - name: Install golangci-lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with: { version: v2.13.1, install-only: true }
-      - uses: kjanat/runner@master
+      - uses: kjanat/runner@6e752d37c4b3de6bda86c89b2f5bc487097425cd # master
       - run: go mod tidy -diff
       - name: Build through Makefile
         run: run make:build

--- a/.github/workflows/matcher.yaml
+++ b/.github/workflows/matcher.yaml
@@ -19,7 +19,7 @@ jobs:
         with: { go-version-file: go.mod }
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with: { node-version-file: .node-version, package-manager-cache: false }
-      - uses: kjanat/runner@master
+      - uses: kjanat/runner@6e752d37c4b3de6bda86c89b2f5bc487097425cd # master
       - name: Update test data
         run: run -s make:scripts/generate-actionlint-matcher/testdata/escape.txt make:scripts/generate-actionlint-matcher/testdata/no_escape.txt make:scripts/generate-actionlint-matcher/testdata/want.json
         env: { SKIP_GO_GENERATE: "true" }

--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with: { node-version-file: .node-version, package-manager-cache: false }
       - uses: $/.github/actions/setup-pandoc
-      - uses: kjanat/runner@master
+      - uses: kjanat/runner@6e752d37c4b3de6bda86c89b2f5bc487097425cd # master
       - name: Install JavaScript dependencies
         run: runner install --frozen
       - name: Build command manual

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with: { persist-credentials: false }
       - uses: $/.github/actions/setup-pandoc
-      - uses: kjanat/runner@master
+      - uses: kjanat/runner@6e752d37c4b3de6bda86c89b2f5bc487097425cd # master
       - run: run make:man/actionlint.1
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with: { name: manual, path: man/actionlint.1, if-no-files-found: error }
@@ -69,7 +69,7 @@ jobs:
     needs: binaries
     if: github.repository == 'rhysd/actionlint'
     steps:
-      - uses: vedantmgoyal9/winget-releaser@main
+      - uses: vedantmgoyal9/winget-releaser@b3a5dae0047c6180023acba3f548c55fdf6b7193 # main
         with:
           identifier: rhysd.actionlint
           installers-regex: '_windows_\w+\.zip$'

--- a/testdata/bench/large.yaml
+++ b/testdata/bench/large.yaml
@@ -158,7 +158,7 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version: '1.25'
-      - uses: github/codeql-action/init@v4
+      - uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4
         with:
           config-file: ./.github/codeql/codeql-config.yaml
           languages: go
@@ -167,7 +167,7 @@ jobs:
           set -x
           go build -v ./cmd/actionlint
           GOOS=js GOARCH=wasm go build -v -o ./playground/main.wasm ./playground
-      - uses: github/codeql-action/analyze@v4
+      - uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4
         with:
           category: "/language:go"
   analyze-ts:

--- a/testdata/examples/main.yaml
+++ b/testdata/examples/main.yaml
@@ -11,11 +11,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - run: echo "Checking commit '${{ github.event.head_commit.message }}'"
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node_version: 18.x
-      - uses: actions/cache@v6
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ~/.npm
           key: ${{ matrix.platform }}-node-${{ hashFiles('**/package-lock.json') }}


### PR DESCRIPTION
This pull request updates several GitHub Actions in workflow files to use specific commit SHAs instead of floating references like `master` or branch names. This change improves the security and reliability of the CI/CD pipelines by ensuring that workflows always use a known, immutable version of each action.

**Workflow dependency pinning:**

* Updated all usages of `kjanat/runner@master` to `kjanat/runner@6e752d37c4b3de6bda86c89b2f5bc487097425cd` in `.github/workflows/ci.yaml`, `.github/workflows/matcher.yaml`, `.github/workflows/pages.yaml`, and `.github/workflows/release.yaml`. [[1]](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL97-R97) [[2]](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL116-R116) [[3]](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL144-R144) [[4]](diffhunk://#diff-40b92d019b0d41792aa27541268197044dfbf8f907e36b861c352aff622e7756L22-R22) [[5]](diffhunk://#diff-86eaae8c6d4108350f0ef9589ef2a19de3d6e3693eff3b89ee35c160ae35c21cL24-R24) [[6]](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL35-R35)

* Updated `vedantmgoyal9/winget-releaser@main` to a specific commit SHA `b3a5dae0047c6180023acba3f548c55fdf6b7193` in `.github/workflows/release.yaml`.

* Updated `github/codeql-action/init@v4` and `github/codeql-action/analyze@v4` to use commit `cdf488f595d80d6e07e03d4674febd5ab45fa938` in `testdata/bench/large.yaml`. [[1]](diffhunk://#diff-bec9356805f136cffa91608c6447bd1fa8a1d3af261faa1b55861f426c39797bL161-R161) [[2]](diffhunk://#diff-bec9356805f136cffa91608c6447bd1fa8a1d3af261faa1b55861f426c39797bL170-R170)

* Updated `actions/checkout@v7`, `actions/setup-node@v7`, and `actions/cache@v6` to their respective commit SHAs in `testdata/examples/main.yaml`.

These updates lock down workflow dependencies, reducing the risk of unexpected changes or supply chain attacks in your CI/CD processes.

- Closes #115.