### PR TITLE
Cover large-script ShellCheck regressions across platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -184,7 +184,7 @@
 ## [v1.8.0](https://github.com/kjanat/actionlint/releases/tag/v1.8.0) - 2026-08-19
 
 - Add support for `entrypoint` and `command` in service containers. (rhysd/actionlint#645, thanks @mkusaka)
-- Fix a macOS ShellCheck integration deadlock when linting large scripts concurrently. (rhysd/actionlint#651, thanks @attehuhtakangas)
+- Fix a ShellCheck integration deadlock when script input fills the pipe before the child starts. Reproduced on macOS and Linux, including a single large `run:` step. (rhysd/actionlint#651, thanks @attehuhtakangas for the fix and @kjanat for the Linux reproducer)
 - Support the [`queue` configuration in workflow- and job-level `concurrency`](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#concurrency). The documented literal values `single` (default) and `max` are accepted, and invalid values or `queue: max` combined with `cancel-in-progress: true` are reported as errors. (rhysd/actionlint#654, rhysd/actionlint#657, thanks @vvoland)
 - Support the `ubuntu-26.04`, `ubuntu-26.04-arm`, `xcode-27`, `xcode-27-xlarge`, and `windows-11-vs2026-arm` runner labels. (rhysd/actionlint#683, thanks @ericcornelissen; rhysd/actionlint#710, thanks @TheAlphaEngineerCode)
 - Follow the moving runner aliases: `macos-latest` now maps to `macos-26`, `macos-latest-large` maps to `macos-26-large`, and `windows-latest` and `windows-2025` map to `windows-2025-vs2026`. The macOS and Windows migrations are confirmed in [actions/runner-images#14167](https://github.com/actions/runner-images/issues/14167) and [actions/runner-images#14017](https://github.com/actions/runner-images/issues/14017).

--- a/process.go
+++ b/process.go
@@ -25,10 +25,8 @@ type cmdExecution struct {
 func (e *cmdExecution) run(ctx context.Context) ([]byte, error) {
 	cmd := exec.CommandContext(ctx, e.cmd, e.args...)
 	cmd.Stderr = nil
-	// Set stdin via an io.Reader so that exec.Cmd pipes the bytes to the child
-	// after Start(). Writing to cmd.StdinPipe() before Start() relies on the
-	// kernel pipe buffer being large enough to absorb the whole payload, which
-	// deadlocks on darwin when multiple workers run concurrently (issue #650).
+	// Let os/exec start the reader before copying stdin. Writing the whole script
+	// before Start can fill the pipe and deadlock, even with a single worker.
 	cmd.Stdin = strings.NewReader(e.stdin)
 
 	var stdout []byte

--- a/process_test.go
+++ b/process_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
+	"os"
 	"runtime"
 	"strings"
 	"sync/atomic" // Note: atomic.Bool was added at Go 1.19
@@ -210,46 +212,65 @@ func TestProcessInputStdin(t *testing.T) {
 	}
 }
 
-// Regression test for issue #650: concurrent runs with a stdin payload larger
-// than the kernel pipe buffer used to deadlock on darwin because the payload
-// was written to cmd.StdinPipe() before cmd.Start().
+func TestProcessStdinHelper(t *testing.T) {
+	if os.Getenv("ACTIONLINT_TEST_STDIN_HELPER") != "1" {
+		return
+	}
+	if _, err := io.Copy(os.Stdout, os.Stdin); err != nil {
+		t.Fatal(err)
+	}
+	os.Exit(0)
+}
+
+// The Linux reproducer in rhysd/actionlint#651 filled a 64 KiB pipe with one script.
+// Larger input must finish with one worker as well as concurrent workers.
 func TestProcessConcurrentStdinDoesNotDeadlock(t *testing.T) {
-	p := newConcurrentProcess(t.Context(), 5)
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("ACTIONLINT_TEST_STDIN_HELPER", "1")
+	payload := strings.Repeat("0123456789abcdef", 8192)
 
-	// 64 KiB is above the default pipe buffer size on darwin and Linux so it
-	// forces the stdin copy to happen after the child has started.
-	payload := strings.Repeat("x", 64*1024)
-
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		cmds := make([]*externalCommand, 0, 5)
-		for range 5 {
-			cat := testSkipIfNoCommand(t, p, "cat")
-			cat.run(nil, payload, func(b []byte, err error) error {
-				if err != nil {
-					t.Errorf("cat failed: %v", err)
-					return err
+	for _, workers := range []int{1, 5} {
+		for _, combined := range []bool{false, true} {
+			t.Run(fmt.Sprintf("workers=%d/combined=%t", workers, combined), func(t *testing.T) {
+				ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+				defer cancel()
+				p := newConcurrentProcess(ctx, workers)
+				cmd := &externalCommand{proc: p, exe: exe, combineOutput: combined}
+				var completed atomic.Int32
+				for range workers {
+					cmd.run([]string{"-test.run=^TestProcessStdinHelper$"}, payload, func(b []byte, err error) error {
+						if err != nil {
+							return err
+						}
+						if string(b) != payload {
+							return fmt.Errorf("stdin was not preserved: got %d bytes, want %d", len(b), len(payload))
+						}
+						completed.Add(1)
+						return nil
+					})
 				}
-				if len(b) != len(payload) {
-					t.Errorf("cat output length %d, want %d", len(b), len(payload))
+				done := make(chan error, 1)
+				go func() {
+					err := cmd.wait()
+					p.wait()
+					done <- err
+				}()
+				select {
+				case err := <-done:
+					if err != nil {
+						t.Fatal(err)
+					}
+				case <-ctx.Done():
+					t.Fatal("stdin larger than the pipe buffer did not finish")
 				}
-				return nil
+				if got := completed.Load(); got != int32(workers) {
+					t.Fatalf("completed %d commands, want %d", got, workers)
+				}
 			})
-			cmds = append(cmds, cat)
 		}
-		for _, c := range cmds {
-			if err := c.wait(); err != nil {
-				t.Errorf("cat wait failed: %v", err)
-			}
-		}
-		p.wait()
-	}()
-
-	select {
-	case <-done:
-	case <-time.After(10 * time.Second):
-		t.Fatal("concurrent stdin writes deadlocked — see issue #650")
 	}
 }
 

--- a/rule_shellcheck_test.go
+++ b/rule_shellcheck_test.go
@@ -1,9 +1,66 @@
 package actionlint
 
 import (
+	"bytes"
+	"context"
 	"fmt"
+	"path/filepath"
+	"strings"
 	"testing"
+	"time"
+
+	"golang.org/x/sys/execabs"
 )
+
+func TestRuleShellcheckLargeRunBlock(t *testing.T) {
+	shellcheck, err := execabs.LookPath("shellcheck")
+	if err != nil {
+		t.Skipf("shellcheck is necessary to run this test: %s", err)
+	}
+	// @kjanat's rhysd/actionlint#651 reproducer uses a single 128 KiB comment.
+	// The second case proves ShellCheck still checks code following that comment.
+	comment := "#" + strings.Repeat("x", 128*1024-2) + "\n"
+	for _, findings := range []bool{false, true} {
+		t.Run(fmt.Sprintf("findings=%t", findings), func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+			defer cancel()
+			var output bytes.Buffer
+			dir := t.TempDir()
+			l, err := NewLinter(&output, &LinterOptions{Shellcheck: shellcheck, WorkingDir: dir, Context: ctx, Color: ColorOptionKindNever})
+			if err != nil {
+				t.Fatal(err)
+			}
+			workflow := "on: push\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps:\n      - run: |\n          " + comment
+			if findings {
+				workflow += "          echo $ACTIONLINT_STDIN_REGRESSION\n"
+			}
+			var errs []*Error
+			done := make(chan error, 1)
+			go func() {
+				var err error
+				errs, err = l.Lint(filepath.Join(dir, "workflow.yml"), []byte(workflow), nil)
+				done <- err
+			}()
+			select {
+			case err := <-done:
+				if err != nil {
+					t.Fatal(err)
+				}
+			case <-ctx.Done():
+				t.Fatal("ShellCheck did not finish checking the large run block")
+			}
+			if !findings {
+				if len(errs) != 0 {
+					t.Fatalf("unexpected diagnostics: %s", output.String())
+				}
+				return
+			}
+			if len(errs) != 1 || errs[0].Kind != "shellcheck" || !strings.Contains(errs[0].Message, "SC2086") || errs[0].Line != 8 {
+				t.Fatalf("expected SC2086 on line 8 after the large comment: %s", output.String())
+			}
+		})
+	}
+}
 
 func TestRuleShellcheckSanitizeExpressionsInScript(t *testing.T) {
 	testCases := []struct {


### PR DESCRIPTION
The stdin deadlock fixed in rhysd/actionlint#651 also affected Linux with a single large script. The existing regression used five `cat` processes with 64 KiB inputs, which did not exceed the 64 KiB pipe capacity measured in [@kjanat's Linux reproduction](https://github.com/rhysd/actionlint/pull/651#issuecomment-5217723922).

Exercise 128 KiB inputs with one and five workers through both output modes, verifying that every byte arrives. A helper in the Go test binary replaces the external `cat` dependency. Add the single large workflow reproduction through ShellCheck, plus a case that requires an SC2086 finding after the large comment so silently skipping analysis cannot pass.

Correct the process comments and v1.8.0 changelog to describe the Linux and macOS impact and credit the Linux reproduction. The underlying stdin fix already shipped in v1.8.0.

Validation:

- All six new regression cases passed on Windows and Ubuntu WSL, including the real ShellCheck cases.
- `go test ./...` passed on Windows with Git Bash and Pyflakes 3.4.0.
- `golangci-lint run` passed with CI's pinned v2.13.1; `git diff --check` passed.
