### PR TITLE
Call npm publishing from the release workflow

### DIFF
--- a/.github/workflows/npm-release.yaml
+++ b/.github/workflows/npm-release.yaml
@@ -1,6 +1,11 @@
 name: npm release
-run-name: ${{ format('npm {0} {1}', case(github.event_name == 'workflow_dispatch' && inputs.dry-run, 'dry-run', 'publish'), case(github.event_name == 'release', github.event.release.tag_name, inputs.tag)) }}
+run-name: ${{ format('npm {0} {1}', case(inputs.dry-run, 'dry-run', 'publish'), case(github.event_name == 'release', github.event.release.tag_name, inputs.tag)) }}
 on:
+  workflow_call:
+    inputs:
+      tag: { description: Release tag to publish, required: true, type: string }
+      dist-tag: { description: npm dist-tag; auto selects next for prereleases and latest otherwise, default: auto, type: string }
+      dry-run: { description: Build and smoke-test without publishing, default: false, type: boolean }
   release: { types: [published] }
   workflow_dispatch:
     inputs:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -69,6 +69,12 @@ jobs:
         with: { subject-checksums: "./dist/actionlint_${{ env.VERSION }}_checksums.txt" }
       - name: Post-release download check
         run: bash ./scripts/download-actionlint.bash
+  npm:
+    needs: binaries
+    permissions: { contents: read, id-token: write }
+    uses: $/.github/workflows/npm-release.yaml
+    with: { tag: "${{ github.ref_name }}" }
+    secrets: inherit
   docker:
     runs-on: ubuntu-latest
     needs: changelog

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # Unreleased
 
+- Call npm publishing as a reusable workflow after the release binaries are uploaded, attested, and checked. This avoids relying on a `release: published` event that GitHub suppresses for releases created with `GITHUB_TOKEN`, while keeping manual publication and dry runs available.
+
 - Name the fork version in the README demo section next to the upstream one, and keep both current through the new `Upkeep` workflow. It regenerates the section after every release and weekly, and opens a pull request when the text moved, so the default branch no longer goes red the moment this fork or upstream ships. The weekly `go generate` and go-shellcheck bumps moved into the same workflow, each on its own pull request branch, and `make lint` no longer compares the README against the releases. The README check still runs on pull requests that touch the fixture, the script, or the section.
 
 <a id="v1.14.0"></a>

--- a/distribution/npm/README.md
+++ b/distribution/npm/README.md
@@ -76,8 +76,16 @@ cd .github/actions/npm-packages && go test ./...
 
 ## Automation
 
-`.github/workflows/npm-release.yaml` publishes on every `release: published`
-event, and on a manual `workflow_dispatch`.
+`.github/workflows/release.yaml` calls the reusable
+`.github/workflows/npm-release.yaml` after the binaries job finishes uploading
+and attesting the release archives and checking the download. The call passes
+the release tag directly: releases created with `GITHUB_TOKEN` do not trigger
+another workflow through `release: published`.
+
+The npm workflow also accepts `release: published` events from releases created
+outside that pipeline, and manual `workflow_dispatch` runs. Reusable callers
+can pass `tag`, `dist-tag`, and `dry-run`; the defaults publish under `latest`
+for stable releases and `next` for prereleases.
 
 The build job assembles the tree, packs every package with `npm pack`, and
 smoke-tests the launcher against a real binary, unpacked from the tarball, so


### PR DESCRIPTION
GoReleaser creates releases with `GITHUB_TOKEN`, so their `release: published` events do not start the separate npm workflow. Call npm publishing directly after the binaries job has uploaded and attested the archives and completed its download check.

The npm workflow now exposes `workflow_call` inputs for the release tag, dist-tag, and dry-run mode. It retains manual dispatch and external release events, the existing package environments, and platform-before-facade publication. Update the packaging documentation and changelog to describe the release chain.

Validation: actionlint passed for both workflows with external script linters disabled; targeted `dprint check` and `git diff --check` passed. No packages were published during validation.
