### PR TITLE
Publish to kjanat/homebrew-tap

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -65,7 +65,8 @@ source:
   files: [man/actionlint.1]
 
 homebrew_casks:
-  - name: actionlint
+  - &actionlint_cask
+    name: actionlint
     ids: [nix]
     directory: Casks
     binaries: [actionlint]
@@ -102,6 +103,14 @@ homebrew_casks:
     commit_author:
       name: "github-actions[bot]"
       email: "41898282+github-actions[bot]@users.noreply.github.com"
+  # One tap for every project. The per-project tap keeps receiving the cask
+  # until it is archived, since Homebrew cannot redirect a tap.
+  - <<: *actionlint_cask
+    repository:
+      owner: kjanat
+      name: homebrew-tap
+      branch: master
+      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
 scoops:
   - name: actionlint
     ids: [windows]

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -85,8 +85,6 @@ homebrew_casks:
     homepage: https://actionlint.kjanat.dev
     description: Static checker for GitHub Actions workflow files
     skip_upload: auto
-    dependencies:
-      - formula: shellcheck
     # The binary is not notarized. Without this, Gatekeeper blocks it, and the
     # completion generation above runs it during install.
     hooks:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -201,10 +201,11 @@ To move the defaults to newer base images:
 
 ## Make a new release
 
-Updating [the Homebrew tap](https://github.com/kjanat/homebrew-actionlint) needs a `HOMEBREW_TAP_TOKEN` secret on this
+Updating the Homebrew taps, [kjanat/homebrew-tap](https://github.com/kjanat/homebrew-tap) and
+[kjanat/homebrew-actionlint](https://github.com/kjanat/homebrew-actionlint), needs a `HOMEBREW_TAP_TOKEN` secret on this
 repository, because the built-in `GITHUB_TOKEN` cannot write to another one. It is a fine-grained personal access token
-whose repository access is `kjanat/homebrew-actionlint` alone, with `Contents: Read and write` and nothing else. The
-GoReleaser step fails without it.
+whose repository access is those two repositories alone, with `Contents: Read and write` and nothing else. The GoReleaser
+step fails without it.
 
 When releasing v1.2.3 as example:
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -96,6 +96,15 @@ brew install kjanat/tap/actionlint
 The cask is also published to the per-project `kjanat/actionlint` tap, so an existing `brew install
 kjanat/actionlint/actionlint` keeps upgrading.
 
+The cask installs the `actionlint` binary and nothing else. The [shellcheck integration](checks.md#check-shellcheck-integ)
+needs a `shellcheck` on `PATH`. The `shellcheck` formula from homebrew-core builds it with GHC and, on Linux, pulls in `gcc`
+and `glibc` as runtime dependencies. The `kjanat/tap/shellcheck` cask installs the static binary ShellCheck itself
+releases, with no dependencies, and conflicts with the formula:
+
+```sh
+brew install kjanat/tap/shellcheck
+```
+
 > [!WARNING]
 > Since the `actionlint` executable is unsigned, macOS displays a warning and tries to move it to the Trash. To allow it to run,
 > go to 'Settings -> Privacy & Security' and grant the permission.

--- a/docs/install.md
+++ b/docs/install.md
@@ -86,12 +86,15 @@ nix-env -iA nixpkgs.actionlint
 brew install actionlint
 ```
 
-That formula tracks the upstream project. To install this fork instead, use its own tap, which is updated automatically
-on every release:
+That formula tracks the upstream project. To install this fork instead, use the `kjanat/tap` tap, which is updated
+automatically on every release:
 
 ```sh
-brew install kjanat/actionlint/actionlint
+brew install kjanat/tap/actionlint
 ```
+
+The cask is also published to the per-project `kjanat/actionlint` tap, so an existing `brew install
+kjanat/actionlint/actionlint` keeps upgrading.
 
 > [!WARNING]
 > Since the `actionlint` executable is unsigned, macOS displays a warning and tries to move it to the Trash. To allow it to run,


### PR DESCRIPTION
Closes #109. Closes #110.

The install line becomes `brew install kjanat/tap/actionlint`. The tap is https://github.com/kjanat/homebrew-tap, on `master` like the current tap.

Homebrew cannot redirect a tap, so whoever tapped `kjanat/actionlint` keeps upgrading from that repository. The cask keeps going there too, as a second `homebrew_casks` entry merged from the first with only `repository` overridden, until that tap is archived. `docs/install.md` names the new line and says the old one keeps working, and CONTRIBUTING names both taps for the token.

The cask no longer depends on the `shellcheck` formula. That dependency turned a 2.6 MB download into fourteen bottles on Linux, gcc among them, because the homebrew-core formula is built with GHC. actionlint runs without ShellCheck, and `-verbose` says whether it found one. For the integration without the toolchain, the tap now carries a `shellcheck` cask that installs the static binary ShellCheck itself releases, for darwin and linux on arm64 and x86_64, and conflicts with the formula: https://github.com/kjanat/homebrew-tap/blob/b1ca5de5d1514cf19e5463e936823dc6a09d4f19/Casks/shellcheck.rb. The install docs point at it.

<details>
<summary>Verified</summary>

```console
$ goreleaser check
  • checking                                  path=.goreleaser.yaml
  • 1 configuration file(s) validated
  • thanks for using GoReleaser!
$ dprint check; echo "dprint exit $?"
dprint exit 0
$ ruby -c Casks/shellcheck.rb
Syntax OK
$ sha256sum *.tar.xz
56affdd8de5527894dca6dc3d7e0a99a873b0f004d7aabc30ae407d3f48b0a79  darwin.aarch64.tar.xz
3c89db4edcab7cf1c27bff178882e0f6f27f7afdf54e859fa041fca10febe4c6  darwin.x86_64.tar.xz
12b331c1d2db6b9eb13cfca64306b1b157a86eb69db83023e261eaa7e7c14588  linux.aarch64.tar.xz
8c3be12b05d5c177a04c29e3c78ce89ac86f1595681cab149b65b97c4e227198  linux.x86_64.tar.xz
```

Not verified: `brew audit --cask` and an install of the `shellcheck` cask, since this machine has no Homebrew.

</details>

