### PR TITLE
Make Comment Cop guidance relevant and reduce documentation false positives

### DIFF
--- a/.github/actions/comment-cop/comment-cop.mjs
+++ b/.github/actions/comment-cop/comment-cop.mjs
@@ -22,28 +22,50 @@ const LANGS = [
 	[/\.md$/, 'md'],
 ];
 
-/** @type {Array<[string, RegExp]>} */
+const CONTRAST_GUIDANCE =
+	'Check whether the comparison explains a real constraint. If it does, keep it; otherwise describe the chosen behavior directly.';
+
+/** @type {Array<[string, RegExp, string]>} */
 const TELLS = [
-	['em dash', /[—–]/],
-	['"X, not Y"', /,[\s]+not\s+\S/],
-	['"X rather than Y"', /\brather than\b/i],
-	['"X instead of Y"', /\b(?:instead of|as opposed to)\b/i],
-	['"not just X but Y"', /\bnot (?:just|merely|only|because)\b[^.]{0,80}?\bbut\b/i],
-	['emphatic cleft', /\b(?:which|that) is (?:what|why|how)\b|\bexactly (?:what|why|how|the)\b/i],
+	[
+		'em dash',
+		/[—–]/,
+		'For ordinary prose, consider a comma, colon, parentheses, or separate sentence. Preserve punctuation that is part of quoted material.',
+	],
+	['"X, not Y"', /,[\s]+not\s+\S/, CONTRAST_GUIDANCE],
+	['"X rather than Y"', /\brather than\b/i, CONTRAST_GUIDANCE],
+	['"X instead of Y"', /\b(?:instead of|as opposed to)\b/i, CONTRAST_GUIDANCE],
+	['"not just X but Y"', /\bnot (?:just|merely|only|because)\b[^.]{0,80}?\bbut\b/i, CONTRAST_GUIDANCE],
+	[
+		'emphatic cleft',
+		/\b(?:which|that) is (?:what|why|how)\b|\bexactly (?:what|why|how|the)\b/i,
+		'Consider stating the behavior or reason directly. Keep the emphasis if it carries a meaningful distinction.',
+	],
 	[
 		'filler phrase',
 		/\b(?:in other words|it(?:'s| is) (?:worth noting|important to note)|that said|under the hood|at its core|(?:simply put|put simply)|in short|in essence|bottom line|needless to say|when it comes to|at the end of the day|think of (?:it|this) as|no more,? no less|(?:that|which) is to say|here(?:'s| is) (?:why|the thing)|the (?:whole|entire) point|the key (?:insight|takeaway))\b/i,
+		'Check whether the introductory phrase adds meaning. If the explanation reads clearly without it, omit the phrase.',
 	],
 	[
 		'inflated diction',
 		/\b(?:leverag(?:e|es|ing)|utiliz(?:e|es|ing)|seamless(?:ly)?|delv(?:e|es|ing)|myriad|plethora|robust|comprehensive(?:ly)?|crucial(?:ly)?|vital(?:ly)?|elegant(?:ly)?|powerful(?:ly)?|intuitive(?:ly)?|nuanced|holistic|granular|meticulous|facilitat(?:e|es|ing)|streamlin(?:e|es|ing)|empower(?:s|ing)?|cutting[-\s]edge|state[-\s]of[-\s]the[-\s]art|arguably|essentially|fundamentally|a wealth of)\b/i,
+		'Consider a plain, precise term. Keep the existing word if it has a specific technical meaning here.',
 	],
-	['connective glue', /\b(?:moreover|furthermore|conversely|as such|it turns out|notably|importantly)\b/i],
+	[
+		'connective glue',
+		/\b(?:moreover|furthermore|conversely|as such|it turns out|notably|importantly)\b/i,
+		'Check whether the transition helps connect the surrounding points. It can be omitted when that connection is already clear.',
+	],
 	[
 		'counterfactual justification',
 		/\bso\b[^.]{0,60}\b(?:cannot|can't|could not|never|would)\b|\bwithout\b[^.]{0,70}\bwould\b|\bwould otherwise\b|\botherwise\b[^.]{0,70}\bwould\b|\bso that\b|\b(?:which|that) (?:prevents|keeps|stops)\b/i,
+		'An explanation of a consequence or failure mode can be useful. Keep it when it documents a non-obvious constraint; otherwise state the behavior directly.',
 	],
-	['paste artifact', /[“”‘’]|[\u00A0\u00AD\u200B-\u200D\uFEFF]/],
+	[
+		'paste artifact',
+		/[“”‘’]|[\u00A0\u00AD\u200B-\u200D\uFEFF]/,
+		'Check typographic quotes and nonstandard whitespace for accidental pasted characters. Preserve intentional examples and quotations.',
+	],
 ];
 
 const TOP_LEVEL_DECL = /^(?:package|const|func|type|var)\b/;
@@ -80,16 +102,28 @@ function stripCommentPrefix(line) {
 		.trim();
 }
 
-/** @param {PendingGroup} group @param {string} nextLine */
-function isDocBlock(group, nextLine) {
-	return group.doc
-		|| (group.lang === 'go' && group.topLevel && TOP_LEVEL_DECL.test(nextLine));
+/** @param {PendingGroup} group @param {string} nextLine @param {string[] | undefined} sourceLines */
+function isDocBlock(group, nextLine, sourceLines) {
+	if (group.doc) return true;
+	if (group.lang !== 'go') return false;
+	let firstLine = group.lines[0];
+	if (sourceLines !== undefined) {
+		let before = group.start - 1;
+		let after = group.end;
+		while (before > 0 && isCommentLine(sourceLines[before - 1], 'go')) before--;
+		while (after < sourceLines.length && isCommentLine(sourceLines[after], 'go')) after++;
+		firstLine = sourceLines[before] ?? firstLine;
+		nextLine = sourceLines[after] ?? nextLine;
+	}
+	if (group.topLevel && TOP_LEVEL_DECL.test(nextLine)) return true;
+	const field = /^\s+([A-Za-z_]\w*)\s+(?:[A-Za-z_*]|\[)/.exec(nextLine)?.[1];
+	return field !== undefined && stripCommentPrefix(firstLine).startsWith(`${field} `);
 }
 
-/** @param {PendingGroup} group @param {string} nextLine */
-function reasonsFor(group, nextLine) {
+/** @param {PendingGroup} group @param {string} nextLine @param {string[] | undefined} sourceLines */
+function reasonsFor(group, nextLine, sourceLines) {
 	const reasons = [];
-	if (group.lang !== 'md' && group.lines.length >= 3 && !isDocBlock(group, nextLine)) {
+	if (group.lang !== 'md' && group.lines.length >= 3 && !isDocBlock(group, nextLine, sourceLines)) {
 		reasons.push(`${group.lines.length} lines`);
 	}
 
@@ -131,6 +165,7 @@ export function groupsFromPatch(path, patch, source) {
 	const lang = langFor(path);
 	if (lang === null) return [];
 	const markdown = lang === 'md';
+	const sourceLines = source?.split('\n');
 	/** @type {Group[]} */
 	const groups = [];
 	/** @type {PendingGroup | null} */
@@ -142,7 +177,7 @@ export function groupsFromPatch(path, patch, source) {
 	/** @param {string} nextLine */
 	const flush = nextLine => {
 		if (pending !== null) {
-			const reasons = reasonsFor(pending, nextLine);
+			const reasons = reasonsFor(pending, nextLine, sourceLines);
 			if (reasons.length > 0) {
 				groups.push({
 					path,
@@ -233,12 +268,23 @@ export const keyFor = group =>
 /** @type {'RIGHT'} */
 const RIGHT = 'RIGHT';
 
+/** @param {string} reason */
+function guidanceFor(reason) {
+	if (/^\d+ lines$/.test(reason)) {
+		return 'This is a length-only flag. Check whether each line adds useful context; a necessary explanation can stay.';
+	}
+	return TELLS.find(([name]) => name === reason)?.[2] ?? 'Review the flagged wording in context.';
+}
+
 /** @param {Group} group */
-const bodyFor = group =>
-	`<!-- actionlint-comment-cop:${keyFor(group)} -->\n`
-	+ `Flagged for: ${group.reasons.join(', ')}.\n\n`
-	+ `This comment is doing too much of the code's job. `
-	+ `Prefer explicit ownership, state, or control flow in code, and keep only the non-obvious constraint here.`;
+export function bodyFor(group) {
+	const guidance = [...new Set(group.reasons.map(guidanceFor))];
+	const advice = guidance.length === 1 ? guidance[0] : guidance.map(text => `- ${text}`).join('\n');
+	return `<!-- actionlint-comment-cop:${keyFor(group)} -->\n`
+		+ `Flagged for: ${group.reasons.join(', ')}.\n\n${advice}\n\n`
+		+ `<sub>Comment Cop is intentionally sensitive; its suggestions are advisory. `
+		+ `If this is a false positive, you are welcome to resolve this thread without changing the text.</sub>`;
+}
 
 /** @param {unknown} error */
 function errorMessage(error) {
@@ -280,7 +326,7 @@ export default async function run({ github, context, core }) {
 		}
 
 		let source;
-		if (langFor(file.filename) === 'md') {
+		if (file.filename.endsWith('.go') || langFor(file.filename) === 'md') {
 			try {
 				const contentsUrl = requiredString(file.contents_url, `contents URL for ${file.filename}`);
 				const response = await github.request(contentsUrl, {
@@ -289,7 +335,7 @@ export default async function run({ github, context, core }) {
 				source = requiredString(response.data, `contents of ${file.filename}`);
 			} catch (error) {
 				unscannedPaths.add(file.filename);
-				core.warning(`Could not read ${file.filename}; skipping Markdown scan: ${errorMessage(error)}`);
+				core.warning(`Could not read ${file.filename}; skipping comment scan: ${errorMessage(error)}`);
 				continue;
 			}
 		}

--- a/.github/actions/comment-cop/comment-cop.test.mjs
+++ b/.github/actions/comment-cop/comment-cop.test.mjs
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { groupsFromPatch, keyFor } from './comment-cop.mjs';
+import { bodyFor, groupsFromPatch, keyFor } from './comment-cop.mjs';
 
 test('flags a long implementation comment', () => {
 	const groups = groupsFromPatch(
@@ -31,6 +31,63 @@ test('does not measure Go doc comments by length', () => {
 	);
 
 	assert.deepEqual(groups, []);
+});
+
+test('does not measure Go field documentation by length', () => {
+	const patch = [
+		'@@ -1,2 +1,5 @@',
+		' type Metadata struct {',
+		'+\t// Defaults holds input values.',
+		'+\t// Each value includes its position.',
+		'+\t// Values remain in source order.',
+		'+\tDefaults []*Value',
+		' }',
+	].join('\n');
+
+	assert.deepEqual(groupsFromPatch('metadata.go', patch), []);
+});
+
+test('recognizes a Go doc comment when its declaration follows unchanged lines', () => {
+	const source = [
+		'// Check scans expressions.',
+		'// It preserves source positions.',
+		'// It reports unavailable contexts.',
+		'// Invalid expressions end the scan.',
+		'func Check() {}',
+	].join('\n');
+	const patch = [
+		'@@ -1,3 +1,5 @@',
+		'-// Check scans source.',
+		'+// Check scans expressions.',
+		'+// It preserves source positions.',
+		'+// It reports unavailable contexts.',
+		' // Invalid expressions end the scan.',
+		' func Check() {}',
+	].join('\n');
+
+	assert.deepEqual(groupsFromPatch('rule.go', patch, source), []);
+});
+
+test('uses the unchanged first line to recognize partial field documentation', () => {
+	const source = [
+		'type Metadata struct {',
+		'\t// Defaults holds input values.',
+		'\t// Each value includes its position.',
+		'\t// Values remain in source order.',
+		'\t// The checker reads these values.',
+		'\tDefaults []*Value',
+		'}',
+	].join('\n');
+	const patch = [
+		'@@ -2,2 +2,5 @@',
+		' \t// Defaults holds input values.',
+		'+\t// Each value includes its position.',
+		'+\t// Values remain in source order.',
+		'+\t// The checker reads these values.',
+		' \tDefaults []*Value',
+	].join('\n');
+
+	assert.deepEqual(groupsFromPatch('metadata.go', patch, source), []);
 });
 
 test('flags style tells at any length', () => {
@@ -115,4 +172,30 @@ test('uses opaque location-specific marker keys', () => {
 	assert.match(keys[0], /^[a-f0-9]{16}$/);
 	assert.match(keys[1], /^[a-f0-9]{16}$/);
 	assert.notEqual(keys[0], keys[1]);
+});
+
+test('tailors advice to the finding and keeps contributor guidance in a sub footer', () => {
+	const group = { path: 'rule.go', start: 1, end: 3, text: '// Explanation', reasons: ['3 lines'] };
+	const lengthBody = bodyFor(group);
+	const consequenceBody = bodyFor({ ...group, reasons: ['counterfactual justification'] });
+
+	assert.match(lengthBody, /length-only flag/);
+	assert.doesNotMatch(consequenceBody, /length-only flag/);
+	assert.match(consequenceBody, /consequence or failure mode/);
+	assert.match(consequenceBody, /<sub>[^<]*advisory[^<]*resolve this thread[^<]*<\/sub>$/);
+});
+
+test('combines different advice and deduplicates equivalent contrast advice', () => {
+	const group = {
+		path: 'rule.go',
+		start: 1,
+		end: 3,
+		text: '// Explanation',
+		reasons: ['3 lines', '"X instead of Y"', '"X rather than Y"'],
+	};
+	const body = bodyFor(group);
+
+	assert.equal(body.split('\n').filter(line => line.startsWith('- ')).length, 2);
+	assert.match(body, /length-only flag/);
+	assert.match(body, /comparison explains a real constraint/);
 });

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,6 +52,10 @@ Before submitting your PR, please ensure the following points:
 - If you added a new public API, consider to add tests and a doc comment for the API.
 - If you updated [the checks document](docs/checks.md), ensure to run [the maintenance script](#about-checks-doc).
 
+Comment Cop may leave automated style suggestions on added comments and documentation. It is intentionally sensitive,
+and its suggestions are advisory. If a finding is a false positive, you are welcome to resolve the review thread
+without changing the text. Keep explanations that help readers understand the code.
+
 Special thanks to the native English speakers for proofreading the documentation and error messages, as the author is not
 proficient in English.
 


### PR DESCRIPTION
Comment Cop used the same structural-code criticism for every style finding and incorrectly counted Go field documentation and partial doc-comment diffs as long implementation comments.

Give each finding guidance tied to its actual trigger. Keep the contributor guidance about resolving false positives in a `<sub>` footer, document the advisory policy, and use the complete Go source to recognize documentation comments. The wording checks remain intentionally sensitive.

Validation: all 12 Comment Cop tests, `npm run typecheck`, and formatting checks pass. Replaying #131 removes the documentation-length findings while retaining the two wording suggestions.

Refs #131.
