### PR TITLE
Call npm publish in release workflow and update CLI documentation

### DIFF
--- a/.github/workflows/npm-release.yaml
+++ b/.github/workflows/npm-release.yaml
@@ -1,6 +1,11 @@
 name: npm release
-run-name: ${{ format('npm {0} {1}', case(github.event_name == 'workflow_dispatch' && inputs.dry-run, 'dry-run', 'publish'), case(github.event_name == 'release', github.event.release.tag_name, inputs.tag)) }}
+run-name: ${{ format('npm {0} {1}', case(inputs.dry-run, 'dry-run', 'publish'), case(github.event_name == 'release', github.event.release.tag_name, inputs.tag)) }}
 on:
+  workflow_call:
+    inputs:
+      tag: { description: Release tag to publish, required: true, type: string }
+      dist-tag: { description: npm dist-tag; auto selects next for prereleases and latest otherwise, default: auto, type: string }
+      dry-run: { description: Build and smoke-test without publishing, default: false, type: boolean }
   release: { types: [published] }
   workflow_dispatch:
     inputs:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -69,6 +69,12 @@ jobs:
         with: { subject-checksums: "./dist/actionlint_${{ env.VERSION }}_checksums.txt" }
       - name: Post-release download check
         run: bash ./scripts/download-actionlint.bash
+  npm:
+    needs: binaries
+    permissions: { contents: read, id-token: write }
+    uses: $/.github/workflows/npm-release.yaml
+    with: { tag: "${{ github.ref_name }}" }
+    secrets: inherit
   docker:
     runs-on: ubuntu-latest
     needs: changelog

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -65,14 +65,11 @@ source:
   files: [man/actionlint.1]
 
 homebrew_casks:
-  - &actionlint_cask
-    name: actionlint
+  - name: actionlint
     ids: [nix]
     directory: Casks
     binaries: [actionlint]
     manpages: [man/actionlint.1]
-    # shell_parameter_format stays unset: Homebrew then appends the bare shell
-    # name, the form -completion takes.
     generate_completions_from_executable:
       executable: actionlint
       args: [-completion]
@@ -95,20 +92,12 @@ homebrew_casks:
           end
     repository:
       owner: kjanat
-      name: homebrew-actionlint
+      name: homebrew-tap
       branch: master
       token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
     commit_author:
       name: "github-actions[bot]"
       email: "41898282+github-actions[bot]@users.noreply.github.com"
-  # One tap for every project. The per-project tap keeps receiving the cask
-  # until it is archived, since Homebrew cannot redirect a tap.
-  - <<: *actionlint_cask
-    repository:
-      owner: kjanat
-      name: homebrew-tap
-      branch: master
-      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
 scoops:
   - name: actionlint
     ids: [windows]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # Unreleased
 
+- Call npm publishing as a reusable workflow after the release binaries are uploaded, attested, and checked. This avoids relying on a `release: published` event that GitHub suppresses for releases created with `GITHUB_TOKEN`, while keeping manual publication and dry runs available.
+
 - Name the fork version in the README demo section next to the upstream one, and keep both current through the new `Upkeep` workflow. It regenerates the section after every release and weekly, and opens a pull request when the text moved, so the default branch no longer goes red the moment this fork or upstream ships. The weekly `go generate` and go-shellcheck bumps moved into the same workflow, each on its own pull request branch, and `make lint` no longer compares the README against the releases. The README check still runs on pull requests that touch the fixture, the script, or the section.
 
 <a id="v1.14.0"></a>

--- a/distribution/npm/README.md
+++ b/distribution/npm/README.md
@@ -76,8 +76,16 @@ cd .github/actions/npm-packages && go test ./...
 
 ## Automation
 
-`.github/workflows/npm-release.yaml` publishes on every `release: published`
-event, and on a manual `workflow_dispatch`.
+`.github/workflows/release.yaml` calls the reusable
+`.github/workflows/npm-release.yaml` after the binaries job finishes uploading
+and attesting the release archives and checking the download. The call passes
+the release tag directly: releases created with `GITHUB_TOKEN` do not trigger
+another workflow through `release: published`.
+
+The npm workflow also accepts `release: published` events from releases created
+outside that pipeline, and manual `workflow_dispatch` runs. Reusable callers
+can pass `tag`, `dist-tag`, and `dry-run`; the defaults publish under `latest`
+for stable releases and `next` for prereleases.
 
 The build job assembles the tree, packs every package with `npm pack`, and
 smoke-tests the launcher against a real binary, unpacked from the tarball, so

--- a/docs/install.md
+++ b/docs/install.md
@@ -32,8 +32,7 @@ The [`actionlint` package in Scoop's main bucket][scoop] installs the upstream p
 
 [![WinGet Package Version][winget-badge]][winget-submission]
 
-The first submission for this fork, [`kjanat.actionlint`][winget-submission], is awaiting review. Until it is merged
-and available in the WinGet source, use Scoop or a release archive. Once available, the command will be:
+The first submission for this fork, `kjanat.actionlint` (microsoft/winget-pkgs#430563), is awaiting review. Until it is merged and available in the WinGet source, use Scoop or a release archive. Once available, the command will be:
 
 ```powershell
 winget install --id kjanat.actionlint --exact --source winget

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,154 +1,140 @@
 # Installation
 
-This document describes how to install [actionlint](../docs).
+[![GitHub Release][release-badge]][releases]
+
+This document describes how to install the [kjanat/actionlint fork](../README.md). Package names matter: several
+registries also provide [rhysd/actionlint][upstream] under the unqualified name `actionlint`.
+
+ShellCheck and pyflakes are optional external linters. The standalone actionlint binary uses them when available on
+`PATH`; see [external linter configuration](usage.md#ignore-some-errors).
 
 ## Windows
 
 ### [Chocolatey](https://chocolatey.org/)
 
-[`actionlint` package][chocolatey] is available in the community repository:
-
-```powershell
-choco install actionlint
-```
+The community [`actionlint` package][chocolatey] installs the upstream project. This fork does not currently publish a
+Chocolatey package. Use [Scoop](#scoop), [mise](#mise), or a [release archive](#prebuilt-binaries) on Windows.
 
 ### [Scoop](https://scoop.sh/)
 
-[`actionlint` package][scoop] is available in the main bucket:
+[![Scoop Version][scoop-badge]][scoop-bucket]
 
-```powershell
-scoop install actionlint
-```
-
-That package is [the upstream project][upstream]. This fork lives in its own bucket, which also carries other `kjanat`
-tools:
+This fork is available in the [kjanat bucket][scoop-bucket]:
 
 ```powershell
 scoop bucket add kjanat https://github.com/kjanat/scoop-bucket
 scoop install kjanat/actionlint
 ```
 
+The [`actionlint` package in Scoop's main bucket][scoop] installs the upstream project.
+
 ### [Winget](https://learn.microsoft.com/en-us/windows/package-manager/)
 
-[`actionlint` package][winget] is available in the winget-pkgs repository under the `rhysd.actionlint` identifier,
-which is [the upstream project][upstream]. This fork is submitted to winget-pkgs as the separate `kjanat.actionlint`
-package on every release. Once its first submission has been merged there:
+[![WinGet Package Version][winget-badge]][winget-submission]
+
+The first submission for this fork, [`kjanat.actionlint`][winget-submission], is awaiting review. Until it is merged
+and available in the WinGet source, use Scoop or a release archive. Once available, the command will be:
 
 ```powershell
-winget install kjanat.actionlint
+winget install --id kjanat.actionlint --exact --source winget
 ```
+
+The existing [`rhysd.actionlint` package][winget] installs the upstream project.
 
 ## Linux
 
 ### [Arch Linux](https://archlinux.org/)
 
-This fork publishes three packages to the [AUR][aur]. The first two are updated automatically on every release:
+[![AUR Version (git)][aur-git-badge]][actionlint-kjanat-git]
+[![AUR Version (binary)][aur-bin-badge]][actionlint-kjanat-bin]
+[![AUR Version (source)][aur-source-badge]][actionlint-kjanat]
 
-| Package                                        | Builds                            |
-| ---------------------------------------------- | --------------------------------- |
-| [actionlint-kjanat][actionlint-kjanat]         | from the release source tarball   |
-| [actionlint-kjanat-bin][actionlint-kjanat-bin] | prebuilt from the release archive |
-| [actionlint-kjanat-git][actionlint-kjanat-git] | from the tip of `master`          |
-
-They can be installed via the [`paru`][paru] command:
+[`actionlint-kjanat-git`][actionlint-kjanat-git] is available in the [AUR][aur] and builds this fork from `master`.
+Install it with an AUR helper such as [`paru`][paru]:
 
 ```sh
-paru -S actionlint-kjanat-bin
+paru -S actionlint-kjanat-git
 ```
 
-All three install `/usr/bin/actionlint` and therefore conflict with each other and with `actionlint` in the official
-repository, `actionlint-bin` and `actionlint-git`, which all track the upstream project; install exactly one. Each
-ships the man page and bash, zsh and fish completions.
+It installs the manpage and shell completions. It conflicts with the upstream `actionlint`, `actionlint-bin`, and
+`actionlint-git` packages because they provide the same executable.
 
-### [Nix](https://nixos.wiki/)
+The release configuration also defines `actionlint-kjanat` (release source) and `actionlint-kjanat-bin` (prebuilt binary),
+but those two packages have not yet been published to the AUR. For a stable fork release, use a release archive or mise.
 
-[`actionlint` package][nixpkgs] is available in the Nix ecosystem:
+### [Nix](https://nix.dev/)
 
-On NixOS:
+The [`actionlint` definition in Nixpkgs][nixpkgs] builds the upstream project. This applies to `pkgs.actionlint`,
+`nixpkgs#actionlint`, and the older `nix-env` commands. They do not install this fork.
+
+This repository does not currently provide a Nix derivation or flake. The fork's statically linked Linux release
+binary runs on NixOS; use a [release archive](#prebuilt-binaries) or the [download script](#download-script) to obtain it.
+That installs a standalone executable rather than a Nix-managed package.
+
+<a id="homebrew"></a>
+
+## [Homebrew][homebrew] on macOS and Linux
+
+Install this fork from the `kjanat/tap` tap:
 
 ```sh
-nix-env -iA nixos.actionlint
+brew install --cask kjanat/tap/actionlint
 ```
 
-On Non NixOS:
+The unqualified [`actionlint` formula][formula] in Homebrew core installs the upstream project.
+
+The per-project `kjanat/actionlint` tap redirects to `kjanat/tap` through Homebrew's tap migration metadata, so existing
+`kjanat/actionlint/actionlint` installations keep upgrading. Releases publish only to `kjanat/tap`.
+
+The cask has no package dependencies. [ShellCheck integration](checks.md#check-shellcheck-integ) is optional and uses
+`shellcheck` when it is available on `PATH`; installing actionlint does not install ShellCheck. To add it separately,
+the `kjanat/tap/shellcheck` cask provides the upstream static binary and shell completions with no dependencies.
+Uninstall the homebrew-core formula first if it already owns the `shellcheck` binary:
 
 ```sh
-nix-env -iA nixpkgs.actionlint
-```
-
-## macOS
-
-### [Homebrew][homebrew]
-
-[`actionlint`][formula] formula is provided by Homebrew officially.
-
-```sh
-brew install actionlint
-```
-
-That formula tracks the upstream project. To install this fork instead, use the `kjanat/tap` tap, which is updated
-automatically on every release:
-
-```sh
-brew install kjanat/tap/actionlint
-```
-
-The cask is also published to the per-project `kjanat/actionlint` tap, so an existing `brew install
-kjanat/actionlint/actionlint` keeps upgrading.
-
-The cask installs the `actionlint` binary and nothing else. The [shellcheck integration](checks.md#check-shellcheck-integ)
-needs a `shellcheck` on `PATH`. The `shellcheck` formula from homebrew-core builds it with GHC and, on Linux, pulls in `gcc`
-and `glibc` as runtime dependencies. The `kjanat/tap/shellcheck` cask installs the static binary ShellCheck itself
-releases, with no dependencies, and conflicts with the formula:
-
-```sh
-brew install kjanat/tap/shellcheck
+brew install --cask kjanat/tap/shellcheck
 ```
 
 > [!WARNING]
-> Since the `actionlint` executable is unsigned, macOS displays a warning and tries to move it to the Trash. To allow it to run,
-> go to 'Settings -> Privacy & Security' and grant the permission.
+> The macOS executable is not notarized. If Gatekeeper blocks a downloaded copy, review and allow it in
+> **System Settings → Privacy & Security**.
 
 ## [npm](https://www.npmjs.com/)
 
-[`@kjanat/actionlint`][npm-package] installs a prebuilt binary, so no Go toolchain is needed:
+[![NPM Version][npm-badge]][npm-package]
+
+Publishing for [`@kjanat/actionlint`][npm-package] is implemented, but its first package has not yet been published to
+the public npm registry. Until then, use a release archive or mise. Once published, it will install a prebuilt binary:
 
 ```sh
 npm install --save-dev @kjanat/actionlint
 ```
 
-Or run it without installing:
+Or run it without adding it to the project:
 
 ```sh
 npx @kjanat/actionlint
 ```
 
-The package itself carries no binary. It declares one `optionalDependencies` entry per platform, each holding a single
-executable and declaring its `os` and `cpu`, so your package manager downloads only the one matching your machine. The
-`actionlint` command is a small launcher that resolves that package and execs the binary inside it, forwarding the exit
-status unchanged.
-
-The binaries are the same ones attached to the [GitHub release][releases]; every archive is verified against the
-release's published checksums before being repackaged.
-
-Linux users on Alpine need nothing special: the binaries are statically linked, so the `linux-*` packages run on musl
-and glibc alike.
+The planned distribution uses platform packages containing the GitHub release binaries. Keep npm's optional
+dependencies enabled, since the launcher needs the package matching your operating system and architecture.
+Linux binaries are statically linked and work with both musl and glibc.
 
 ## Prebuilt binaries
 
 Download an archive file from [the releases page][releases] for your platform, unarchive it and put the executable file to a
 directory in `$PATH`.
 
-Prebuilt binaries are built at each releases by CI for the following OS and arch:
+Release archives are available for:
 
 - macOS (x86_64, arm64)
-- Linux (i386, x86_64, arm32, arm64)
+- Linux (i386, x86_64, ARMv6-compatible 32-bit ARM, arm64)
 - Windows (i386, x86_64, arm64)
 - FreeBSD (i386, x86_64)
 
-Note that the following targets are not tested since GitHub Actions doesn't support them:
+The release matrix builds all these targets, but native CI tests do not cover:
 
-- Linux i386, arm32
+- Linux i386, 32-bit ARM
 - Windows i386
 - FreeBSD i386, x86_64
 
@@ -160,8 +146,7 @@ tar xf actionlint_1.14.0_linux_amd64.tar.gz
 ./actionlint -version
 ```
 
-Optionally you can verify the [attestation][attestations] of the downloaded artifact. This is highly recommended in terms of
-security. Note that the attestation support was introduced since actionlint v1.7.11.
+Verify the downloaded archive's [build provenance attestation][attestations] against this repository:
 
 ```sh
 gh attestation verify -R kjanat/actionlint actionlint_1.14.0_linux_amd64.tar.gz
@@ -172,82 +157,85 @@ gh attestation verify -R kjanat/actionlint actionlint_1.14.0_linux_amd64.tar.gz
 ## Download script
 
 To install `actionlint` executable with one command, [the download script](../scripts/download-actionlint.bash) is available.
-It downloads the latest version of actionlint (`actionlint.exe` on Windows and `actionlint` on other OSes) to the current
-directory automatically. This is a recommended way if you install actionlint in some shell script.
+It downloads `actionlint.exe` on Windows and `actionlint` on other supported platforms. Pass `latest` to resolve the
+newest release, or omit the argument to use the default version recorded in the script:
 
 ```sh
-bash <(curl https://raw.githubusercontent.com/kjanat/actionlint/HEAD/scripts/download-actionlint.bash)
+bash <(curl -fsSL https://raw.githubusercontent.com/kjanat/actionlint/HEAD/scripts/download-actionlint.bash) latest
 ```
 
 When you need to install specific version of actionlint, please give the version to the 1st command line argument. The following
 example installs v1.14.0.
 
 ```sh
-bash <(curl https://raw.githubusercontent.com/kjanat/actionlint/HEAD/scripts/download-actionlint.bash) 1.14.0
+bash <(curl -fsSL https://raw.githubusercontent.com/kjanat/actionlint/HEAD/scripts/download-actionlint.bash) 1.14.0
 ```
 
 This script downloads `actionlint` (or `actionlint.exe` on Windows) binary to the current working directory. When you need to put
 the downloaded binary to some other directory, please give the directory path to the 2nd command line argument. The following
-example installs the latest version to `/usr/bin`.
+example installs the latest version to `~/.local/bin`. The destination must already exist and be on your `PATH`:
 
 ```sh
-bash <(curl https://raw.githubusercontent.com/kjanat/actionlint/HEAD/scripts/download-actionlint.bash) latest /usr/bin
+mkdir -p "$HOME/.local/bin"
+bash <(curl -fsSL https://raw.githubusercontent.com/kjanat/actionlint/HEAD/scripts/download-actionlint.bash) latest "$HOME/.local/bin"
 ```
+
+The script verifies the archive's attestation when an authenticated `gh` command is available; otherwise it reports
+that attestation verification was skipped. It extracts only the executable, so use the complete release archive if you
+also want the manpage and documentation.
 
 For the usage of actionlint on GitHub Actions, see [the usage document](usage.md#on-github-actions).
 
 ## Docker image
 
-See [the usage document](./usage.md#docker) to know how to install and use an official actionlint Docker image.
+[![Docker Image Version][docker-badge]][dockerhub]
+
+The fork publishes CLI images as `ghcr.io/kjanat/actionlint` and `docker.io/kjanat/actionlint`. See
+[Docker usage](usage.md#docker) for running the linter with a mounted repository.
 
 ## Cross-platform version managers
 
 ### asdf
 
-You can install actionlint with the [asdf version manager][asdf] using the [asdf-actionlint][asdf-plugin] plugin, which
-automates the process of installing (and switching between) various versions of GitHub release binaries. With asdf already
-installed, run these commands to install actionlint:
-
-```bash
-# Add actionlint plugin
-asdf plugin add actionlint
-
-# Show all installable versions
-asdf list-all actionlint
-
-# Install specific version
-asdf install actionlint latest
-
-# Set a version globally (on your ~/.tool-versions file)
-asdf global actionlint latest
-```
+The [asdf-actionlint plugin][asdf-plugin] downloads upstream releases. This fork does not currently provide an asdf
+plugin. Use mise's GitHub backend or a release archive instead.
 
 ### mise
 
-You can install actionlint with the [mise-en-place][mise] which automates the process of installing (and switching
-between) various versions of GitHub release binaries. With mise already installed, run these commands to install
-actionlint:
+Use [mise's GitHub backend][mise-github] with this repository's full name. The short `actionlint` tool name resolves to
+upstream packages in mise's registry.
 
 ```bash
 # Show all installable versions
-mise ls-remote actionlint
+mise ls-remote github:kjanat/actionlint
 
-# Install specific version
-mise install actionlint@latest
+# Install the latest release
+mise install github:kjanat/actionlint@latest
 
 # Set a version globally (on your ~/.config/mise/config.toml file)
-mise use -g actionlint@latest
+mise use -g github:kjanat/actionlint@latest
+```
+
+For a project-local selection, put this in `mise.toml` and run `mise install`:
+
+```toml
+[tools]
+"github:kjanat/actionlint" = "latest"
 ```
 
 ## Build from source
 
-Recent [Go][Go] toolchain is necessary to build actionlint from source. Last two major versions of Go are supported.
+[![Go Module Version][go-module-badge]][go-module]
+
+Use a [Go][Go] toolchain compatible with the revision's [`go.mod`](../go.mod). Its `go` directive specifies the minimum
+Go version and its `toolchain` directive specifies the preferred toolchain; Go's automatic toolchain selection may
+download a newer compiler. No Go toolchain is needed when using prebuilt binaries.
 
 ```sh
 # Install the latest stable version
 go install actionlint.kjanat.dev/cmd/actionlint@latest
 
-# Install the head of the main branch
+# Install the head of the master branch
 go install actionlint.kjanat.dev/cmd/actionlint@master
 ```
 
@@ -258,20 +246,32 @@ go install actionlint.kjanat.dev/cmd/actionlint@master
 [formula]: https://formulae.brew.sh/formula/actionlint
 [homebrew]: https://brew.sh/
 [releases]: https://github.com/kjanat/actionlint/releases
+[release-badge]: https://img.shields.io/github/v/release/kjanat/actionlint
 [gh]: https://docs.github.com/en/github-cli/github-cli/about-github-cli
 [attestations]: https://docs.github.com/en/actions/concepts/security/artifact-attestations
-[Go]: https://golang.org/
-[asdf]: https://asdf-vm.com/
+[Go]: https://go.dev/
+[go-module]: https://pkg.go.dev/actionlint.kjanat.dev
+[go-module-badge]: https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fproxy.golang.org%2Factionlint.kjanat.dev%2F%40latest&query=%24.Version&label=Go%20module
 [asdf-plugin]: https://github.com/crazy-matt/asdf-actionlint
 [chocolatey]: https://community.chocolatey.org/packages/actionlint
+[docker-badge]: https://img.shields.io/docker/v/kjanat/actionlint
+[dockerhub]: https://hub.docker.com/r/kjanat/actionlint
 [npm-package]: https://www.npmjs.com/package/@kjanat/actionlint
+[npm-badge]: https://img.shields.io/npm/v/%40kjanat%2Factionlint
 [upstream]: https://github.com/rhysd/actionlint
 [scoop]: https://scoop.sh/#/apps?q=actionlint&s=0&d=1&o=true
+[scoop-bucket]: https://github.com/kjanat/scoop-bucket/blob/master/bucket/actionlint.json
+[scoop-badge]: https://img.shields.io/scoop/v/actionlint?bucket=https%3A%2F%2Fgithub.com%2Fkjanat%2Fscoop-bucket
 [winget]: https://github.com/microsoft/winget-pkgs/tree/master/manifests/r/rhysd/actionlint
-[actionlint-kjanat-bin]: https://aur.archlinux.org/packages/actionlint-kjanat-bin
+[winget-submission]: https://github.com/microsoft/winget-pkgs/pull/430563
+[winget-badge]: https://img.shields.io/winget/v/kjanat.actionlint
 [actionlint-kjanat-git]: https://aur.archlinux.org/packages/actionlint-kjanat-git
+[actionlint-kjanat-bin]: https://aur.archlinux.org/packages/actionlint-kjanat-bin
 [actionlint-kjanat]: https://aur.archlinux.org/packages/actionlint-kjanat
+[aur-git-badge]: https://img.shields.io/aur/version/actionlint-kjanat-git?label=AUR%20%28git%29
+[aur-bin-badge]: https://img.shields.io/aur/version/actionlint-kjanat-bin?label=AUR%20%28binary%29
+[aur-source-badge]: https://img.shields.io/aur/version/actionlint-kjanat?label=AUR%20%28source%29
 [aur]: https://aur.archlinux.org/
 [paru]: https://github.com/Morganamilo/paru
-[nixpkgs]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/tools/analysis/actionlint/default.nix
-[mise]: https://github.com/jdx/mise
+[nixpkgs]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/ac/actionlint/package.nix
+[mise-github]: https://mise.jdx.dev/dev-tools/backends/github.html

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,5 +1,7 @@
 # Usage
 
+[![GitHub Release][release-badge]][releases]
+
 This document describes how to use [actionlint](../README.md).
 
 ## `actionlint` command
@@ -138,12 +140,12 @@ actionlint -format '
 
 Output:
 
+<!-- dprint-ignore-start -->
+
 ````markdown
 ### Error at line 21, col 20 of `test.yaml`
 
 property "platform" is not defined in object type {os: string}
-
-<!-- dprint-ignore-start -->
 
 ```plaintext
           key: ${{ matrix.platform }}-node-${{ hashFiles('**/package-lock.json') }}
@@ -449,6 +451,8 @@ results table moves a cursor to position of the error in the code editor.
 <a id="docker"></a>
 
 ## [Docker][docker] image
+
+[![Docker Image Version][docker-badge]][dockerhub]
 
 [Docker image][docker-image] is available. The image contains `actionlint`
 executable and all dependencies (shellcheck and pyflakes).
@@ -773,6 +777,8 @@ You can also see actionlint issues inline in VS Code via the [Trunk VS Code exte
 
 [actionlint-matcher]: https://raw.githubusercontent.com/kjanat/actionlint/HEAD/.github/actionlint-matcher.json
 [cmd-manual]: https://kjanat.github.io/actionlint/usage.html
+[docker-badge]: https://img.shields.io/docker/v/kjanat/actionlint
+[dockerhub]: https://hub.docker.com/r/kjanat/actionlint
 [docker-image]: https://github.com/kjanat/actionlint/pkgs/container/actionlint
 [docker]: https://www.docker.com/
 [emacs-flycheck-extension]: https://github.com/tirimia/flycheck-actionlint
@@ -794,6 +800,8 @@ You can also see actionlint issues inline in VS Code via the [Trunk VS Code exte
 [pulsar-linter]: https://web.pulsar-edit.dev/packages/linter-github-actions
 [pulsar]: https://pulsar-edit.dev/
 [re2]: https://golang.org/s/re2syntax
+[release-badge]: https://img.shields.io/github/v/release/kjanat/actionlint
+[releases]: https://github.com/kjanat/actionlint/releases
 [reviewdog-actionlint]: https://github.com/reviewdog/action-actionlint
 [reviewdog]: https://github.com/reviewdog/reviewdog
 [sarif]: https://docs.oasis-open.org/sarif/sarif/v2.1.0/sarif-v2.1.0.html

--- a/man/actionlint.1.md
+++ b/man/actionlint.1.md
@@ -17,99 +17,290 @@ footer: actionlint 1.14.0
 
 # DESCRIPTION
 
-**actionlint** is a linter for GitHub Actions workflow files.
+**actionlint** checks GitHub Actions workflow files without executing the workflows. This is
+the maintained `kjanat/actionlint` fork, distributed as the Go module `actionlint.kjanat.dev`.
 
-Features:
+Checks include workflow syntax, expression types and context availability, action inputs and
+outputs, local action metadata and composite steps, reusable workflow inputs and permissions,
+job dependencies, parallel steps, runner labels, event filters, schedules, and YAML anchors.
+Security checks report potentially unsafe expression interpolation in scripts and hard-coded
+credentials. Optional ShellCheck and pyflakes integrations check scripts in `run:` steps.
 
-- **Syntax check for workflow files** to check unexpected or missing keys following workflow syntax
-- **Strong type check for `${{ }}` expressions** to catch several semantic errors like access to
-  not existing property, type mismatches, ...
-- **Actions usage check** to check that inputs at `with:` and outputs in `steps.{id}.outputs` are
-  correct
-- **shellcheck and pyflakes integrations** for scripts at `run:`
-- **Security checks**; script injection by untrusted inputs, hard-coded credentials
-- **Other several useful checks**; glob syntax validation, dependencies check for `needs:`, runner
-  label validation, cron syntax validation, ...
+Repository policy checks can require immutable action references, job timeouts, and particular
+actions. These checks are enabled explicitly in the configuration file; ordinary workflow
+checks do not require configuration.
 
 # USAGE
 
-To check all workflow files in the current repository, just run **actionlint** without arguments.
-It automatically finds the nearest `.github/workflows` directory:
+With no file arguments, **actionlint** searches the current directory and its parents for a
+repository containing both `.git` and `.github/workflows`. It recursively checks `.yml` and
+`.yaml` files in that workflow directory:
 
     $ actionlint
 
-To check specific workflow files, pass the file paths as arguments:
+To check specific workflow files, pass their paths. Explicit files can be outside a repository:
 
     $ actionlint file1.yaml file2.yaml
 
-To check a content which is not saved in file yet (e.g. output from some command), pass **-**
-argument. It reads stdin and checks it as workflow file:
+Pass **-** as the only file argument to read a workflow from standard input:
 
     $ actionlint -
 
-To serialize errors into JSON, use **-format** option. It allows to format error messages flexibly
-with Go template syntax.
+Use **-stdin-filename** to label diagnostics. If that path exists in a detected repository,
+actionlint also uses its repository configuration and local action metadata. For an unsaved
+file, select configuration explicitly with **-config-file** when needed:
+
+    $ actionlint -stdin-filename .github/workflows/ci.yml - < .github/workflows/ci.yml
+    $ actionlint -config-file .github/actionlint.yaml - < /tmp/workflow.yml
+
+Local action metadata and reusable workflows are read from disk when referenced by a workflow.
+Passing an `action.yml` file directly does not select a standalone action-metadata lint mode.
+
+Place flags before file arguments. Both `-flag` and `--flag` spellings are accepted, and a value
+can follow a flag or an equals sign. Use `--` to end flag parsing before a filename that starts
+with a dash. Boolean flags accept `=true` or `=false`.
+
+Use **-format** to serialize diagnostics or customize their presentation with Go templates:
 
     $ actionlint -format '{{json .}}'
 
 # FLAGS
 
 **-color**
-: Always enable colorful output. This is useful to force colorful outputs
+: Force colored output, including when standard output is redirected. **-no-color** takes
+precedence if both flags are set.
 
 **-completion** *SHELL*
 : Print a shell completion script for the given shell to stdout. One of `bash`, `fish`,
 `powershell`, `zsh`. Also accepted are `pwsh`, a shell path such as `$SHELL`, and `auto` to
-detect the current shell from the environment.
+detect the current shell from `SHELL`, falling back to PowerShell when `PSModulePath` is set.
+Prints the script and exits without linting. See SHELL COMPLETION below.
 
 **-config-file** *PATH*
-: File path to config file
+: Read configuration from *PATH* instead of using the detected repository's configuration.
+Relative paths are resolved from the current working directory.
 
 **-debug**
-: Enable debug output (for development)
+: Write development diagnostics to standard error. Use without **-verbose**, which takes
+precedence when both flags are set.
 
 **-format** *FORMAT*
-: Custom template to format error messages in Go template syntax. See the usage documentation
-for more details.
+: Format diagnostics using a Go text template. The template receives a sequence of error
+objects. See OUTPUT below. This overrides **-oneline**.
 
 **-ignore** *PATTERN*
-: Regular expression matching to error messages you want to ignore. This flag is repeatable. For
-example, `-ignore A -ignore B` ignores errors whose message includes "A" OR "B".
+: Suppress diagnostics whose message matches *PATTERN*, using Go regular expression syntax.
+Repeat the flag to match any of several patterns: `-ignore A -ignore B` suppresses messages
+matching either pattern. Suppressed diagnostics do not cause exit status 1.
 
 **-init-config**
-: Generate default config file at `.github/actionlint.yaml` in current project
+: Create `.github/actionlint.yaml` in the detected repository and exit without linting.
+Requires a repository with `.github/workflows` and refuses to overwrite either supported
+configuration filename.
 
 **-no-color**
-: Disable colorful output
+: Disable colored output, even when **-color** is also set.
 
 **-oneline**
-: Use one line per one error. Useful for reading error messages from programs
+: Print one line per diagnostic, without the source snippet and position marker.
 
 **-pyflakes** *COMMAND*
-: Command line of "pyflakes" external command. A command name, a file path, or a command with flags
-such as "python3 -m pyflakes", or "uvx pyflakes".
-If empty, pyflakes integration will be disabled (default "pyflakes")
+: Command used to check Python `run:` scripts. Accepts an executable name, a path, or a quoted
+command line such as `"python3 -m pyflakes"` or `"uvx pyflakes"`. Defaults to `pyflakes`;
+**-pyflakes=** disables the integration.
 
 **-shellcheck** *COMMAND*
-: Command line of "shellcheck" external command. A command name, a file path, or a command with
-flags such as "shellcheck -e SC2086".
-If empty, shellcheck integration will be disabled (default "shellcheck")
-
-**-verbose**
-: Enable verbose output
+: Command used to check supported shell `run:` scripts. Accepts an executable name, a path,
+or a quoted command line such as `"shellcheck -e SC2086"`. Defaults to `shellcheck`;
+**-shellcheck=** disables the integration.
 
 **-stdin-filename** *NAME*
-: File name when reading input from stdin (default `<stdin>`)
+: Filename used for standard-input diagnostics. Defaults to `<stdin>`. An existing path also
+allows repository discovery; see USAGE above.
+
+**-verbose**
+: Write progress information to standard error, including file discovery and disabled external
+linter integrations.
 
 **-version**
-: Show version and how this binary was installed
+: Print the build's module name and version, installation source, Go compiler version, and
+target operating system and architecture, then exit.
 
 **-help**, **-h**
-: Show help
+: Print command usage and flags to standard error, then exit successfully.
+
+# CONFIGURATION
+
+Configuration is optional. In a detected repository, actionlint reads `.github/actionlint.yaml`,
+or `.github/actionlint.yml` if the first filename is absent. **-config-file** selects a different
+file; settings are not merged with the repository file or a user-global configuration.
+
+The available settings are:
+
+**self-hosted-runner.labels**
+: Additional runner-label patterns. Patterns use Go `path.Match` glob syntax.
+
+**config-variables**
+: Allowed names in the `vars` context. Omitted or `null` disables this check; an empty list
+allows no configuration variables.
+
+**config-secrets**
+: Allowed secret names, compared case-insensitively. Omitted or `null` disables this check.
+The built-in secrets `GITHUB_TOKEN`, `ACTIONS_STEP_DEBUG`, and `ACTIONS_RUNNER_DEBUG`, and
+secrets declared in `on.workflow_call.secrets`, remain allowed even with an empty list.
+
+**assume-default-permissions**
+: Permission assumption for a local reusable workflow call when neither the calling job nor
+its workflow declares `permissions`. Defaults to `restricted`, which assumes read access to
+`contents` and `packages`. `permissive` assumes write access; `id-token` still requires an
+explicit grant. This setting does not change the repository's actual GitHub permissions.
+
+**paths**
+: Map repository-relative glob patterns to configuration. Patterns use `/` separators and
+support `**` and brace alternatives. Each entry's `ignore` list contains message regular
+expressions, applied in addition to **-ignore**.
+
+**policy.require-commit-hash**
+: When `true`, require action and reusable workflow references to use 40- or 64-digit hexadecimal
+commit IDs, and `docker://` images to use digests. Local references and expression-based
+references are skipped.
+
+**policy.require-job-timeout**
+: When `true`, require `timeout-minutes` on jobs that run steps. A mapping such as
+`{ max-minutes: 60 }` also limits literal timeout values. Jobs calling reusable workflows are
+skipped; expression-based timeouts are not compared with the maximum.
+
+**policy.required-actions**
+: List actions every workflow must use. Entries accept name and ref glob patterns, such as
+`actions/checkout` or `my-org/security-scan@v2*`. Only steps directly in the workflow are
+searched. Workflows consisting entirely of reusable workflow calls, or containing an
+expression-based action reference, are skipped.
+
+Policy checks are off until enabled. For example:
+
+```yaml
+self-hosted-runner: { labels: [linux.2xlarge] }
+config-variables: [DEFAULT_RUNNER]
+config-secrets: [DEPLOY_TOKEN]
+assume-default-permissions: restricted
+policy:
+  require-commit-hash: true
+  require-job-timeout: { max-minutes: 60 }
+  required-actions: [actions/checkout]
+paths:
+  ".github/workflows/**/*.{yml,yaml}":
+    ignore: ['shellcheck reported issue in this script: SC2086:.+']
+```
+
+The repository supplies `actionlint.schema.json` for editor completion and validation. See the
+configuration document below for the schema URL and full matching rules.
+
+# EXTERNAL LINTERS
+
+ShellCheck checks supported shell scripts in `run:` steps; pyflakes checks Python scripts.
+The executables must be available through `PATH` or the corresponding command flag. If a
+command cannot be resolved, its integration is skipped; **-verbose** explains why.
+
+    $ actionlint -shellcheck= -pyflakes=
+    $ actionlint -shellcheck 'shellcheck -e SC2086'
+    $ actionlint -pyflakes 'python3 -m pyflakes'
+
+Command strings are parsed into an executable and arguments, not executed by a shell. Shell
+pipes and redirections are not supported in these flags. Your arguments precede actionlint's
+own arguments, so do not supply input filenames or override ShellCheck's output format.
+
+actionlint invokes ShellCheck with `--norc` and JSON1 output, so `.shellcheckrc` is not read.
+Use **-shellcheck** arguments or `SHELLCHECK_OPTS` for ShellCheck options. Filter pyflakes
+diagnostics with **-ignore** or the configuration's `paths` entries.
+
+# OUTPUT
+
+Diagnostics go to standard output. Command usage, progress logs, and fatal errors go to standard
+error. The default diagnostic includes the file, line, column, message, rule name, and source
+snippet. **-oneline** omits the snippet; **-format** replaces the diagnostic presentation.
+
+The Go template receives a sequence of errors. Each has `Message`, `Snippet`, `Kind`, `Filepath`,
+`Line`, `Column`, and `EndColumn` fields. Line and column numbers start at 1. Custom template
+functions include `json`, `replace`, `toPascalCase`, `allKinds`, and `getVersion`.
+
+JSON:
+
+    $ actionlint -format '{{json .}}'
+
+JSON Lines:
+
+    $ actionlint -format '{{range .}}{{json .}}{{end}}'
+
+Custom lines:
+
+    $ actionlint -format '{{range .}}{{.Filepath}}:{{.Line}}:{{.Column}}: {{.Message}} [{{.Kind}}]\n{{end}}'
+
+Backslash escapes such as `\n` in the format string are expanded before the template is parsed.
+
+For SARIF, pass the contents of `sarif_template.txt` from the actionlint source repository to
+**-format**, for example in Bash:
+
+    $ actionlint -format "$(cat sarif_template.txt)" > actionlint.sarif
+
+The CLI's **-format** accepts template text. The GitHub Action's `format` input instead accepts
+names such as `json` and `sarif`. Changing output format does not change the lint exit status.
+
+# SHELL COMPLETION
+
+**-completion** generates native completion scripts for Bash, Fish, Zsh, and PowerShell. Scripts
+complete flags, flag values, and workflow paths. Load one into the current shell session:
+
+Bash:
+
+    $ source <(actionlint -completion bash)
+
+Fish:
+
+    $ actionlint -completion fish | source
+
+Zsh, after initializing its completion system:
+
+    $ autoload -Uz compinit && compinit
+    $ source <(actionlint -completion zsh)
+
+PowerShell:
+
+```powershell
+actionlint -completion powershell | Out-String | Invoke-Expression
+```
+
+For persistent installation, save Bash output in a directory loaded by bash-completion, Fish
+output as `~/.config/fish/completions/actionlint.fish`, or Zsh output as `_actionlint` in a
+directory on `fpath`. Load PowerShell output from your profile. Regenerate saved scripts after
+upgrading actionlint so they reflect the installed CLI. See the usage document for setup examples.
+
+# ENVIRONMENT
+
+**PATH**
+: Used to find ShellCheck and pyflakes, including the executable selected by their command flags.
+
+**NO_COLOR**
+: A nonempty value disables automatic color. **-color** can force color; **-no-color** always
+disables it.
+
+**SHELL**, **PSModulePath**
+: Used by **-completion auto**. A supported shell named by `SHELL` takes precedence over the
+PowerShell fallback indicated by a nonempty `PSModulePath`.
+
+**SHELLCHECK_OPTS**
+: Additional options interpreted by the external ShellCheck process.
+
+# FILES
+
+**.github/workflows/**
+: Workflow directory scanned when no filenames are provided.
+
+**.github/actionlint.yaml**, **.github/actionlint.yml**
+: Optional repository configuration; the `.yaml` spelling takes precedence.
 
 # DOCUMENTS
 
-Documents for more details are available online.
+Detailed documentation for this release is available online.
 
 ## Checks
 
@@ -128,14 +319,14 @@ image, a download script (for CI) are available.
 
 https://github.com/kjanat/actionlint/blob/v1.14.0/docs/usage.md
 
-How to use `actionlint` command locally or on GitHub Actions, the online playground, an official
-Docker image, and integrations with reviewdog, Problem Matchers, super-linter, pre-commit.
+CLI usage, shell completion, output templates, the GitHub Action, Docker images, and editor
+and CI integrations.
 
 ## Configuration
 
 https://github.com/kjanat/actionlint/blob/v1.14.0/docs/config.md
 
-How to configure actionlint behavior by the configuration file `actionlint.yaml`.
+Repository configuration, runner labels, variables, secrets, and opt-in policy checks.
 
 ## Go API
 
@@ -151,44 +342,39 @@ Links to resources.
 
 # USAGE ON GITHUB ACTIONS
 
-Please try the download script.
-
-https://github.com/kjanat/actionlint/blob/HEAD/scripts/download-actionlint.bash
-
-It downloads the latest version of actionlint executable to the current directory automatically.
-On GitHub Actions environment, it sets a file path to executable to the `executable` output for
-using the executable in the following steps easily.
-
-Here is an example of simple workflow to run actionlint on GitHub Actions. Please ensure `shell: bash`
-since the default shell for Windows runners is `pwsh`.
+The repository provides a GitHub Action with actionlint, ShellCheck, and pyflakes in a prebuilt
+Docker image. It reports GitHub annotations by default and fails when problems are found:
 
 ```yaml
 name: Lint GitHub Actions workflows
 on: [push, pull_request]
+permissions: { contents: read }
 
 jobs:
   actionlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - name: Download actionlint
-        id: get_actionlint
-        run: bash <(curl https://raw.githubusercontent.com/kjanat/actionlint/HEAD/scripts/download-actionlint.bash)
-        shell: bash
-      - name: Check workflow files
-        run: ${{ steps.get_actionlint.outputs.executable }} -color
-        shell: bash
+      - uses: actions/checkout@v7
+        with: { persist-credentials: false }
+      - uses: kjanat/actionlint@v1
 ```
 
-or simply run
+The Docker action requires a Linux runner with a reachable Docker daemon. To run the binary
+directly, including on macOS, Windows with Bash, or a runner without a Docker daemon, use the
+download script:
 
 ```yaml
 - name: Check workflow files
   run: |
-    bash <(curl https://raw.githubusercontent.com/kjanat/actionlint/HEAD/scripts/download-actionlint.bash)
+    bash <(curl -fsSL https://raw.githubusercontent.com/kjanat/actionlint/HEAD/scripts/download-actionlint.bash) latest
     ./actionlint -color
   shell: bash
 ```
+
+The script accepts `latest` to resolve the newest release, or a specific version. Without a
+version argument, it uses the default recorded in the script. It writes the executable to the
+current directory and, on GitHub Actions, exposes its path as the
+`executable` step output. External linters must be available separately when using the binary.
 
 # EXIT STATUS
 
@@ -196,31 +382,33 @@ or simply run
 
 - **0**: It ran successfully and no problem was found.
 - **1**: It ran successfully and some problem was found.
-- **2**: It failed due to invalid command line option.
-- **3**: It failed due to some fatal error.
+- **2**: Command-line flag parsing failed, for example because of an unknown flag or missing value.
+- **3**: Initialization or linting failed, for example because a file cannot be read, a project
+  cannot be found, or a configuration, ignore pattern, or output template is invalid.
 
 # PLAYGROUND
 
-Thanks to WebAssembly, actionlint playground is available on your browser. It never sends any data
-to outside of the browser.
+The WebAssembly playground runs actionlint in your browser. Workflow linting happens locally in
+the browser; it does not execute workflows or run the external ShellCheck and pyflakes programs.
 
 https://kjanat.github.io/actionlint/
 
-Paste your workflow content to the code editor at left pane. It automatically shows the results at
-right pane. When editing the workflow content at the left pane, the results will be updated on the
-fly in the right pane. Clicking an error message in the results table moves a cursor to the
-position of the error in the code editor.
+Paste a workflow into the editor to see diagnostics update as you type. Select a diagnostic to
+jump to its source position.
 
 # BUGS
 
-Please visit issues page to see known bugs. If you found a new bug or have some feature request,
-please report by making a new issue.
+Report problems with this fork to its issue tracker. Include the output of **-version**, the
+relevant configuration, and a minimal workflow that reproduces the problem.
 
 https://github.com/kjanat/actionlint/issues
 
 # COPYRIGHT
 
-**actionlint** is licensed under the MIT License: `Copyright (c) 2021 rhysd`
+**actionlint** is licensed under the MIT License.
+
+Copyright (c) 2026 Kaj Kowalski\
+Copyright (c) 2021 rhysd
 
 https://github.com/kjanat/actionlint/blob/HEAD/LICENSE.txt
 

--- a/man/actionlint.1.md
+++ b/man/actionlint.1.md
@@ -107,12 +107,12 @@ configuration filename.
 **-pyflakes** *COMMAND*
 : Command used to check Python `run:` scripts. Accepts an executable name, a path, or a quoted
 command line such as `"python3 -m pyflakes"` or `"uvx pyflakes"`. Defaults to `pyflakes`;
-**-pyflakes=** disables the integration.
+`-pyflakes=` disables the integration.
 
 **-shellcheck** *COMMAND*
 : Command used to check supported shell `run:` scripts. Accepts an executable name, a path,
 or a quoted command line such as `"shellcheck -e SC2086"`. Defaults to `shellcheck`;
-**-shellcheck=** disables the integration.
+`-shellcheck=` disables the integration.
 
 **-stdin-filename** *NAME*
 : Filename used for standard-input diagnostics. Defaults to `<stdin>`. An existing path also

--- a/scripts/bump-version/targets.go
+++ b/scripts/bump-version/targets.go
@@ -83,7 +83,6 @@ var targets = []*target{
 			mustRule("download script example description", `example installs v(\d+\.\d+\.\d+)`, 1),
 			mustRule("download script argument", `download-actionlint\.bash\) (\d+\.\d+\.\d+)`, 1),
 		},
-		unrelated: []string{"actionlint v1.7.11"},
 	},
 	{
 		path: "README.md",


### PR DESCRIPTION
This pull request introduces significant improvements to the release automation and documentation for the `kjanat/actionlint` fork. The main focus is on making npm publishing more robust and decoupled from GitHub's `release: published` event, as well as clarifying and modernizing installation instructions across platforms. The documentation now provides clearer guidance for users of various package managers and highlights the distinction between the fork and upstream packages.

**Release automation improvements:**

* The `npm-release.yaml` workflow is now designed as a reusable workflow that can be called directly after release binaries are uploaded and verified, rather than relying solely on the `release: published` event (which is suppressed when using `GITHUB_TOKEN`). This ensures npm publishing is reliable and supports both automated and manual triggers. Inputs for `tag`, `dist-tag`, and `dry-run` are now configurable. (`.github/workflows/npm-release.yaml`, `.github/workflows/release.yaml`, `CHANGELOG.md`, [[1]](diffhunk://#diff-87293b50a62d910ae676d4cd3f5835e600df23e2ede59332f8ee73478c4487afL2-R8) [[2]](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaR72-R77) [[3]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR5-R6)

**Documentation and installation instructions:**

* The installation guide (`docs/install.md`) has been rewritten for clarity, with updated instructions and badges for all supported package managers (Homebrew, Scoop, WinGet, npm, AUR, mise, etc.). It now clearly distinguishes between the fork and upstream, explains the current status of each distribution channel, and adds details on attestation verification and the download script. (`docs/install.md`, [[1]](diffhunk://#diff-162b45a313f5f057a233411edbe31e72a13185f4df0ae0e1af2c13521bc05d5aL3-R137) [[2]](diffhunk://#diff-162b45a313f5f057a233411edbe31e72a13185f4df0ae0e1af2c13521bc05d5aL163-R149) [[3]](diffhunk://#diff-162b45a313f5f057a233411edbe31e72a13185f4df0ae0e1af2c13521bc05d5aL175-R238)
* The usage documentation (`docs/usage.md`) now includes a release badge at the top for quick access to the latest version. (`docs/usage.md`, [docs/usage.mdR3-R4](diffhunk://#diff-72376d0b487d7231cf31959bf266f6aea098e899743bae02e36d176cef4db476R3-R4))

**Homebrew release configuration:**

* The Homebrew cask release setup in `.goreleaser.yaml` has been streamlined: the cask now publishes only to the `kjanat/homebrew-tap` repository, and migration notes for the old tap are updated. (`.goreleaser.yaml`, [[1]](diffhunk://#diff-7326b55c062b0f46fe9e39aace0a25f4515cf206040fb91a6fd2cae839f5e826L68-L75) [[2]](diffhunk://#diff-7326b55c062b0f46fe9e39aace0a25f4515cf206040fb91a6fd2cae839f5e826L98-L111)

**Automation documentation:**

* The npm automation section in `distribution/npm/README.md` is updated to reflect the new workflow structure, making it clear how and when npm packages are published and what parameters can be set by reusable workflow callers. (`distribution/npm/README.md`, [distribution/npm/README.mdL79-R88](diffhunk://#diff-bba4b1c1e789a8b8e11f329ae15880aedcf93a23bfebaffac59644ca7e9ac0f2L79-R88))

**Reference and badge updates:**

* Documentation links and badges for Go modules, Docker, npm, Scoop, WinGet, and AUR are updated for accuracy and visibility. (`docs/install.md`, [docs/install.mdR249-R277](diffhunk://#diff-162b45a313f5f057a233411edbe31e72a13185f4df0ae0e1af2c13521bc05d5aR249-R277))

These changes collectively make the release process more reliable and the installation experience more user-friendly across all platforms.