### PR TITLE
Publish the npm schema and expose package manifests

### DIFF
--- a/.github/actions/npm-packages/main.go
+++ b/.github/actions/npm-packages/main.go
@@ -364,6 +364,9 @@ func (c *config) platformManifest(tf *targetsFile, t target, name string) ([]byt
 	if err := o.set("files", []string{"bin/"}); err != nil {
 		return nil, err
 	}
+	if err := o.set("exports", map[string]string{"./package.json": "./package.json"}); err != nil {
+		return nil, err
+	}
 	// Tells Yarn's PnP linker to keep this package unzipped on disk, since an
 	// executable has to be a real file to be spawned.
 	if err := o.set("preferUnplugged", true); err != nil {
@@ -419,6 +422,9 @@ func (c *config) buildFacade(tf *targetsFile) error {
 		}
 	}
 	if err := copyFile(filepath.Join(src, "README.md"), filepath.Join(dir, "README.md")); err != nil {
+		return err
+	}
+	if err := copyFile(filepath.Join(c.repoRoot, "actionlint.schema.json"), filepath.Join(dir, "actionlint.schema.json")); err != nil {
 		return err
 	}
 	if err := c.copyLegal(dir); err != nil {

--- a/.github/actions/npm-packages/main_test.go
+++ b/.github/actions/npm-packages/main_test.go
@@ -95,8 +95,10 @@ func fixture(t *testing.T, version string) *config {
 	if err := copyTree(filepath.Join(repoRoot, "distribution", "npm"), npmDir); err != nil {
 		t.Fatalf("staging distribution/npm: %v", err)
 	}
-	if err := copyFile(filepath.Join(repoRoot, "LICENSE.txt"), filepath.Join(work, "LICENSE.txt")); err != nil {
-		t.Fatalf("staging LICENSE.txt: %v", err)
+	for _, file := range []string{"LICENSE.txt", "actionlint.schema.json"} {
+		if err := copyFile(filepath.Join(repoRoot, file), filepath.Join(work, file)); err != nil {
+			t.Fatalf("staging %s: %v", file, err)
+		}
 	}
 
 	tf, err := loadTargets(filepath.Join(npmDir, "targets.json"))
@@ -208,6 +210,9 @@ func TestBuildsEveryTargetAndTheFacade(t *testing.T) {
 		if manifest["version"] != version {
 			t.Errorf("%s: version is %v", target.Pkg, manifest["version"])
 		}
+		if exports, ok := manifest["exports"].(map[string]any); !ok || exports["./package.json"] != "./package.json" {
+			t.Errorf("%s: package.json export is missing or incorrect: %v", target.Pkg, manifest["exports"])
+		}
 		// os and cpu are what stop npm installing this package elsewhere.
 		if osv, ok := manifest["os"].([]any); !ok || len(osv) != 1 || osv[0] != target.OS {
 			t.Errorf("%s: os is %v", target.Pkg, manifest["os"])
@@ -231,6 +236,7 @@ func TestBuildsEveryTargetAndTheFacade(t *testing.T) {
 
 	facadeDir := filepath.Join(cfg.outDir, "facade")
 	facade := readJSON(t, filepath.Join(facadeDir, "package.json"))
+	checkFacadeSchema(t, cfg)
 	if facade["version"] != version {
 		t.Errorf("facade version is %v", facade["version"])
 	}
@@ -278,6 +284,49 @@ func TestFacadeOnlyBuildFetchesTheManual(t *testing.T) {
 	}
 	if string(got) != "man" {
 		t.Errorf("facade manual is %q", got)
+	}
+	checkFacadeSchema(t, cfg)
+}
+
+func checkFacadeSchema(t *testing.T, cfg *config) {
+	t.Helper()
+	want, err := os.ReadFile(filepath.Join(cfg.repoRoot, "actionlint.schema.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(cfg.outDir, "facade")
+	got, err := os.ReadFile(filepath.Join(dir, "actionlint.schema.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Error("facade schema differs from the workspace schema")
+	}
+	manifest := readJSON(t, filepath.Join(dir, "package.json"))
+	exports, ok := manifest["exports"].(map[string]any)
+	if !ok {
+		t.Fatalf("facade exports is %T", manifest["exports"])
+	}
+	if len(exports) != 2 || exports["./package.json"] != "./package.json" {
+		t.Errorf("facade exports are %v, want only package.json and schema", exports)
+	}
+	if exports["./schema"] != "./actionlint.schema.json" {
+		t.Errorf("facade schema alias is %v", exports["./schema"])
+	}
+}
+
+func TestFacadeRejectsMissingSchema(t *testing.T) {
+	cfg := fixture(t, "3.2.1")
+	tf, err := loadTargets(filepath.Join(cfg.npmDir, "targets.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(filepath.Join(cfg.repoRoot, "actionlint.schema.json")); err != nil {
+		t.Fatal(err)
+	}
+	err = cfg.buildFacade(tf)
+	if err == nil || !strings.Contains(err.Error(), "actionlint.schema.json") {
+		t.Fatalf("buildFacade returned %v, want the missing schema error", err)
 	}
 }
 

--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -125,9 +125,16 @@ jobs:
             local tarball="$1" dest="$2"
             mkdir -p "${dest}"
             tar -xzf "${tarball}" -C "${dest}" --strip-components=1
+            local name
+            name="$(jq -r .name "${dest}/package.json")"
+            (cd "${smoke}" && node -e 'require(process.argv[1] + "/package.json")' "${name}")
           }
           unpack distribution/npm/tarballs/facade.tgz "${facade}"
-          unpack distribution/npm/tarballs/linux-x64.tgz "${scope}/actionlint-linux-x64"
+          for pkg in $(jq -r '.targets[].pkg' distribution/npm/targets.json); do
+            unpack "distribution/npm/tarballs/${pkg}.tgz" "${scope}/actionlint-${pkg}"
+          done
+          cmp actionlint.schema.json "${facade}/actionlint.schema.json"
+          (cd "${smoke}" && node -e 'require("@kjanat/actionlint/schema")')
           got="$(node "${facade}/bin/actionlint.mjs" -version | head -1)"
           echo "launcher reported: ${got}"
           case "${got}" in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # Unreleased
 
+- Include and export `actionlint.schema.json` in `@kjanat/actionlint`, and export `package.json` from every platform package. (kjanat/actionlint#136)
+
 - Generate accepted JavaScript action runtimes, bundled-runtime availability, and deprecation details from GitHub's runner source. Distinguish invalid metadata values from deprecated and removed runtimes, report Node 20 deprecation for local and known popular actions, and preserve input/output validation for deprecated actions. Refresh the data through `go generate` and weekly Upkeep.
 
 - Allow the `windows-11-arm` alias to overlap `windows-11-vs2026-arm` during its announced Visual Studio 2026 migration while retaining incompatible image diagnostics. (kjanat/actionlint#126)

--- a/distribution/npm/README.md
+++ b/distribution/npm/README.md
@@ -18,11 +18,15 @@ binary through npm:
 
 - `@kjanat/actionlint` contains no binary. It declares every platform package in
   `optionalDependencies`, pinned to the exact same version, and its `bin` entry
-  is a small launcher.
+  is a small launcher. It also includes the manual and configuration schema.
 - `@kjanat-actionlint/actionlint-<os>-<cpu>` contains one executable and declares `os` and
   `cpu`, so a package manager downloads only the one matching the host. The
   platform packages sit in their own npm organisation, `kjanat-actionlint`, so
   eleven binary-only packages nobody installs by hand stay out of `@kjanat/*`.
+
+Every package exports `./package.json`. The facade exports its configuration schema as `./schema`, pointing to
+`./actionlint.schema.json`, copied from the repository checkout during packaging. Published builds use the schema from
+the release tag.
 
 At run time the launcher looks up `actionlint-<process.platform>-<process.arch>`
 among the declared platform packages, resolves the match, and execs the binary inside.
@@ -69,7 +73,7 @@ npm run test:npm-facade
 
 The builder has its own tests, which assemble synthetic release archives, run
 the whole pipeline, and assert each package ends up with its own binary and the
-facade with the manual:
+facade with the manual and the workspace's schema:
 
 ```bash
 cd .github/actions/npm-packages && go test ./...
@@ -99,8 +103,8 @@ can pass `tag`, `dist-tag`, and `dry-run`; the defaults publish under `latest`
 for stable releases and `next` for prereleases.
 
 The build job assembles the tree, packs every package with `npm pack`, and
-smoke-tests the launcher against a real binary, unpacked from the tarball, so
-anything the `files` list omits fails in CI. The packed tarballs are the ones
+smoke-tests the launcher against a real binary, unpacked from the tarball. It also loads every package's exported
+manifest and the facade's exported schema, comparing the schema with the source file. The packed tarballs are the ones
 published, making the tested bytes the published bytes.
 
 Publishing is one job per package, each recording its own deployment with that

--- a/distribution/npm/facade/README.md
+++ b/distribution/npm/facade/README.md
@@ -63,9 +63,23 @@ The package includes `actionlint.schema.json` for completion and validation in c
 
 These URLs require an npm release containing the schema:
 
-- [jsDelivr](https://cdn.jsdelivr.net/npm/@kjanat/actionlint/actionlint.schema.json)
-- [esm.sh (raw)](https://esm.sh/@kjanat/actionlint/actionlint.schema.json?raw)
-- [UNPKG](https://unpkg.com/@kjanat/actionlint/actionlint.schema.json)
+jsDelivr:
+
+```text
+https://cdn.jsdelivr.net/npm/@kjanat/actionlint/actionlint.schema.json
+```
+
+esm.sh:
+
+```text
+https://esm.sh/@kjanat/actionlint/actionlint.schema.json
+```
+
+UNPKG:
+
+```text
+https://unpkg.com/@kjanat/actionlint/actionlint.schema.json
+```
 
 For example, use jsDelivr in an editor's schema directive:
 

--- a/distribution/npm/facade/README.md
+++ b/distribution/npm/facade/README.md
@@ -49,6 +49,24 @@ v11; from v12 it no longer does, so on a current npm read it directly:
 man ./node_modules/@kjanat/actionlint/man/actionlint.1
 ```
 
+### Configuration schema
+
+The package includes `actionlint.schema.json` for completion and validation in configuration editors. For a config at
+`.github/actionlint.yaml`, use the installed copy with:
+
+```yaml
+# yaml-language-server: $schema=../node_modules/@kjanat/actionlint/actionlint.schema.json
+```
+
+The schema is exported as `./schema`. Tooling can load it alongside the package manifest:
+
+```js
+const schema = require('@kjanat/actionlint/schema');
+const manifest = require('@kjanat/actionlint/package.json');
+```
+
+Each platform package also exports its own `package.json`.
+
 ### ShellCheck and Pyflakes
 
 `actionlint` also checks the shell scripts inside `run:` steps with [ShellCheck][shellcheck], and Python scripts with

--- a/distribution/npm/facade/README.md
+++ b/distribution/npm/facade/README.md
@@ -58,14 +58,25 @@ The package includes `actionlint.schema.json` for completion and validation in c
 # yaml-language-server: $schema=../node_modules/@kjanat/actionlint/actionlint.schema.json
 ```
 
-The schema is exported as `./schema`. Tooling can load it alongside the package manifest:
+<details>
+<summary>CDN URLs for the JSON schema</summary>
 
-```js
-const schema = require('@kjanat/actionlint/schema');
-const manifest = require('@kjanat/actionlint/package.json');
+These URLs require an npm release containing the schema:
+
+- [jsDelivr](https://cdn.jsdelivr.net/npm/@kjanat/actionlint/actionlint.schema.json)
+- [esm.sh (raw)](https://esm.sh/@kjanat/actionlint/actionlint.schema.json?raw)
+- [UNPKG](https://unpkg.com/@kjanat/actionlint/actionlint.schema.json)
+
+For example, use jsDelivr in an editor's schema directive:
+
+```yaml
+# yaml-language-server: $schema=https://cdn.jsdelivr.net/npm/@kjanat/actionlint/actionlint.schema.json
 ```
 
-Each platform package also exports its own `package.json`.
+Unversioned URLs follow the latest npm release. Insert `@<version>` after `@kjanat/actionlint` to select the schema for
+a specific release that includes it.
+
+</details>
 
 ### ShellCheck and Pyflakes
 

--- a/distribution/npm/facade/package.json
+++ b/distribution/npm/facade/package.json
@@ -34,7 +34,8 @@
     "#resolve": "./lib/resolve.mjs"
   },
   "exports": {
-    "./package.json": "./package.json"
+    "./package.json": "./package.json",
+    "./schema": "./actionlint.schema.json"
   },
   "bin": {
     "actionlint": "bin/actionlint.mjs"
@@ -50,6 +51,7 @@
     "bin/",
     "lib/",
     "man/",
+    "actionlint.schema.json",
     "README.md",
     "LICENSE.txt"
   ],

--- a/docs/config.md
+++ b/docs/config.md
@@ -34,8 +34,15 @@ your project, a config at `.github/actionlint.yaml` can use the local schema:
 # yaml-language-server: $schema=../node_modules/@kjanat/actionlint/actionlint.schema.json
 ```
 
-Node.js tooling can load it with `require("@kjanat/actionlint/schema")` or locate it with
-`require.resolve("@kjanat/actionlint/schema")`.
+The published schema is also available through a CDN for editor configuration:
+
+```yaml
+# yaml-language-server: $schema=https://cdn.jsdelivr.net/npm/@kjanat/actionlint/actionlint.schema.json
+```
+
+This URL follows the latest npm release and requires a release containing the schema. See the
+[npm package documentation](../distribution/npm/facade/README.md#configuration-schema) for other CDN URLs and version
+selection.
 
 The schema rejects unknown keys everywhere. Runtime parsing ignores unknown keys at the top level, inside
 `self-hosted-runner`, and inside each `paths` entry. For example, `config-secret` is silently ignored. Both validators

--- a/docs/config.md
+++ b/docs/config.md
@@ -27,6 +27,16 @@ that it stays up to date. Custom YAML types have explicit mappings in
 [`scripts/generate-config-schema`](../scripts/generate-config-schema/main.go); nullable values and field constraints
 use `jsonschema` struct tags.
 
+The `@kjanat/actionlint` npm package includes and exports the schema for its release. If the package is installed in
+your project, a config at `.github/actionlint.yaml` can use the local schema:
+
+```yaml
+# yaml-language-server: $schema=../node_modules/@kjanat/actionlint/actionlint.schema.json
+```
+
+Node.js tooling can load it with `require("@kjanat/actionlint/schema")` or locate it with
+`require.resolve("@kjanat/actionlint/schema")`.
+
 The schema rejects unknown keys everywhere. Runtime parsing ignores unknown keys at the top level, inside
 `self-hosted-runner`, and inside each `paths` entry. For example, `config-secret` is silently ignored. Both validators
 reject unknown keys inside `policy` and `require-job-timeout`. Go regular expression and glob syntax require additional


### PR DESCRIPTION
The npm facade now includes the release checkout's `actionlint.schema.json` and exports it as `@kjanat/actionlint/schema`. Its export map is:

```json
"exports": {
  "./package.json": "./package.json",
  "./schema": "./actionlint.schema.json"
}
```

All eleven platform packages also export `./package.json`. The release smoke test unpacks every package and checks manifest resolution, schema resolution and contents, and launcher execution. Documentation covers the installed JSON file's YAML Language Server directive and the `./schema` export.

Validation:

- Go 1.27 builder tests and `go vet`, plus all 12 launcher tests, passed under WSL.
- Built and packed all twelve packages with the v1.15.1 release binaries. On Windows, the packed schema matched the source byte-for-byte, every manifest export resolved, and the launcher ran successfully.
- Workflow lint, dprint, Comment Cop, and `git diff --check` passed.

Fixes #136.

This would make it also importable through e.g.

```text
# jsDelivr (https://www.jsdelivr.com/)
https://cdn.jsdelivr.net/npm/@kjanat/actionlint/actionlint.schema.json
# esm.sh (https://esm.sh)
https://esm.sh/@kjanat/actionlint/actionlint.schema.json
# UNPKG (https://unpkg.com)
https://unpkg.com/@kjanat/actionlint/actionlint.schema.json
```