### PR TITLE
Add upstream conformance tests

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -1,0 +1,36 @@
+name: Upstream conformance
+on:
+  push: { branches: [master] }
+  pull_request:
+  workflow_dispatch:
+permissions: { contents: read }
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+jobs:
+  conformance:
+    name: Upstream fixtures (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix: { os: [ubuntu-latest, macos-latest, windows-latest] }
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with: { persist-credentials: false }
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
+        with: { go-version-file: go.mod }
+      - name: Cache upstream fixture archives
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
+        with:
+          path: .cache/conformance/*.zip
+          key: conformance-${{ runner.os }}-${{ hashFiles('internal/conformance/sources.json') }}
+      - name: Fetch and verify pinned fixtures
+        run: go run ./scripts/fetch-conformance
+      - name: Compare actionlint with upstream expectations
+        run: go test -tags conformance -run '^TestUpstreamConformance' -count=1 -timeout 2m .
+        env: { ACTIONLINT_CONFORMANCE_REPORT: .cache/conformance/results.json }
+      - name: Upload comparison report
+        if: ${{ always() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with: { name: "conformance-${{ runner.os }}", path: .cache/conformance/results.json, include-hidden-files: true, if-no-files-found: warn }

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /.github/actionlint.yaml
 /.github/actionlint.yml
+/.cache/
 /.idea
 /.playwright-mcp/
 /.worktrees/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # Unreleased
 
+- Add upstream conformance tests using GitHub's language-services and runner fixtures, with SchemaStore and YAML Test Suite comparisons. Run them across Linux, macOS, and Windows and report known differences separately from agreements.
+
 <a id="v1.16.0"></a>
 
 ## [v1.16.0](https://github.com/kjanat/actionlint/releases/tag/v1.16.0) - 2026-09-08

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,6 +119,9 @@ open coverage.html
 
 Automated tests are as follows.
 
+- [Upstream conformance tests](docs/conformance.md) compare actionlint with fixtures from GitHub's language services and
+  runner, SchemaStore, and YAML Test Suite. Run `make conformance` when changing parsing or validation. Known differences
+  remain visible and are checked for changes; a green job does not mean full runtime compatibility.
 - Unit tests are implemented in `*_test.go` files for testing the corresponding APIs. Test data for unit tests are put in
   `testdata/` directory.
 - UI tests based on matching to error messages are implemented in `linter_test.go` and all test data are stored in `testdata/`

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,11 @@ comment-cop:
 t test:
 	go test $(RACE) ./...
 
+.PHONY: conformance
+conformance:
+	go run ./scripts/fetch-conformance
+	go test -tags conformance -run '^TestUpstreamConformance' -count=1 -timeout 2m .
+
 coverage.out: $(TESTS) $(SRCS) $(TESTDATA) $(TOOL)
 	go test $(RACE) -coverprofile coverage.out -covermode=atomic ./...
 

--- a/UPSTREAM.md
+++ b/UPSTREAM.md
@@ -21,6 +21,10 @@ Local composite-action evidence and Go requirements were refreshed against `6dbd
 
 ## How to use this tracker
 
+The [upstream conformance suite](docs/conformance.md) provides additional evidence for parser and validation work.
+Its recorded differences include extra lint checks and limits of offline analysis; adopting a fixture does not by
+itself mean the related feature is implemented.
+
 - Review new items before adding them to the tracker.
 - Add each reviewed item once, checked, under one local disposition with concrete evidence.
 - Use one of these local dispositions: `Implemented locally`, `Partially implemented`, `Still affects fork`, `Candidate to port`, `Needs reproduction`, `Not applicable`, or `Superseded/duplicate`.

--- a/docs/conformance.md
+++ b/docs/conformance.md
@@ -59,19 +59,19 @@ CI runs on Linux, macOS, and Windows. Each job caches the archives, publishes a 
 - **Action manifests:** parse and validate metadata. Empty companion files satisfy the file-existence checks which
   the runner's manifest-parser fixtures do not exercise. Scripts and containers are never executed. Runtime
   deprecation diagnostics remain visible as additional lint findings.
-- **YAML:** decode every document in each stream and compare success with the upstream `error` marker. This tests
-  stream acceptance, not event sequences, scalar resolution, or GitHub's more restrictive YAML rules.
+- **YAML:** decode every document in each stream and compare success with the upstream `error` marker. The assertion
+  covers stream acceptance. Event sequences, scalar resolution, and GitHub's more restrictive YAML rules are outside
+  its scope.
 
-These are selected contracts from the upstream suites, not their complete test runners. Editor completion, hover,
-protocol behavior, runner execution, and expression evaluation are outside this harness. An acceptance match on a
-negative case means both implementations report an error; it does not prove they identify the same error. Existing
-actionlint tests continue to check exact diagnostics and positions.
+The harness exercises the upstream contracts listed above. Editor completion, hover, protocol behavior, runner
+execution, and expression evaluation are outside its scope. Matching rejection establishes that both implementations
+report an error. They may report different errors; existing actionlint tests check exact diagnostics and positions.
 
 ## Known differences
 
-The initial comparison has **1,721 cases: 1,368 agreements and 353 differences**. That is a starting inventory, not a
-compatibility score. Several fixtures exercise the same missing feature, and some differences are intentional lint
-checks or limits of offline analysis.
+The initial comparison has **1,721 cases: 1,368 agreements and 353 differences**. Several fixtures exercise the same
+missing feature, and some differences are intentional lint checks or limits of offline analysis. These counts help
+track changes in the imported cases; evaluating compatibility requires reviewing the individual differences.
 
 [`differences.json`](../testdata/conformance/differences.json) groups exact case IDs and current diagnostics under an
 explanation. Every listed case still runs. CI fails if a new difference appears, recorded diagnostics change, a known
@@ -95,8 +95,9 @@ To update a source, resolve the desired commit in its repository (`main` for Git
 SHA-256 digest. Update its revision and digest together in `sources.json`, then run the fetch command and tests.
 
 Review changed upstream assertions, fixture counts, adapter formats, and each new or resolved difference. The adapter
-checks exact inventory counts so a changed fixture layout cannot silently reduce coverage. Update this document when
-the selected contracts change. Never refresh the difference file merely to make CI green.
+requires the recorded fixture counts to match the imported corpus. Review count changes when updating the sources,
+and update this document when the selected contracts change. Each change to the difference file needs a reviewed
+explanation.
 
 The upstream projects retain authorship of their fixtures. The cache keeps their archives unmodified, including any
 license notices they contain; fixture source text is not copied into this repository or release packages.

--- a/docs/conformance.md
+++ b/docs/conformance.md
@@ -1,0 +1,102 @@
+# Upstream conformance tests
+
+The conformance job runs upstream fixtures through actionlint's Go implementation. It gives us independent inputs and
+expectations before changing the implementation or attempting a language port.
+
+## Sources and coverage
+
+| Source                                                                  | Imported cases | What is compared                                                                                  |
+| ----------------------------------------------------------------------- | -------------: | ------------------------------------------------------------------------------------------------- |
+| [actions/languageservices](https://github.com/actions/languageservices) |          1,228 | 1,020 expression fixtures, 195 workflow-reader fixtures, and 13 language-service validation cases |
+| [actions/runner](https://github.com/actions/runner)                     |             24 | 20 action-manifest fixtures and four expression context/function tests                            |
+| [SchemaStore/schemastore](https://github.com/SchemaStore/schemastore)   |             67 | Positive and negative GitHub workflow/action schema fixtures                                      |
+| [yaml/yaml-test-suite](https://github.com/yaml/yaml-test-suite)         |            402 | YAML stream acceptance by the Go YAML dependency                                                  |
+
+GitHub's language server lives in `actions/languageservices`. Its shared expression and workflow-parser corpora are
+designed for use across languages. We also import the language-service tests for service container commands and YAML
+anchors. The runner fixtures come from `ActionManifestManagerL0.cs` and `ExpressionParserL0.cs`.
+
+SchemaStore and YAML Test Suite provide additional comparisons. They do not define GitHub's runtime behavior. In
+particular, a schema-valid example can still contain undefined context properties, incomplete jobs, or retired actions.
+
+## Run locally
+
+```sh
+go run ./scripts/fetch-conformance
+go test -tags conformance -run '^TestUpstreamConformance' -count=1 -timeout 2m .
+```
+
+`make conformance` runs both commands. Ordinary `go test ./...` does not fetch or require these archives.
+
+The fetch command downloads the revisions in [`sources.json`](../internal/conformance/sources.json) and verifies their
+SHA-256 digests. Archives live in `.cache/conformance/`, outside Git. Tests read them without extracting or executing
+upstream code. A missing or corrupt archive fails the test. Once the archives and Go dependencies are cached, the tests
+run offline; no GitHub token, JavaScript runtime, .NET SDK, ShellCheck, or Pyflakes is needed.
+
+Optional environment variables:
+
+| Variable                          | Purpose                                                                                        |
+| --------------------------------- | ---------------------------------------------------------------------------------------------- |
+| `ACTIONLINT_CONFORMANCE_DIR`      | Read archives from another directory; pass the same directory to the fetch command with `-dir` |
+| `ACTIONLINT_CONFORMANCE_REPORT`   | Write the full comparison as JSON to this path                                                 |
+| `ACTIONLINT_CONFORMANCE_STRICT=1` | Fail on every upstream difference, including recorded differences                              |
+
+CI runs on Linux, macOS, and Windows. Each job caches the archives, publishes a summary, and uploads its JSON report.
+
+## What the assertions mean
+
+- **Expressions:** compare lexing/parsing acceptance, context names, function names, and arity. The adapter uses
+  actionlint's parser and semantic checker, with argument types erased for function-signature checks. It does not
+  compare evaluated values or runtime coercion. An upstream evaluation error still means the expression parsed.
+- **Workflow reader:** lint the original caller text with external tools disabled and an empty configuration. Extra
+  lint findings count as differences. Remote reusable workflow bodies supplied to GitHub's mock file provider are
+  not resolved by actionlint; the resulting differences are recorded explicitly. Expanded workflow objects and
+  repository-specific limits are not compared.
+- **Language service:** preserve the selected upstream assertions. The container tests check diagnostics mentioning
+  `command` or `entrypoint`; the circular-alias case checks completion without a panic or hang. Other selected cases
+  compare acceptance. Test blocks and assertions are read from the pinned TypeScript sources; unsupported changes to
+  their shape fail the adapter.
+- **Action manifests:** parse and validate metadata. Empty companion files satisfy the file-existence checks which
+  the runner's manifest-parser fixtures do not exercise. Scripts and containers are never executed. Runtime
+  deprecation diagnostics remain visible as additional lint findings.
+- **YAML:** decode every document in each stream and compare success with the upstream `error` marker. This tests
+  stream acceptance, not event sequences, scalar resolution, or GitHub's more restrictive YAML rules.
+
+These are selected contracts from the upstream suites, not their complete test runners. Editor completion, hover,
+protocol behavior, runner execution, and expression evaluation are outside this harness. An acceptance match on a
+negative case means both implementations report an error; it does not prove they identify the same error. Existing
+actionlint tests continue to check exact diagnostics and positions.
+
+## Known differences
+
+The initial comparison has **1,721 cases: 1,368 agreements and 353 differences**. That is a starting inventory, not a
+compatibility score. Several fixtures exercise the same missing feature, and some differences are intentional lint
+checks or limits of offline analysis.
+
+[`differences.json`](../testdata/conformance/differences.json) groups exact case IDs and current diagnostics under an
+explanation. Every listed case still runs. CI fails if a new difference appears, recorded diagnostics change, a known
+difference disappears, or a recorded case is missing. There are no wildcard exceptions or automatic baseline updates.
+
+Examples worth investigating include bracket wildcards, numeric expression spellings, expression depth limits,
+Docker `pre-if`/`post-if`, Docker environment contexts, action output metadata, and reserved job ID prefixes. An
+upstream reader fixture can describe internal or experimental behavior, so confirm the intended public contract
+before changing actionlint to match it.
+
+When fixing a difference, add a focused actionlint regression test and remove the resolved entry. If a diagnostic
+changes intentionally, review and update its recorded text. Use strict mode to inspect the remaining disagreements.
+
+## Updating the sources
+
+The revisions keep a normal PR run reproducible. They pin test inputs; they do not control generated action/runtime
+metadata or fetch anything while users run actionlint.
+
+To update a source, resolve the desired commit in its repository (`main` for GitHub's repositories, `master` for SchemaStore,
+`data` for YAML Test Suite), download its `https://codeload.github.com/OWNER/REPO/zip/COMMIT` archive, and calculate the
+SHA-256 digest. Update its revision and digest together in `sources.json`, then run the fetch command and tests.
+
+Review changed upstream assertions, fixture counts, adapter formats, and each new or resolved difference. The adapter
+checks exact inventory counts so a changed fixture layout cannot silently reduce coverage. Update this document when
+the selected contracts change. Never refresh the difference file merely to make CI green.
+
+The upstream projects retain authorship of their fixtures. The cache keeps their archives unmodified, including any
+license notices they contain; fixture source text is not copied into this repository or release packages.

--- a/internal/conformance/sources.go
+++ b/internal/conformance/sources.go
@@ -1,0 +1,138 @@
+// Package conformance loads the pinned upstream test corpora without extracting or executing their code.
+package conformance
+
+import (
+	"archive/zip"
+	"context"
+	"crypto/sha256"
+	_ "embed"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/fs"
+	"net/http"
+	"os"
+	"path"
+	"path/filepath"
+	"regexp"
+)
+
+//go:embed sources.json
+var manifest []byte
+
+// Source identifies a repository archive and its content digest.
+type Source struct {
+	Name       string `json:"name"`
+	Repository string `json:"repository"`
+	Revision   string `json:"revision"`
+	SHA256     string `json:"sha256"`
+}
+
+// Sources reads and validates the checked-in source revisions.
+func Sources() ([]Source, error) {
+	var sources []Source
+	if err := json.Unmarshal(manifest, &sources); err != nil {
+		return nil, err
+	}
+	seen := map[string]bool{}
+	for _, s := range sources {
+		if seen[s.Name] || !regexp.MustCompile(`^[a-z][a-z0-9-]*$`).MatchString(s.Name) ||
+			!regexp.MustCompile(`^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$`).MatchString(s.Repository) ||
+			!regexp.MustCompile(`^[0-9a-f]{40}$`).MatchString(s.Revision) ||
+			!regexp.MustCompile(`^[0-9a-f]{64}$`).MatchString(s.SHA256) {
+			return nil, fmt.Errorf("invalid or duplicate conformance source %q", s.Name)
+		}
+		seen[s.Name] = true
+	}
+	return sources, nil
+}
+
+// ArchivePath returns the cache filename for a source revision.
+func (s Source) ArchivePath(dir string) string {
+	return filepath.Join(dir, s.Name+"-"+s.Revision+".zip")
+}
+
+func (s Source) verify(filename string) error {
+	f, err := os.Open(filename)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return err
+	}
+	if got := hex.EncodeToString(h.Sum(nil)); got != s.SHA256 {
+		return fmt.Errorf("%s: SHA-256 mismatch: got %s, want %s", filename, got, s.SHA256)
+	}
+	return nil
+}
+
+// Fetch downloads a missing archive. Existing archives must still match their pinned digest.
+func (s Source) Fetch(ctx context.Context, dir string) error {
+	filename := s.ArchivePath(dir)
+	if _, err := os.Stat(filename); err == nil {
+		return s.verify(filename)
+	} else if !os.IsNotExist(err) {
+		return err
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://codeload.github.com/"+s.Repository+"/zip/"+s.Revision, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("download %s: %s", s.Repository, resp.Status)
+	}
+	f, err := os.CreateTemp(dir, ".download-*.zip")
+	if err != nil {
+		return err
+	}
+	defer os.Remove(f.Name())
+	const maxSize = 256 << 20
+	n, copyErr := io.Copy(f, io.LimitReader(resp.Body, maxSize+1))
+	closeErr := f.Close()
+	if copyErr != nil {
+		return copyErr
+	}
+	if closeErr != nil {
+		return closeErr
+	}
+	if n > maxSize {
+		return fmt.Errorf("%s archive exceeds %d bytes", s.Name, maxSize)
+	}
+	if err := s.verify(f.Name()); err != nil {
+		return err
+	}
+	return os.Rename(f.Name(), filename)
+}
+
+// Open verifies an archive and exposes its repository root as a read-only filesystem.
+func (s Source) Open(dir string) (fs.FS, func() error, error) {
+	filename := s.ArchivePath(dir)
+	if err := s.verify(filename); err != nil {
+		return nil, nil, err
+	}
+	z, err := zip.OpenReader(filename)
+	if err != nil {
+		return nil, nil, err
+	}
+	root, err := fs.Sub(z, path.Base(s.Repository)+"-"+s.Revision)
+	if err != nil {
+		z.Close()
+		return nil, nil, err
+	}
+	if _, err := fs.Stat(root, "."); err != nil {
+		z.Close()
+		return nil, nil, fmt.Errorf("%s archive has no expected repository root: %w", s.Name, err)
+	}
+	return root, z.Close, nil
+}

--- a/internal/conformance/sources.json
+++ b/internal/conformance/sources.json
@@ -1,0 +1,26 @@
+[
+  {
+    "name": "languageservices",
+    "repository": "actions/languageservices",
+    "revision": "4043eda158e16579cc5fb1b0b07a4bce2a76f0b5",
+    "sha256": "21715cfc48f75413ff1c6f78d3771bdc6ea2aa60b2b4189000d181d51f942672"
+  },
+  {
+    "name": "runner",
+    "repository": "actions/runner",
+    "revision": "602c0085328df8cb595fc2641d69f640a11377a4",
+    "sha256": "acdc27f68728b0623e73b117b9af5e0109023547e85a81bfd177b7f4ddcf6341"
+  },
+  {
+    "name": "schemastore",
+    "repository": "SchemaStore/schemastore",
+    "revision": "7d8659ecbca26d6d6d39646ef3f0d92f5f35ded1",
+    "sha256": "eeb121d5cacf88e7a883fb0dce11d13820830b5da6b65e054b4f6e6efd582d9a"
+  },
+  {
+    "name": "yaml-test-suite",
+    "repository": "yaml/yaml-test-suite",
+    "revision": "6ad3d2c62885d82fc349026c136ef560838fdf3d",
+    "sha256": "57ac1326b1fd5628fff811696d5280231b56999c259cd04a4abf99fee9acebe1"
+  }
+]

--- a/internal/conformance/sources_test.go
+++ b/internal/conformance/sources_test.go
@@ -1,0 +1,77 @@
+package conformance
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"strings"
+	"testing"
+)
+
+func fixtureArchive(t *testing.T, root string) (Source, string) {
+	t.Helper()
+	var data bytes.Buffer
+	z := zip.NewWriter(&data)
+	f, err := z.Create(root + "/fixture.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.Write([]byte("upstream fixture")); err != nil {
+		t.Fatal(err)
+	}
+	if err := z.Close(); err != nil {
+		t.Fatal(err)
+	}
+	s := Source{Name: "fixture", Repository: "owner/suite", Revision: strings.Repeat("a", 40), SHA256: fmt.Sprintf("%x", sha256.Sum256(data.Bytes()))}
+	dir := t.TempDir()
+	if err := os.WriteFile(s.ArchivePath(dir), data.Bytes(), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return s, dir
+}
+
+func TestSourceArchiveVerification(t *testing.T) {
+	s, dir := fixtureArchive(t, "suite-"+strings.Repeat("a", 40))
+	root, closeSource, err := s.Open(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, readErr := fs.ReadFile(root, "fixture.txt")
+	closeErr := closeSource()
+	if readErr != nil || closeErr != nil || string(data) != "upstream fixture" {
+		t.Fatalf("read verified fixture: %q, %v, %v", data, readErr, closeErr)
+	}
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	if err := s.Fetch(ctx, dir); err != nil {
+		t.Fatalf("verified cached archive must work without a network request: %v", err)
+	}
+	if err := os.WriteFile(s.ArchivePath(dir), []byte("corrupted cache"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, closeSource, err := s.Open(dir); err == nil {
+		_ = closeSource()
+		t.Fatal("corrupted archive was accepted")
+	} else if !strings.Contains(err.Error(), "SHA-256 mismatch") {
+		t.Fatal(err)
+	}
+	if err := s.Fetch(ctx, dir); err == nil || !strings.Contains(err.Error(), "SHA-256 mismatch") {
+		t.Fatalf("corrupted cache must fail verification without a replacement download: %v", err)
+	}
+}
+
+func TestSourceArchiveMissingRoot(t *testing.T) {
+	s, dir := fixtureArchive(t, "wrong-root")
+	if _, closeSource, err := s.Open(dir); err == nil {
+		_ = closeSource()
+		t.Fatal("archive with wrong repository root was accepted")
+	}
+	if _, _, err := s.Open(t.TempDir()); !errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("missing archive should require fetching: %v", err)
+	}
+}

--- a/scripts/fetch-conformance/main.go
+++ b/scripts/fetch-conformance/main.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"time"
+
+	"actionlint.kjanat.dev/internal/conformance"
+)
+
+func main() {
+	dir := flag.String("dir", ".cache/conformance", "Directory for verified upstream archives")
+	flag.Parse()
+	if err := fetch(*dir); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func fetch(dir string) error {
+	sources, err := conformance.Sources()
+	if err != nil {
+		return err
+	}
+	for _, s := range sources {
+		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+		err := s.Fetch(ctx, dir)
+		cancel()
+		if err != nil {
+			return fmt.Errorf("%s: %w", s.Name, err)
+		}
+		fmt.Printf("Verified %s@%s\n", s.Repository, s.Revision)
+	}
+	return nil
+}

--- a/testdata/conformance/differences.json
+++ b/testdata/conformance/differences.json
@@ -1,0 +1,1823 @@
+[
+  {
+    "reason": "Action context gap: the runner restricts Docker runs.env expressions to inputs; actionlint does not reject the github context here.",
+    "cases": {
+      "runner/src/Test/TestData/dockerfileaction_env_invalid_context.yml": []
+    }
+  },
+  {
+    "reason": "Action metadata gap: SchemaStore accepts Docker pre-if and post-if; actionlint currently forbids these keys for Docker actions.",
+    "cases": {
+      "schemastore/src/test/github-action/docker.json": [
+        ":1:1: \"pre-if\" is not allowed in \"runs\" section because \"Test Docker action\" is a Docker action. the action is defined at \"<action>\" [action]",
+        ":1:1: \"post-if\" is not allowed in \"runs\" section because \"Test Docker action\" is a Docker action. the action is defined at \"<action>\" [action]"
+      ]
+    }
+  },
+  {
+    "reason": "Action metadata gap: the runner accepts Docker pre-if and post-if; actionlint currently forbids these keys for Docker actions.",
+    "cases": {
+      "runner/src/Test/TestData/dockerfileaction_cleanup.yml": [
+        ":1:1: \"post-if\" is not allowed in \"runs\" section because \"Hello World\" is a Docker action. the action is defined at \"<action>\" [action]"
+      ],
+      "runner/src/Test/TestData/dockerfileaction_init.yml": [
+        ":1:1: \"pre-if\" is not allowed in \"runs\" section because \"Hello World\" is a Docker action. the action is defined at \"<action>\" [action]"
+      ]
+    }
+  },
+  {
+    "reason": "Action output gap: actionlint does not reject value on JavaScript action outputs.",
+    "cases": {
+      "schemastore/src/negative_test/github-action/javascript-output-with-value.json": []
+    }
+  },
+  {
+    "reason": "Action output gap: actionlint does not require value on composite action outputs.",
+    "cases": {
+      "schemastore/src/negative_test/github-action/composite-output-missing-value.json": []
+    }
+  },
+  {
+    "reason": "Empty-input contract difference: the upstream expression parser accepts empty input as null; actionlint requires an expression.",
+    "cases": {
+      "languageservices/expressions/testdata/basic.json/empty_expression/0": [
+        "1:1:0: unexpected end of input while parsing variable access, function call, null, bool, int, float or string. expecting \"IDENT\", \"(\", \"INTEGER\", \"FLOAT\", \"STRING\""
+      ]
+    }
+  },
+  {
+    "reason": "Event shape difference: this reader fixture accepts types under image_version; actionlint accepts names and versions.",
+    "cases": {
+      "languageservices/workflow-parser/testdata/reader/on-event-config-image-version-names.yml": [
+        "<stdin>:3:5: unexpected key \"types\" for \"image_version\" section. expected one of \"names\", \"versions\" [syntax-check]"
+      ],
+      "languageservices/workflow-parser/testdata/reader/on-event-config-image-version-versions.yml": [
+        "<stdin>:3:5: unexpected key \"types\" for \"image_version\" section. expected one of \"names\", \"versions\" [syntax-check]"
+      ]
+    }
+  },
+  {
+    "reason": "Event shape gap: the reader accepts scalar image_version names and versions; actionlint currently requires sequences.",
+    "cases": {
+      "languageservices/workflow-parser/testdata/reader/on-event-config-image-version-name-version.yml": [
+        "<stdin>:3:12: \"names\" section must be sequence node but got scalar node with \"!!str\" tag [syntax-check]",
+        "<stdin>:4:15: \"versions\" section must be sequence node but got scalar node with \"!!str\" tag [syntax-check]"
+      ]
+    }
+  },
+  {
+    "reason": "Expression gap: actionlint rejects the non-breaking space in this expression; the reader fixture accepts it. The fixture also uses a retired action.",
+    "cases": {
+      "languageservices/workflow-parser/testdata/reader/bad-character.yml": [
+        "<stdin>:12:15: the runtime or service used by \"actions/checkout@v3\" action is retired on GitHub.com. update the action's version to fix this issue [action]",
+        "<stdin>:16:43: got unexpected character '\\u00a0' while lexing expression, expecting 'a'..'z', 'A'..'Z', '_', '0'..'9', ''', '}', '(', ')', '[', ']', '.', '!', '<', '>', '=', '&', '|', '*', ',', ' ' [expression]"
+      ]
+    }
+  },
+  {
+    "reason": "Expression limit gap: actionlint does not enforce the upstream maximum expression depth of 50.",
+    "cases": {
+      "languageservices/expressions/testdata/syntax-errors.json/depth-errors/0": [],
+      "languageservices/expressions/testdata/syntax-errors.json/depth-errors/10": [],
+      "languageservices/expressions/testdata/syntax-errors.json/depth-errors/2": [],
+      "languageservices/expressions/testdata/syntax-errors.json/depth-errors/4": [],
+      "languageservices/expressions/testdata/syntax-errors.json/depth-errors/6": []
+    }
+  },
+  {
+    "reason": "Expression literal gap: actionlint does not recognize NaN or Infinity literals accepted by the upstream expression corpus.",
+    "cases": {
+      "languageservices/expressions/testdata/coerce_number.json/array/0": [
+        "1:19:18: undefined variable \"NaN\". available variables are "
+      ],
+      "languageservices/expressions/testdata/coerce_number.json/array/1": [
+        "1:19:18: undefined variable \"NaN\". available variables are "
+      ],
+      "languageservices/expressions/testdata/coerce_number.json/array/2": [
+        "1:18:17: undefined variable \"NaN\". available variables are "
+      ],
+      "languageservices/expressions/testdata/coerce_number.json/array/3": [
+        "1:18:17: undefined variable \"NaN\". available variables are "
+      ],
+      "languageservices/expressions/testdata/coerce_number.json/object/0": [
+        "1:19:18: undefined variable \"NaN\". available variables are "
+      ],
+      "languageservices/expressions/testdata/coerce_number.json/object/1": [
+        "1:19:18: undefined variable \"NaN\". available variables are "
+      ],
+      "languageservices/expressions/testdata/coerce_number.json/object/2": [
+        "1:18:17: undefined variable \"NaN\". available variables are "
+      ],
+      "languageservices/expressions/testdata/coerce_number.json/object/3": [
+        "1:18:17: undefined variable \"NaN\". available variables are "
+      ],
+      "languageservices/expressions/testdata/coerce_number.json/string/10": [
+        "1:12:11: undefined variable \"NaN\". available variables are "
+      ],
+      "languageservices/expressions/testdata/coerce_number.json/string/11": [
+        "1:11:10: undefined variable \"NaN\". available variables are "
+      ],
+      "languageservices/expressions/testdata/coerce_number.json/string/12": [
+        "1:11:10: undefined variable \"NaN\". available variables are "
+      ],
+      "languageservices/expressions/testdata/coerce_number.json/string/13": [
+        "1:12:11: undefined variable \"NaN\". available variables are "
+      ],
+      "languageservices/expressions/testdata/coerce_number.json/string/14": [
+        "1:12:11: undefined variable \"NaN\". available variables are "
+      ],
+      "languageservices/expressions/testdata/coerce_number.json/string/15": [
+        "1:11:10: undefined variable \"NaN\". available variables are "
+      ],
+      "languageservices/expressions/testdata/coerce_number.json/string/16": [
+        "1:11:10: undefined variable \"NaN\". available variables are "
+      ],
+      "languageservices/expressions/testdata/coerce_number.json/string/7": [
+        "1:17:16: undefined variable \"Infinity\". available variables are "
+      ],
+      "languageservices/expressions/testdata/coerce_number.json/string/8": [
+        "1:19:18: got unexpected character 'I' while lexing integer part of number, expecting '0'..'9'"
+      ],
+      "languageservices/expressions/testdata/coerce_number.json/string/9": [
+        "1:12:11: undefined variable \"NaN\". available variables are "
+      ],
+      "languageservices/expressions/testdata/coerce_string.json/number/27": [
+        "1:15:14: undefined variable \"Infinity\". available variables are "
+      ],
+      "languageservices/expressions/testdata/coerce_string.json/number/28": [
+        "1:16:15: got unexpected character 'I' while lexing integer part of number, expecting '0'..'9'"
+      ],
+      "languageservices/expressions/testdata/coerce_string.json/number/29": [
+        "1:15:14: undefined variable \"NaN\". available variables are "
+      ],
+      "languageservices/expressions/testdata/format.json/format/16": [
+        "1:15:14: undefined variable \"Infinity\". available variables are "
+      ],
+      "languageservices/expressions/testdata/format.json/format/17": [
+        "1:16:15: got unexpected character 'I' while lexing integer part of number, expecting '0'..'9'"
+      ],
+      "languageservices/expressions/testdata/format.json/format/18": [
+        "1:15:14: undefined variable \"NaN\". available variables are "
+      ],
+      "languageservices/expressions/testdata/number.json/number/11": [
+        "1:15:14: undefined variable \"NaN\". available variables are "
+      ],
+      "languageservices/expressions/testdata/number.json/number/8": [
+        "1:16:15: got unexpected character 'I' while lexing integer part of number, expecting '0'..'9'"
+      ],
+      "languageservices/expressions/testdata/number.json/number/9": [
+        "1:15:14: undefined variable \"Infinity\". available variables are "
+      ],
+      "languageservices/expressions/testdata/op_eq.json/coerce_bool_number/2": [
+        "1:10:9: undefined variable \"NaN\". available variables are "
+      ],
+      "languageservices/expressions/testdata/op_eq.json/coerce_number_bool/2": [
+        "1:1:0: undefined variable \"NaN\". available variables are "
+      ],
+      "languageservices/expressions/testdata/op_eq.json/coerce_number_string/11": [
+        "1:1:0: undefined variable \"Infinity\". available variables are "
+      ],
+      "languageservices/expressions/testdata/op_eq.json/coerce_number_string/12": [
+        "1:2:1: got unexpected character 'I' while lexing integer part of number, expecting '0'..'9'"
+      ],
+      "languageservices/expressions/testdata/op_eq.json/coerce_number_string/13": [
+        "1:1:0: undefined variable \"NaN\". available variables are "
+      ],
+      "languageservices/expressions/testdata/op_eq.json/coerce_string_number/11": [
+        "1:17:16: undefined variable \"Infinity\". available variables are "
+      ],
+      "languageservices/expressions/testdata/op_eq.json/coerce_string_number/12": [
+        "1:19:18: got unexpected character 'I' while lexing integer part of number, expecting '0'..'9'"
+      ],
+      "languageservices/expressions/testdata/op_eq.json/coerce_string_number/13": [
+        "1:10:9: undefined variable \"NaN\". available variables are "
+      ],
+      "languageservices/expressions/testdata/op_eq.json/number/5": [
+        "1:1:0: undefined variable \"NaN\". available variables are ",
+        "1:8:7: undefined variable \"NaN\". available variables are "
+      ],
+      "languageservices/expressions/testdata/op_eq.json/number/6": [
+        "1:1:0: undefined variable \"Infinity\". available variables are ",
+        "1:13:12: undefined variable \"Infinity\". available variables are "
+      ],
+      "languageservices/expressions/testdata/op_eq.json/number/7": [
+        "1:2:1: got unexpected character 'I' while lexing integer part of number, expecting '0'..'9'"
+      ],
+      "languageservices/expressions/testdata/op_eq.json/number/8": [
+        "1:6:5: undefined variable \"Infinity\". available variables are "
+      ],
+      "languageservices/expressions/testdata/op_eq.json/number/9": [
+        "1:6:5: undefined variable \"Infinity\". available variables are "
+      ],
+      "languageservices/expressions/testdata/op_gt.json/coerce_bool_number/4": [
+        "1:9:8: undefined variable \"NaN\". available variables are "
+      ],
+      "languageservices/expressions/testdata/op_gt.json/coerce_bool_number/5": [
+        "1:8:7: undefined variable \"NaN\". available variables are "
+      ],
+      "languageservices/expressions/testdata/op_gt.json/coerce_bool_number/6": [
+        "1:9:8: undefined variable \"Infinity\". available variables are "
+      ],
+      "languageservices/expressions/testdata/op_gt.json/coerce_bool_number/7": [
+        "1:8:7: undefined variable \"Infinity\". available variables are "
+      ],
+      "languageservices/expressions/testdata/op_gt.json/coerce_bool_number/8": [
+        "1:10:9: got unexpected character 'I' while lexing integer part of number, expecting '0'..'9'"
+      ],
+      "languageservices/expressions/testdata/op_gt.json/coerce_bool_number/9": [
+        "1:9:8: got unexpected character 'I' while lexing integer part of number, expecting '0'..'9'"
+      ],
+      "languageservices/expressions/testdata/op_gt.json/coerce_number_bool/4": [
+        "1:1:0: undefined variable \"NaN\". available variables are "
+      ],
+      "languageservices/expressions/testdata/op_gt.json/coerce_number_bool/5": [
+        "1:1:0: undefined variable \"NaN\". available variables are "
+      ],
+      "languageservices/expressions/testdata/op_gt.json/coerce_number_bool/6": [
+        "1:1:0: undefined variable \"Infinity\". available variables are "
+      ],
+      "languageservices/expressions/testdata/op_gt.json/coerce_number_bool/7": [
+        "1:1:0: undefined variable \"Infinity\". available variables are "
+      ],
+      "languageservices/expressions/testdata/op_gt.json/coerce_number_bool/8": [
+        "1:2:1: got unexpected character 'I' while lexing integer part of number, expecting '0'..'9'"
+      ],
+      "languageservices/expressions/testdata/op_gt.json/coerce_number_bool/9": [
+        "1:2:1: got unexpected character 'I' while lexing integer part of number, expecting '0'..'9'"
+      ],
+      "languageservices/expressions/testdata/op_idx.json/array-index-out-of-range/2": [
+        "1:6:5: got unexpected character 'I' while lexing integer part of number, expecting '0'..'9'"
+      ],
+      "languageservices/expressions/testdata/op_idx.json/array-index-out-of-range/3": [
+        "1:5:4: undefined variable \"Infinity\". available variables are \"foo\""
+      ],
+      "languageservices/expressions/testdata/op_idx.json/array-index-out-of-range/4": [
+        "1:5:4: undefined variable \"NaN\". available variables are \"foo\""
+      ],
+      "languageservices/expressions/testdata/op_idx.json/object-index-coercion/4": [
+        "1:5:4: undefined variable \"NaN\". available variables are \"foo\""
+      ],
+      "languageservices/expressions/testdata/op_idx.json/object-index-coercion/5": [
+        "1:5:4: undefined variable \"Infinity\". available variables are \"foo\""
+      ],
+      "languageservices/expressions/testdata/op_idx.json/object-index-coercion/6": [
+        "1:6:5: got unexpected character 'I' while lexing integer part of number, expecting '0'..'9'"
+      ],
+      "languageservices/expressions/testdata/op_lt.json/coerce_bool_number/4": [
+        "1:9:8: undefined variable \"NaN\". available variables are "
+      ],
+      "languageservices/expressions/testdata/op_lt.json/coerce_bool_number/5": [
+        "1:8:7: undefined variable \"NaN\". available variables are "
+      ],
+      "languageservices/expressions/testdata/op_lt.json/coerce_bool_number/6": [
+        "1:9:8: undefined variable \"Infinity\". available variables are "
+      ],
+      "languageservices/expressions/testdata/op_lt.json/coerce_bool_number/7": [
+        "1:8:7: undefined variable \"Infinity\". available variables are "
+      ],
+      "languageservices/expressions/testdata/op_lt.json/coerce_bool_number/8": [
+        "1:10:9: got unexpected character 'I' while lexing integer part of number, expecting '0'..'9'"
+      ],
+      "languageservices/expressions/testdata/op_lt.json/coerce_bool_number/9": [
+        "1:9:8: got unexpected character 'I' while lexing integer part of number, expecting '0'..'9'"
+      ],
+      "languageservices/expressions/testdata/op_lt.json/coerce_number_bool/4": [
+        "1:1:0: undefined variable \"NaN\". available variables are "
+      ],
+      "languageservices/expressions/testdata/op_lt.json/coerce_number_bool/5": [
+        "1:1:0: undefined variable \"NaN\". available variables are "
+      ],
+      "languageservices/expressions/testdata/op_lt.json/coerce_number_bool/6": [
+        "1:1:0: undefined variable \"Infinity\". available variables are "
+      ],
+      "languageservices/expressions/testdata/op_lt.json/coerce_number_bool/7": [
+        "1:1:0: undefined variable \"Infinity\". available variables are "
+      ],
+      "languageservices/expressions/testdata/op_lt.json/coerce_number_bool/8": [
+        "1:2:1: got unexpected character 'I' while lexing integer part of number, expecting '0'..'9'"
+      ],
+      "languageservices/expressions/testdata/op_lt.json/coerce_number_bool/9": [
+        "1:2:1: got unexpected character 'I' while lexing integer part of number, expecting '0'..'9'"
+      ],
+      "languageservices/expressions/testdata/op_ne.json/coerce_bool_number/3": [
+        "1:10:9: undefined variable \"NaN\". available variables are "
+      ],
+      "languageservices/expressions/testdata/op_ne.json/coerce_number_bool/4": [
+        "1:1:0: undefined variable \"NaN\". available variables are "
+      ],
+      "languageservices/expressions/testdata/op_ne.json/coerce_number_string/11": [
+        "1:1:0: undefined variable \"Infinity\". available variables are "
+      ],
+      "languageservices/expressions/testdata/op_ne.json/coerce_number_string/12": [
+        "1:2:1: got unexpected character 'I' while lexing integer part of number, expecting '0'..'9'"
+      ],
+      "languageservices/expressions/testdata/op_ne.json/coerce_number_string/13": [
+        "1:1:0: undefined variable \"NaN\". available variables are "
+      ],
+      "languageservices/expressions/testdata/op_ne.json/coerce_string_number/11": [
+        "1:17:16: undefined variable \"Infinity\". available variables are "
+      ],
+      "languageservices/expressions/testdata/op_ne.json/coerce_string_number/12": [
+        "1:19:18: got unexpected character 'I' while lexing integer part of number, expecting '0'..'9'"
+      ],
+      "languageservices/expressions/testdata/op_ne.json/coerce_string_number/13": [
+        "1:10:9: undefined variable \"NaN\". available variables are "
+      ],
+      "languageservices/expressions/testdata/op_ne.json/number/10": [
+        "1:6:5: undefined variable \"Infinity\". available variables are "
+      ],
+      "languageservices/expressions/testdata/op_ne.json/number/11": [
+        "1:6:5: undefined variable \"Infinity\". available variables are "
+      ],
+      "languageservices/expressions/testdata/op_ne.json/number/5": [
+        "1:1:0: undefined variable \"NaN\". available variables are ",
+        "1:8:7: undefined variable \"NaN\". available variables are "
+      ],
+      "languageservices/expressions/testdata/op_ne.json/number/6": [
+        "1:6:5: undefined variable \"NaN\". available variables are "
+      ],
+      "languageservices/expressions/testdata/op_ne.json/number/7": [
+        "1:6:5: undefined variable \"NaN\". available variables are "
+      ],
+      "languageservices/expressions/testdata/op_ne.json/number/8": [
+        "1:1:0: undefined variable \"Infinity\". available variables are ",
+        "1:13:12: undefined variable \"Infinity\". available variables are "
+      ],
+      "languageservices/expressions/testdata/op_ne.json/number/9": [
+        "1:2:1: got unexpected character 'I' while lexing integer part of number, expecting '0'..'9'"
+      ],
+      "languageservices/expressions/testdata/op_not.json/not/10": [
+        "1:3:2: undefined variable \"Infinity\". available variables are "
+      ],
+      "languageservices/expressions/testdata/op_not.json/not/11": [
+        "1:3:2: undefined variable \"NaN\". available variables are "
+      ],
+      "languageservices/expressions/testdata/op_not.json/not/9": [
+        "1:4:3: got unexpected character 'I' while lexing integer part of number, expecting '0'..'9'"
+      ]
+    }
+  },
+  {
+    "reason": "Expression numeric syntax gap: actionlint accepts negative hexadecimal -0xFF; the upstream parser rejects it.",
+    "cases": {
+      "languageservices/expressions/testdata/number.json/number/33": []
+    }
+  },
+  {
+    "reason": "Expression numeric syntax gap: leading-dot decimals, unary plus, octal prefixes, and some hexadecimal spellings differ from the upstream lexer.",
+    "cases": {
+      "languageservices/expressions/testdata/coerce_string.json/number/1": [
+        "1:15:14: unexpected token \".\" while parsing variable access, function call, null, bool, int, float or string. expecting \"IDENT\", \"(\", \"INTEGER\", \"FLOAT\", \"STRING\""
+      ],
+      "languageservices/expressions/testdata/coerce_string.json/number/13": [
+        "1:15:14: got unexpected character '+' while lexing expression, expecting 'a'..'z', 'A'..'Z', '_', '0'..'9', ''', '}', '(', ')', '[', ']', '.', '!', '<', '>', '=', '&', '|', '*', ',', ' '"
+      ],
+      "languageservices/expressions/testdata/coerce_string.json/number/20": [
+        "1:16:15: got unexpected character 'o' while lexing character following number 0, expecting ''', '}', '(', ')', '[', ']', '.', '!', '<', '>', '=', '&', '|', '*', ',', ' '"
+      ],
+      "languageservices/expressions/testdata/coerce_string.json/number/5": [
+        "1:16:15: got unexpected character '.' while lexing integer part of number, expecting '0'..'9'"
+      ],
+      "languageservices/expressions/testdata/number.json/number/1": [
+        "1:1:0: unexpected token \".\" while parsing variable access, function call, null, bool, int, float or string. expecting \"IDENT\", \"(\", \"INTEGER\", \"FLOAT\", \"STRING\""
+      ],
+      "languageservices/expressions/testdata/number.json/number/10": [
+        "1:15:14: got unexpected character '+' while lexing expression, expecting 'a'..'z', 'A'..'Z', '_', '0'..'9', ''', '}', '(', ')', '[', ']', '.', '!', '<', '>', '=', '&', '|', '*', ',', ' '"
+      ],
+      "languageservices/expressions/testdata/number.json/number/17": [
+        "1:4:3: got unexpected character '0' while lexing character following hex integer 0x0, expecting ''', '}', '(', ')', '[', ']', '.', '!', '<', '>', '=', '&', '|', '*', ',', ' '"
+      ],
+      "languageservices/expressions/testdata/number.json/number/21": [
+        "1:2:1: got unexpected character 'o' while lexing character following number 0, expecting ''', '}', '(', ')', '[', ']', '.', '!', '<', '>', '=', '&', '|', '*', ',', ' '"
+      ],
+      "languageservices/expressions/testdata/number.json/number/22": [
+        "1:2:1: got unexpected character 'o' while lexing character following number 0, expecting ''', '}', '(', ')', '[', ']', '.', '!', '<', '>', '=', '&', '|', '*', ',', ' '"
+      ],
+      "languageservices/expressions/testdata/number.json/number/23": [
+        "1:2:1: got unexpected character 'o' while lexing character following number 0, expecting ''', '}', '(', ')', '[', ']', '.', '!', '<', '>', '=', '&', '|', '*', ',', ' '"
+      ],
+      "languageservices/expressions/testdata/number.json/number/24": [
+        "1:2:1: got unexpected character 'o' while lexing character following number 0, expecting ''', '}', '(', ')', '[', ']', '.', '!', '<', '>', '=', '&', '|', '*', ',', ' '"
+      ],
+      "languageservices/expressions/testdata/number.json/number/5": [
+        "1:1:0: got unexpected character '+' while lexing expression, expecting 'a'..'z', 'A'..'Z', '_', '0'..'9', ''', '}', '(', ')', '[', ']', '.', '!', '<', '>', '=', '&', '|', '*', ',', ' '"
+      ],
+      "languageservices/expressions/testdata/number.json/number/6": [
+        "1:2:1: got unexpected character '.' while lexing integer part of number, expecting '0'..'9'"
+      ],
+      "languageservices/expressions/testdata/op_idx.json/object-index-coercion/1": [
+        "1:5:4: unexpected token \".\" while parsing variable access, function call, null, bool, int, float or string. expecting \"IDENT\", \"(\", \"INTEGER\", \"FLOAT\", \"STRING\""
+      ],
+      "languageservices/expressions/testdata/op_idx.json/object-index-coercion/2": [
+        "1:6:5: got unexpected character '.' while lexing integer part of number, expecting '0'..'9'"
+      ],
+      "languageservices/expressions/testdata/op_idx.json/object-index-coercion/3": [
+        "1:8:7: got unexpected character 'f' while lexing character following hex integer 0x0, expecting ''', '}', '(', ')', '[', ']', '.', '!', '<', '>', '=', '&', '|', '*', ',', ' '"
+      ],
+      "languageservices/expressions/testdata/op_not.json/not/3": [
+        "1:3:2: unexpected token \".\" while parsing variable access, function call, null, bool, int, float or string. expecting \"IDENT\", \"(\", \"INTEGER\", \"FLOAT\", \"STRING\""
+      ],
+      "languageservices/expressions/testdata/op_not.json/not/7": [
+        "1:4:3: got unexpected character '.' while lexing integer part of number, expecting '0'..'9'"
+      ]
+    }
+  },
+  {
+    "reason": "Expression syntax gap: actionlint accepts dot wildcards but does not parse bracket wildcards such as items[*].",
+    "cases": {
+      "languageservices/expressions/testdata/op_dot.json/property-basics/9": [
+        "1:5:4: unexpected token \"*\" while parsing variable access, function call, null, bool, int, float or string. expecting \"IDENT\", \"(\", \"INTEGER\", \"FLOAT\", \"STRING\""
+      ],
+      "languageservices/expressions/testdata/op_idx.json/index-star/0": [
+        "1:5:4: unexpected token \"*\" while parsing variable access, function call, null, bool, int, float or string. expecting \"IDENT\", \"(\", \"INTEGER\", \"FLOAT\", \"STRING\""
+      ],
+      "languageservices/expressions/testdata/op_idx.json/index-star/2": [
+        "1:5:4: unexpected token \"*\" while parsing variable access, function call, null, bool, int, float or string. expecting \"IDENT\", \"(\", \"INTEGER\", \"FLOAT\", \"STRING\""
+      ],
+      "languageservices/expressions/testdata/op_idx_star.json/double-index/0": [
+        "1:5:4: unexpected token \"*\" while parsing variable access, function call, null, bool, int, float or string. expecting \"IDENT\", \"(\", \"INTEGER\", \"FLOAT\", \"STRING\""
+      ],
+      "languageservices/expressions/testdata/op_idx_star.json/nested-array-index-coercion/0": [
+        "1:5:4: unexpected token \"*\" while parsing variable access, function call, null, bool, int, float or string. expecting \"IDENT\", \"(\", \"INTEGER\", \"FLOAT\", \"STRING\""
+      ],
+      "languageservices/expressions/testdata/op_idx_star.json/nested-array-index-coercion/1": [
+        "1:5:4: unexpected token \"*\" while parsing variable access, function call, null, bool, int, float or string. expecting \"IDENT\", \"(\", \"INTEGER\", \"FLOAT\", \"STRING\""
+      ],
+      "languageservices/expressions/testdata/op_idx_star.json/nested-array-index-coercion/2": [
+        "1:5:4: unexpected token \"*\" while parsing variable access, function call, null, bool, int, float or string. expecting \"IDENT\", \"(\", \"INTEGER\", \"FLOAT\", \"STRING\""
+      ],
+      "languageservices/expressions/testdata/op_idx_star.json/nested-array-index-coercion/3": [
+        "1:5:4: unexpected token \"*\" while parsing variable access, function call, null, bool, int, float or string. expecting \"IDENT\", \"(\", \"INTEGER\", \"FLOAT\", \"STRING\""
+      ],
+      "languageservices/expressions/testdata/op_idx_star.json/nested-array-index-coercion/4": [
+        "1:5:4: unexpected token \"*\" while parsing variable access, function call, null, bool, int, float or string. expecting \"IDENT\", \"(\", \"INTEGER\", \"FLOAT\", \"STRING\""
+      ],
+      "languageservices/expressions/testdata/op_idx_star.json/nested-array-index-coercion/5": [
+        "1:5:4: unexpected token \"*\" while parsing variable access, function call, null, bool, int, float or string. expecting \"IDENT\", \"(\", \"INTEGER\", \"FLOAT\", \"STRING\""
+      ],
+      "languageservices/expressions/testdata/op_idx_star.json/nested-array-index-coercion/6": [
+        "1:5:4: unexpected token \"*\" while parsing variable access, function call, null, bool, int, float or string. expecting \"IDENT\", \"(\", \"INTEGER\", \"FLOAT\", \"STRING\""
+      ],
+      "languageservices/expressions/testdata/op_idx_star.json/nested-array-index-coercion/7": [
+        "1:5:4: unexpected token \"*\" while parsing variable access, function call, null, bool, int, float or string. expecting \"IDENT\", \"(\", \"INTEGER\", \"FLOAT\", \"STRING\""
+      ],
+      "languageservices/expressions/testdata/op_idx_star.json/nested-array-index-not-found/0": [
+        "1:5:4: unexpected token \"*\" while parsing variable access, function call, null, bool, int, float or string. expecting \"IDENT\", \"(\", \"INTEGER\", \"FLOAT\", \"STRING\""
+      ],
+      "languageservices/expressions/testdata/op_idx_star.json/nested-array-index-not-found/1": [
+        "1:5:4: unexpected token \"*\" while parsing variable access, function call, null, bool, int, float or string. expecting \"IDENT\", \"(\", \"INTEGER\", \"FLOAT\", \"STRING\""
+      ],
+      "languageservices/expressions/testdata/op_idx_star.json/nested-array-index-not-found/2": [
+        "1:5:4: unexpected token \"*\" while parsing variable access, function call, null, bool, int, float or string. expecting \"IDENT\", \"(\", \"INTEGER\", \"FLOAT\", \"STRING\""
+      ],
+      "languageservices/expressions/testdata/op_idx_star.json/nested-array-index-not-found/3": [
+        "1:5:4: unexpected token \"*\" while parsing variable access, function call, null, bool, int, float or string. expecting \"IDENT\", \"(\", \"INTEGER\", \"FLOAT\", \"STRING\""
+      ],
+      "languageservices/expressions/testdata/op_idx_star.json/nested-array-index-not-found/4": [
+        "1:5:4: unexpected token \"*\" while parsing variable access, function call, null, bool, int, float or string. expecting \"IDENT\", \"(\", \"INTEGER\", \"FLOAT\", \"STRING\""
+      ],
+      "languageservices/expressions/testdata/op_idx_star.json/nested-array/0": [
+        "1:5:4: unexpected token \"*\" while parsing variable access, function call, null, bool, int, float or string. expecting \"IDENT\", \"(\", \"INTEGER\", \"FLOAT\", \"STRING\""
+      ],
+      "languageservices/expressions/testdata/op_idx_star.json/nested-object-property-coercion/0": [
+        "1:5:4: unexpected token \"*\" while parsing variable access, function call, null, bool, int, float or string. expecting \"IDENT\", \"(\", \"INTEGER\", \"FLOAT\", \"STRING\""
+      ],
+      "languageservices/expressions/testdata/op_idx_star.json/nested-object-property-coercion/1": [
+        "1:5:4: unexpected token \"*\" while parsing variable access, function call, null, bool, int, float or string. expecting \"IDENT\", \"(\", \"INTEGER\", \"FLOAT\", \"STRING\""
+      ],
+      "languageservices/expressions/testdata/op_idx_star.json/nested-object-property-coercion/2": [
+        "1:5:4: unexpected token \"*\" while parsing variable access, function call, null, bool, int, float or string. expecting \"IDENT\", \"(\", \"INTEGER\", \"FLOAT\", \"STRING\""
+      ],
+      "languageservices/expressions/testdata/op_idx_star.json/nested-object-property-coercion/3": [
+        "1:5:4: unexpected token \"*\" while parsing variable access, function call, null, bool, int, float or string. expecting \"IDENT\", \"(\", \"INTEGER\", \"FLOAT\", \"STRING\""
+      ],
+      "languageservices/expressions/testdata/op_idx_star.json/nested-object-property-coercion/4": [
+        "1:5:4: unexpected token \"*\" while parsing variable access, function call, null, bool, int, float or string. expecting \"IDENT\", \"(\", \"INTEGER\", \"FLOAT\", \"STRING\""
+      ],
+      "languageservices/expressions/testdata/op_idx_star.json/nested-object-property-coercion/5": [
+        "1:5:4: unexpected token \"*\" while parsing variable access, function call, null, bool, int, float or string. expecting \"IDENT\", \"(\", \"INTEGER\", \"FLOAT\", \"STRING\""
+      ],
+      "languageservices/expressions/testdata/op_idx_star.json/nested-object-property-coercion/6": [
+        "1:5:4: unexpected token \"*\" while parsing variable access, function call, null, bool, int, float or string. expecting \"IDENT\", \"(\", \"INTEGER\", \"FLOAT\", \"STRING\""
+      ],
+      "languageservices/expressions/testdata/op_idx_star.json/nested-object-property-coercion/7": [
+        "1:5:4: unexpected token \"*\" while parsing variable access, function call, null, bool, int, float or string. expecting \"IDENT\", \"(\", \"INTEGER\", \"FLOAT\", \"STRING\""
+      ],
+      "languageservices/expressions/testdata/op_idx_star.json/nested-object-property-coercion/8": [
+        "1:5:4: unexpected token \"*\" while parsing variable access, function call, null, bool, int, float or string. expecting \"IDENT\", \"(\", \"INTEGER\", \"FLOAT\", \"STRING\""
+      ],
+      "languageservices/expressions/testdata/op_idx_star.json/nested-object/1": [
+        "1:5:4: unexpected token \"*\" while parsing variable access, function call, null, bool, int, float or string. expecting \"IDENT\", \"(\", \"INTEGER\", \"FLOAT\", \"STRING\""
+      ],
+      "languageservices/expressions/testdata/op_idx_star.json/not-found-always-returns-empty-array/0": [
+        "1:5:4: unexpected token \"*\" while parsing variable access, function call, null, bool, int, float or string. expecting \"IDENT\", \"(\", \"INTEGER\", \"FLOAT\", \"STRING\""
+      ],
+      "languageservices/expressions/testdata/op_idx_star.json/not-found-always-returns-empty-array/1": [
+        "1:5:4: unexpected token \"*\" while parsing variable access, function call, null, bool, int, float or string. expecting \"IDENT\", \"(\", \"INTEGER\", \"FLOAT\", \"STRING\""
+      ],
+      "languageservices/expressions/testdata/syntax-errors.json/depth-errors/9": [
+        "1:8:7: unexpected token \"*\" while parsing variable access, function call, null, bool, int, float or string. expecting \"IDENT\", \"(\", \"INTEGER\", \"FLOAT\", \"STRING\""
+      ]
+    }
+  },
+  {
+    "reason": "Extra expression type check: a whole steps object is interpolated into a string.",
+    "cases": {
+      "languageservices/workflow-parser/testdata/reader/job-with-outputs-context.yml": [
+        "<stdin>:6:20: object, array, and null values should not be evaluated in template with ${{ }} but evaluating the value of type {conclusion: string; outcome: string; outputs: {string => string}} [expression]"
+      ]
+    }
+  },
+  {
+    "reason": "Extra expression type check: the fixture references an undeclared steps.foo property.",
+    "cases": {
+      "languageservices/workflow-parser/testdata/reader/step-run.yml": [
+        "<stdin>:8:23: property \"foo\" is not defined in object type {} [expression]"
+      ]
+    }
+  },
+  {
+    "reason": "Extra lifecycle check: the fixture uses the retired windows-2019 runner label.",
+    "cases": {
+      "languageservices/workflow-parser/testdata/reader/workflow-env.yml": [
+        "<stdin>:6:14: label \"windows-2019\" is unknown. available labels are \"windows-latest\", \"windows-latest-8-cores\", \"windows-2025\", \"windows-2025-vs2026\", \"windows-2022\", \"windows-11-arm\", \"windows-11-vs2026-arm\", \"ubuntu-slim\", \"ubuntu-latest\", \"ubuntu-latest-4-cores\", \"ubuntu-latest-8-cores\", \"ubuntu-latest-16-cores\", \"ubuntu-26.04\", \"ubuntu-26.04-arm\", \"ubuntu-24.04\", \"ubuntu-24.04-arm\", \"ubuntu-22.04\", \"ubuntu-22.04-arm\", \"xcode-27\", \"xcode-27-xlarge\", \"macos-latest\", \"macos-latest-xlarge\", \"macos-latest-large\", \"macos-26-intel\", \"macos-26-xlarge\", \"macos-26-large\", \"macos-26\", \"macos-15-intel\", \"macos-15-xlarge\", \"macos-15-large\", \"macos-15\", \"macos-14-xlarge\", \"macos-14-large\", \"macos-14\", \"self-hosted\", \"x64\", \"arm\", \"arm64\", \"linux\", \"macos\", \"windows\". if it is a custom label for self-hosted runner, set list of labels in actionlint.yaml config file [runner-label]"
+      ]
+    }
+  },
+  {
+    "reason": "Extra lifecycle checks: these historical fixtures remain parser-valid, while actionlint reports their deprecated or retired action runtimes.",
+    "cases": {
+      "languageservices/languageservice/src/validate.yaml-anchors.test.ts/should handle anchors in steps": [
+        "<stdin>:8:15: runtime \"node20\" is deprecated in GitHub Actions; removal is scheduled for September 23rd, 2026. see https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/. update the version of action \"actions/checkout@v4\" [action]"
+      ],
+      "languageservices/workflow-parser/testdata/reader/background-steps.yml": [
+        "<stdin>:10:15: runtime \"node20\" is deprecated in GitHub Actions; removal is scheduled for September 23rd, 2026. see https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/. update the version of action \"actions/checkout@v4\" [action]"
+      ],
+      "languageservices/workflow-parser/testdata/reader/basic.yml": [
+        "<stdin>:6:15: the runtime or service used by \"actions/checkout@v3\" action is retired on GitHub.com. update the action's version to fix this issue [action]"
+      ],
+      "languageservices/workflow-parser/testdata/reader/events-mapping-repo-dispatch.yml": [
+        "<stdin>:9:15: the runtime or service used by \"actions/checkout@v3\" action is retired on GitHub.com. update the action's version to fix this issue [action]"
+      ],
+      "languageservices/workflow-parser/testdata/reader/events-mapping.yml": [
+        "<stdin>:25:15: the runtime or service used by \"actions/checkout@v3\" action is retired on GitHub.com. update the action's version to fix this issue [action]"
+      ],
+      "languageservices/workflow-parser/testdata/reader/events-sequence.yml": [
+        "<stdin>:6:15: the runtime or service used by \"actions/checkout@v3\" action is retired on GitHub.com. update the action's version to fix this issue [action]"
+      ],
+      "languageservices/workflow-parser/testdata/reader/events-single-with-types.yml": [
+        "<stdin>:8:15: the runtime or service used by \"actions/checkout@v3\" action is retired on GitHub.com. update the action's version to fix this issue [action]"
+      ],
+      "languageservices/workflow-parser/testdata/reader/events-single.yml": [
+        "<stdin>:6:15: the runtime or service used by \"actions/checkout@v3\" action is retired on GitHub.com. update the action's version to fix this issue [action]"
+      ],
+      "languageservices/workflow-parser/testdata/reader/float-folded-style.yml": [
+        "<stdin>:7:13: the runtime or service used by \"actions/setup-python@v4\" action is retired on GitHub.com. update the action's version to fix this issue [action]"
+      ],
+      "languageservices/workflow-parser/testdata/reader/misc-steps.yml": [
+        "<stdin>:7:15: the runtime or service used by \"actions/checkout@v3\" action is retired on GitHub.com. update the action's version to fix this issue [action]"
+      ],
+      "languageservices/workflow-parser/testdata/reader/mvp.yml": [
+        "<stdin>:26:15: the runtime or service used by \"actions/checkout@v3\" action is retired on GitHub.com. update the action's version to fix this issue [action]"
+      ],
+      "languageservices/workflow-parser/testdata/reader/permissions.yml": [
+        "<stdin>:20:15: the runtime or service used by \"actions/checkout@v3\" action is retired on GitHub.com. update the action's version to fix this issue [action]",
+        "<stdin>:40:15: the runtime or service used by \"actions/checkout@v3\" action is retired on GitHub.com. update the action's version to fix this issue [action]"
+      ],
+      "languageservices/workflow-parser/testdata/reader/root-env-defaults.yml": [
+        "<stdin>:12:15: the runtime or service used by \"actions/checkout@v3\" action is retired on GitHub.com. update the action's version to fix this issue [action]"
+      ],
+      "languageservices/workflow-parser/testdata/reader/step-id-generates-counter-per-collision.yml": [
+        "<stdin>:6:15: the runtime or service used by \"actions/checkout@v2\" action is retired on GitHub.com. update the action's version to fix this issue [action]",
+        "<stdin>:8:15: the runtime or service used by \"actions/setup-node@v2\" action is retired on GitHub.com. update the action's version to fix this issue [action]",
+        "<stdin>:11:15: the runtime or service used by \"actions/checkout@v2\" action is retired on GitHub.com. update the action's version to fix this issue [action]",
+        "<stdin>:13:15: the runtime or service used by \"actions/setup-node@v3\" action is retired on GitHub.com. update the action's version to fix this issue [action]"
+      ],
+      "languageservices/workflow-parser/testdata/reader/step-id-generates-when-empty-and-considers-collisions.yml": [
+        "<stdin>:6:15: the runtime or service used by \"actions/checkout@v2\" action is retired on GitHub.com. update the action's version to fix this issue [action]",
+        "<stdin>:7:15: the runtime or service used by \"actions/setup-node@v2\" action is retired on GitHub.com. update the action's version to fix this issue [action]",
+        "<stdin>:10:15: the runtime or service used by \"actions/checkout@v2\" action is retired on GitHub.com. update the action's version to fix this issue [action]",
+        "<stdin>:11:15: the runtime or service used by \"actions/setup-node@v3\" action is retired on GitHub.com. update the action's version to fix this issue [action]"
+      ],
+      "languageservices/workflow-parser/testdata/reader/step-id-generates-when-empty.yml": [
+        "<stdin>:6:15: the runtime or service used by \"actions/checkout@v2\" action is retired on GitHub.com. update the action's version to fix this issue [action]"
+      ],
+      "languageservices/workflow-parser/testdata/reader/step-id.yml": [
+        "<stdin>:6:15: the runtime or service used by \"actions/checkout@v1\" action is retired on GitHub.com. update the action's version to fix this issue [action]"
+      ],
+      "runner/src/Test/TestData/node16action.yml": [
+        ":1:1: runtime \"node16\" is no longer bundled with current GitHub Actions runners. update runs.using in local action \"Hello World\" to a current runtime [action]"
+      ],
+      "runner/src/Test/TestData/node20action.yml": [
+        ":1:1: runtime \"node20\" is deprecated in GitHub Actions; removal is scheduled for September 23rd, 2026. see https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/. update runs.using in local action \"Hello World\" to a current runtime [action]"
+      ],
+      "runner/src/Test/TestData/nodeaction.yml": [
+        ":1:1: runtime \"node12\" is no longer bundled with current GitHub Actions runners. update runs.using in local action \"Hello World\" to a current runtime [action]"
+      ],
+      "runner/src/Test/TestData/nodeaction_cleanup.yml": [
+        ":1:1: runtime \"node12\" is no longer bundled with current GitHub Actions runners. update runs.using in local action \"Hello World\" to a current runtime [action]"
+      ],
+      "runner/src/Test/TestData/nodeaction_cleanup_default.yml": [
+        ":1:1: runtime \"node12\" is no longer bundled with current GitHub Actions runners. update runs.using in local action \"Hello World\" to a current runtime [action]"
+      ],
+      "runner/src/Test/TestData/nodeaction_init.yml": [
+        ":1:1: runtime \"node12\" is no longer bundled with current GitHub Actions runners. update runs.using in local action \"Hello World\" to a current runtime [action]"
+      ],
+      "runner/src/Test/TestData/nodeaction_init_default.yml": [
+        ":1:1: runtime \"node12\" is no longer bundled with current GitHub Actions runners. update runs.using in local action \"Hello World\" to a current runtime [action]"
+      ],
+      "schemastore/src/test/github-workflow/1567.yaml": [
+        "<stdin>:17:15: the runtime or service used by \"actions/checkout@v2\" action is retired on GitHub.com. update the action's version to fix this issue [action]"
+      ],
+      "schemastore/src/test/github-workflow/919.yaml": [
+        "<stdin>:11:15: the runtime or service used by \"actions/checkout@v1\" action is retired on GitHub.com. update the action's version to fix this issue [action]",
+        "<stdin>:12:15: the runtime or service used by \"actions/setup-node@v1\" action is retired on GitHub.com. update the action's version to fix this issue [action]"
+      ],
+      "schemastore/src/test/github-workflow/env-from-json.yaml": [
+        "<stdin>:11:15: the runtime or service used by \"actions/checkout@v1\" action is retired on GitHub.com. update the action's version to fix this issue [action]",
+        "<stdin>:12:15: the runtime or service used by \"actions/setup-node@v1\" action is retired on GitHub.com. update the action's version to fix this issue [action]"
+      ],
+      "schemastore/src/test/github-workflow/issue_2463_file_1.yaml": [
+        "<stdin>:23:15: the runtime or service used by \"actions/cache@v3\" action is retired on GitHub.com. update the action's version to fix this issue [action]"
+      ],
+      "schemastore/src/test/github-workflow/npm-publish.yaml": [
+        "<stdin>:14:15: the runtime or service used by \"actions/checkout@v2\" action is retired on GitHub.com. update the action's version to fix this issue [action]",
+        "<stdin>:15:15: the runtime or service used by \"actions/setup-node@v2\" action is retired on GitHub.com. update the action's version to fix this issue [action]",
+        "<stdin>:24:15: the runtime or service used by \"actions/checkout@v2\" action is retired on GitHub.com. update the action's version to fix this issue [action]",
+        "<stdin>:25:15: the runtime or service used by \"actions/setup-node@v2\" action is retired on GitHub.com. update the action's version to fix this issue [action]",
+        "<stdin>:40:15: the runtime or service used by \"actions/checkout@v2\" action is retired on GitHub.com. update the action's version to fix this issue [action]",
+        "<stdin>:41:15: the runtime or service used by \"actions/setup-node@v2\" action is retired on GitHub.com. update the action's version to fix this issue [action]"
+      ],
+      "schemastore/src/test/github-workflow/parallel-steps.yaml": [
+        "<stdin>:21:15: runtime \"node20\" is deprecated in GitHub Actions; removal is scheduled for September 23rd, 2026. see https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/. update the version of action \"actions/checkout@v4\" [action]",
+        "<stdin>:78:15: runtime \"node20\" is deprecated in GitHub Actions; removal is scheduled for September 23rd, 2026. see https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/. update the version of action \"actions/checkout@v4\" [action]",
+        "<stdin>:93:19: runtime \"node20\" is deprecated in GitHub Actions; removal is scheduled for September 23rd, 2026. see https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/. update the version of action \"actions/setup-node@v4\" [action]",
+        "<stdin>:94:19: runtime \"node20\" is deprecated in GitHub Actions; removal is scheduled for September 23rd, 2026. see https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/. update the version of action \"actions/setup-python@v5\" [action]",
+        "<stdin>:100:15: runtime \"node20\" is deprecated in GitHub Actions; removal is scheduled for September 23rd, 2026. see https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/. update the version of action \"actions/checkout@v4\" [action]"
+      ],
+      "schemastore/src/test/github-workflow/reusable-workflow.yaml": [
+        "<stdin>:27:15: the runtime or service used by \"actions/checkout@v2\" action is retired on GitHub.com. update the action's version to fix this issue [action]"
+      ],
+      "schemastore/src/test/github-workflow/runs-on-interpolated.yaml": [
+        "<stdin>:13:15: the runtime or service used by \"actions/checkout@v2\" action is retired on GitHub.com. update the action's version to fix this issue [action]"
+      ],
+      "schemastore/src/test/github-workflow/workflow_dispatch-inputs.yaml": [
+        "<stdin>:48:15: the runtime or service used by \"actions/checkout@v2\" action is retired on GitHub.com. update the action's version to fix this issue [action]"
+      ]
+    }
+  },
+  {
+    "reason": "Extra lint checks: cmd is used on Linux and github.test is not a known context property.",
+    "cases": {
+      "languageservices/workflow-parser/testdata/reader/job-defaults.yml": [
+        "<stdin>:7:16: shell name \"cmd\" is invalid on macOS or Linux. available names are \"bash\", \"pwsh\", \"python\", \"sh\" [shell-name]",
+        "<stdin>:8:31: property \"test\" is not defined in object type {action: string; action_path: string; action_ref: string; action_repository: string; action_status: string; actor: string; actor_id: string; api_url: string; artifact_cache_size_limit: number; artifacts: string; artifacts_list: string; base_ref: string; env: string; event: object; event_name: string; event_path: string; graphql_url: string; head_ref: string; job: string; output: string; path: string; ref: string; ref_name: string; ref_protected: bool; ref_type: string; repository: string; repository_id: string; repository_owner: string; repository_owner_id: string; repository_visibility: string; repositoryurl: string; retention_days: string; run_attempt: string; run_id: string; run_number: string; secret_source: string; server_url: string; sha: string; state: string; step_summary: string; token: string; triggering_actor: string; workflow: string; workflow_ref: string; workflow_sha: string; workspace: string} [expression]"
+      ]
+    }
+  },
+  {
+    "reason": "Extra lint checks: constant conditions and a reference to an undeclared step are accepted by this reader fixture.",
+    "cases": {
+      "languageservices/workflow-parser/testdata/reader/step-if.yml": [
+        "<stdin>:12:13: constant expression \"123\" in condition. remove the if: section [if-cond]",
+        "<stdin>:14:13: constant expression \"0 || 1\" in condition. remove the if: section [if-cond]",
+        "<stdin>:18:13: constant expression \"0 || 1\" in condition. remove the if: section [if-cond]",
+        "<stdin>:28:13: constant expression \"true || 'success()'\" in condition. remove the if: section [if-cond]",
+        "<stdin>:37:18: property \"build\" is not defined in object type {} [expression]"
+      ]
+    }
+  },
+  {
+    "reason": "Extra lint checks: empty environment names and references to missing step outputs are accepted by this reader fixture.",
+    "cases": {
+      "languageservices/workflow-parser/testdata/reader/job-environment.yml": [
+        "<stdin>:9:18: string should not be empty [syntax-check]",
+        "<stdin>:21:22: property \"env\" is not defined in object type {} [expression]",
+        "<stdin>:27:17: property \"env\" is not defined in object type {} [expression]"
+      ]
+    }
+  },
+  {
+    "reason": "Extra lint checks: misleading and constant conditions, incompatible runner labels, and a placeholder runner label are accepted by this serialization fixture.",
+    "cases": {
+      "languageservices/workflow-parser/testdata/reader/escape-html-values.yml": [
+        "<stdin>:6:9: if: condition \"false || ${{ true && true }}\" is always evaluated to true because extra characters are around ${{ }} [if-cond]",
+        "<stdin>:7:28: label \"linux\" conflicts with label \"macos-latest\" defined at line:7,col:15. note: to run your job on each workers, use matrix [runner-label]",
+        "<stdin>:7:47: label \"<\" is unknown. available labels are \"windows-latest\", \"windows-latest-8-cores\", \"windows-2025\", \"windows-2025-vs2026\", \"windows-2022\", \"windows-11-arm\", \"windows-11-vs2026-arm\", \"ubuntu-slim\", \"ubuntu-latest\", \"ubuntu-latest-4-cores\", \"ubuntu-latest-8-cores\", \"ubuntu-latest-16-cores\", \"ubuntu-26.04\", \"ubuntu-26.04-arm\", \"ubuntu-24.04\", \"ubuntu-24.04-arm\", \"ubuntu-22.04\", \"ubuntu-22.04-arm\", \"xcode-27\", \"xcode-27-xlarge\", \"macos-latest\", \"macos-latest-xlarge\", \"macos-latest-large\", \"macos-26-intel\", \"macos-26-xlarge\", \"macos-26-large\", \"macos-26\", \"macos-15-intel\", \"macos-15-xlarge\", \"macos-15-large\", \"macos-15\", \"macos-14-xlarge\", \"macos-14-large\", \"macos-14\", \"self-hosted\", \"x64\", \"arm\", \"arm64\", \"linux\", \"macos\", \"windows\". if it is a custom label for self-hosted runner, set list of labels in actionlint.yaml config file [runner-label]",
+        "<stdin>:11:9: constant expression \"false\" in condition. remove the if: section [if-cond]"
+      ]
+    }
+  },
+  {
+    "reason": "Extra lint checks: the fixture uses arbitrary runner labels without configuring them as self-hosted labels.",
+    "cases": {
+      "languageservices/workflow-parser/testdata/reader/job-runs-on.yml": [
+        "<stdin>:9:9: label \"label 1\" is unknown. available labels are \"windows-latest\", \"windows-latest-8-cores\", \"windows-2025\", \"windows-2025-vs2026\", \"windows-2022\", \"windows-11-arm\", \"windows-11-vs2026-arm\", \"ubuntu-slim\", \"ubuntu-latest\", \"ubuntu-latest-4-cores\", \"ubuntu-latest-8-cores\", \"ubuntu-latest-16-cores\", \"ubuntu-26.04\", \"ubuntu-26.04-arm\", \"ubuntu-24.04\", \"ubuntu-24.04-arm\", \"ubuntu-22.04\", \"ubuntu-22.04-arm\", \"xcode-27\", \"xcode-27-xlarge\", \"macos-latest\", \"macos-latest-xlarge\", \"macos-latest-large\", \"macos-26-intel\", \"macos-26-xlarge\", \"macos-26-large\", \"macos-26\", \"macos-15-intel\", \"macos-15-xlarge\", \"macos-15-large\", \"macos-15\", \"macos-14-xlarge\", \"macos-14-large\", \"macos-14\", \"self-hosted\", \"x64\", \"arm\", \"arm64\", \"linux\", \"macos\", \"windows\". if it is a custom label for self-hosted runner, set list of labels in actionlint.yaml config file [runner-label]",
+        "<stdin>:10:9: label \"label 2\" is unknown. available labels are \"windows-latest\", \"windows-latest-8-cores\", \"windows-2025\", \"windows-2025-vs2026\", \"windows-2022\", \"windows-11-arm\", \"windows-11-vs2026-arm\", \"ubuntu-slim\", \"ubuntu-latest\", \"ubuntu-latest-4-cores\", \"ubuntu-latest-8-cores\", \"ubuntu-latest-16-cores\", \"ubuntu-26.04\", \"ubuntu-26.04-arm\", \"ubuntu-24.04\", \"ubuntu-24.04-arm\", \"ubuntu-22.04\", \"ubuntu-22.04-arm\", \"xcode-27\", \"xcode-27-xlarge\", \"macos-latest\", \"macos-latest-xlarge\", \"macos-latest-large\", \"macos-26-intel\", \"macos-26-xlarge\", \"macos-26-large\", \"macos-26\", \"macos-15-intel\", \"macos-15-xlarge\", \"macos-15-large\", \"macos-15\", \"macos-14-xlarge\", \"macos-14-large\", \"macos-14\", \"self-hosted\", \"x64\", \"arm\", \"arm64\", \"linux\", \"macos\", \"windows\". if it is a custom label for self-hosted runner, set list of labels in actionlint.yaml config file [runner-label]",
+        "<stdin>:17:11: label \"label 1\" is unknown. available labels are \"windows-latest\", \"windows-latest-8-cores\", \"windows-2025\", \"windows-2025-vs2026\", \"windows-2022\", \"windows-11-arm\", \"windows-11-vs2026-arm\", \"ubuntu-slim\", \"ubuntu-latest\", \"ubuntu-latest-4-cores\", \"ubuntu-latest-8-cores\", \"ubuntu-latest-16-cores\", \"ubuntu-26.04\", \"ubuntu-26.04-arm\", \"ubuntu-24.04\", \"ubuntu-24.04-arm\", \"ubuntu-22.04\", \"ubuntu-22.04-arm\", \"xcode-27\", \"xcode-27-xlarge\", \"macos-latest\", \"macos-latest-xlarge\", \"macos-latest-large\", \"macos-26-intel\", \"macos-26-xlarge\", \"macos-26-large\", \"macos-26\", \"macos-15-intel\", \"macos-15-xlarge\", \"macos-15-large\", \"macos-15\", \"macos-14-xlarge\", \"macos-14-large\", \"macos-14\", \"self-hosted\", \"x64\", \"arm\", \"arm64\", \"linux\", \"macos\", \"windows\". if it is a custom label for self-hosted runner, set list of labels in actionlint.yaml config file [runner-label]",
+        "<stdin>:18:11: label \"label 2\" is unknown. available labels are \"windows-latest\", \"windows-latest-8-cores\", \"windows-2025\", \"windows-2025-vs2026\", \"windows-2022\", \"windows-11-arm\", \"windows-11-vs2026-arm\", \"ubuntu-slim\", \"ubuntu-latest\", \"ubuntu-latest-4-cores\", \"ubuntu-latest-8-cores\", \"ubuntu-latest-16-cores\", \"ubuntu-26.04\", \"ubuntu-26.04-arm\", \"ubuntu-24.04\", \"ubuntu-24.04-arm\", \"ubuntu-22.04\", \"ubuntu-22.04-arm\", \"xcode-27\", \"xcode-27-xlarge\", \"macos-latest\", \"macos-latest-xlarge\", \"macos-latest-large\", \"macos-26-intel\", \"macos-26-xlarge\", \"macos-26-large\", \"macos-26\", \"macos-15-intel\", \"macos-15-xlarge\", \"macos-15-large\", \"macos-15\", \"macos-14-xlarge\", \"macos-14-large\", \"macos-14\", \"self-hosted\", \"x64\", \"arm\", \"arm64\", \"linux\", \"macos\", \"windows\". if it is a custom label for self-hosted runner, set list of labels in actionlint.yaml config file [runner-label]",
+        "<stdin>:25:11: label \"label 1\" is unknown. available labels are \"windows-latest\", \"windows-latest-8-cores\", \"windows-2025\", \"windows-2025-vs2026\", \"windows-2022\", \"windows-11-arm\", \"windows-11-vs2026-arm\", \"ubuntu-slim\", \"ubuntu-latest\", \"ubuntu-latest-4-cores\", \"ubuntu-latest-8-cores\", \"ubuntu-latest-16-cores\", \"ubuntu-26.04\", \"ubuntu-26.04-arm\", \"ubuntu-24.04\", \"ubuntu-24.04-arm\", \"ubuntu-22.04\", \"ubuntu-22.04-arm\", \"xcode-27\", \"xcode-27-xlarge\", \"macos-latest\", \"macos-latest-xlarge\", \"macos-latest-large\", \"macos-26-intel\", \"macos-26-xlarge\", \"macos-26-large\", \"macos-26\", \"macos-15-intel\", \"macos-15-xlarge\", \"macos-15-large\", \"macos-15\", \"macos-14-xlarge\", \"macos-14-large\", \"macos-14\", \"self-hosted\", \"x64\", \"arm\", \"arm64\", \"linux\", \"macos\", \"windows\". if it is a custom label for self-hosted runner, set list of labels in actionlint.yaml config file [runner-label]",
+        "<stdin>:26:11: label \"label 2\" is unknown. available labels are \"windows-latest\", \"windows-latest-8-cores\", \"windows-2025\", \"windows-2025-vs2026\", \"windows-2022\", \"windows-11-arm\", \"windows-11-vs2026-arm\", \"ubuntu-slim\", \"ubuntu-latest\", \"ubuntu-latest-4-cores\", \"ubuntu-latest-8-cores\", \"ubuntu-latest-16-cores\", \"ubuntu-26.04\", \"ubuntu-26.04-arm\", \"ubuntu-24.04\", \"ubuntu-24.04-arm\", \"ubuntu-22.04\", \"ubuntu-22.04-arm\", \"xcode-27\", \"xcode-27-xlarge\", \"macos-latest\", \"macos-latest-xlarge\", \"macos-latest-large\", \"macos-26-intel\", \"macos-26-xlarge\", \"macos-26-large\", \"macos-26\", \"macos-15-intel\", \"macos-15-xlarge\", \"macos-15-large\", \"macos-15\", \"macos-14-xlarge\", \"macos-14-large\", \"macos-14\", \"self-hosted\", \"x64\", \"arm\", \"arm64\", \"linux\", \"macos\", \"windows\". if it is a custom label for self-hosted runner, set list of labels in actionlint.yaml config file [runner-label]",
+        "<stdin>:33:11: label \"label 1\" is unknown. available labels are \"windows-latest\", \"windows-latest-8-cores\", \"windows-2025\", \"windows-2025-vs2026\", \"windows-2022\", \"windows-11-arm\", \"windows-11-vs2026-arm\", \"ubuntu-slim\", \"ubuntu-latest\", \"ubuntu-latest-4-cores\", \"ubuntu-latest-8-cores\", \"ubuntu-latest-16-cores\", \"ubuntu-26.04\", \"ubuntu-26.04-arm\", \"ubuntu-24.04\", \"ubuntu-24.04-arm\", \"ubuntu-22.04\", \"ubuntu-22.04-arm\", \"xcode-27\", \"xcode-27-xlarge\", \"macos-latest\", \"macos-latest-xlarge\", \"macos-latest-large\", \"macos-26-intel\", \"macos-26-xlarge\", \"macos-26-large\", \"macos-26\", \"macos-15-intel\", \"macos-15-xlarge\", \"macos-15-large\", \"macos-15\", \"macos-14-xlarge\", \"macos-14-large\", \"macos-14\", \"self-hosted\", \"x64\", \"arm\", \"arm64\", \"linux\", \"macos\", \"windows\". if it is a custom label for self-hosted runner, set list of labels in actionlint.yaml config file [runner-label]",
+        "<stdin>:34:11: label \"label 2\" is unknown. available labels are \"windows-latest\", \"windows-latest-8-cores\", \"windows-2025\", \"windows-2025-vs2026\", \"windows-2022\", \"windows-11-arm\", \"windows-11-vs2026-arm\", \"ubuntu-slim\", \"ubuntu-latest\", \"ubuntu-latest-4-cores\", \"ubuntu-latest-8-cores\", \"ubuntu-latest-16-cores\", \"ubuntu-26.04\", \"ubuntu-26.04-arm\", \"ubuntu-24.04\", \"ubuntu-24.04-arm\", \"ubuntu-22.04\", \"ubuntu-22.04-arm\", \"xcode-27\", \"xcode-27-xlarge\", \"macos-latest\", \"macos-latest-xlarge\", \"macos-latest-large\", \"macos-26-intel\", \"macos-26-xlarge\", \"macos-26-large\", \"macos-26\", \"macos-15-intel\", \"macos-15-xlarge\", \"macos-15-large\", \"macos-15\", \"macos-14-xlarge\", \"macos-14-large\", \"macos-14\", \"self-hosted\", \"x64\", \"arm\", \"arm64\", \"linux\", \"macos\", \"windows\". if it is a custom label for self-hosted runner, set list of labels in actionlint.yaml config file [runner-label]",
+        "<stdin>:41:11: label \"label 1\" is unknown. available labels are \"windows-latest\", \"windows-latest-8-cores\", \"windows-2025\", \"windows-2025-vs2026\", \"windows-2022\", \"windows-11-arm\", \"windows-11-vs2026-arm\", \"ubuntu-slim\", \"ubuntu-latest\", \"ubuntu-latest-4-cores\", \"ubuntu-latest-8-cores\", \"ubuntu-latest-16-cores\", \"ubuntu-26.04\", \"ubuntu-26.04-arm\", \"ubuntu-24.04\", \"ubuntu-24.04-arm\", \"ubuntu-22.04\", \"ubuntu-22.04-arm\", \"xcode-27\", \"xcode-27-xlarge\", \"macos-latest\", \"macos-latest-xlarge\", \"macos-latest-large\", \"macos-26-intel\", \"macos-26-xlarge\", \"macos-26-large\", \"macos-26\", \"macos-15-intel\", \"macos-15-xlarge\", \"macos-15-large\", \"macos-15\", \"macos-14-xlarge\", \"macos-14-large\", \"macos-14\", \"self-hosted\", \"x64\", \"arm\", \"arm64\", \"linux\", \"macos\", \"windows\". if it is a custom label for self-hosted runner, set list of labels in actionlint.yaml config file [runner-label]",
+        "<stdin>:42:11: label \"label 2\" is unknown. available labels are \"windows-latest\", \"windows-latest-8-cores\", \"windows-2025\", \"windows-2025-vs2026\", \"windows-2022\", \"windows-11-arm\", \"windows-11-vs2026-arm\", \"ubuntu-slim\", \"ubuntu-latest\", \"ubuntu-latest-4-cores\", \"ubuntu-latest-8-cores\", \"ubuntu-latest-16-cores\", \"ubuntu-26.04\", \"ubuntu-26.04-arm\", \"ubuntu-24.04\", \"ubuntu-24.04-arm\", \"ubuntu-22.04\", \"ubuntu-22.04-arm\", \"xcode-27\", \"xcode-27-xlarge\", \"macos-latest\", \"macos-latest-xlarge\", \"macos-latest-large\", \"macos-26-intel\", \"macos-26-xlarge\", \"macos-26-large\", \"macos-26\", \"macos-15-intel\", \"macos-15-xlarge\", \"macos-15-large\", \"macos-15\", \"macos-14-xlarge\", \"macos-14-large\", \"macos-14\", \"self-hosted\", \"x64\", \"arm\", \"arm64\", \"linux\", \"macos\", \"windows\". if it is a custom label for self-hosted runner, set list of labels in actionlint.yaml config file [runner-label]",
+        "<stdin>:49:11: label \"label 1\" is unknown. available labels are \"windows-latest\", \"windows-latest-8-cores\", \"windows-2025\", \"windows-2025-vs2026\", \"windows-2022\", \"windows-11-arm\", \"windows-11-vs2026-arm\", \"ubuntu-slim\", \"ubuntu-latest\", \"ubuntu-latest-4-cores\", \"ubuntu-latest-8-cores\", \"ubuntu-latest-16-cores\", \"ubuntu-26.04\", \"ubuntu-26.04-arm\", \"ubuntu-24.04\", \"ubuntu-24.04-arm\", \"ubuntu-22.04\", \"ubuntu-22.04-arm\", \"xcode-27\", \"xcode-27-xlarge\", \"macos-latest\", \"macos-latest-xlarge\", \"macos-latest-large\", \"macos-26-intel\", \"macos-26-xlarge\", \"macos-26-large\", \"macos-26\", \"macos-15-intel\", \"macos-15-xlarge\", \"macos-15-large\", \"macos-15\", \"macos-14-xlarge\", \"macos-14-large\", \"macos-14\", \"self-hosted\", \"x64\", \"arm\", \"arm64\", \"linux\", \"macos\", \"windows\". if it is a custom label for self-hosted runner, set list of labels in actionlint.yaml config file [runner-label]",
+        "<stdin>:50:11: label \"label 2\" is unknown. available labels are \"windows-latest\", \"windows-latest-8-cores\", \"windows-2025\", \"windows-2025-vs2026\", \"windows-2022\", \"windows-11-arm\", \"windows-11-vs2026-arm\", \"ubuntu-slim\", \"ubuntu-latest\", \"ubuntu-latest-4-cores\", \"ubuntu-latest-8-cores\", \"ubuntu-latest-16-cores\", \"ubuntu-26.04\", \"ubuntu-26.04-arm\", \"ubuntu-24.04\", \"ubuntu-24.04-arm\", \"ubuntu-22.04\", \"ubuntu-22.04-arm\", \"xcode-27\", \"xcode-27-xlarge\", \"macos-latest\", \"macos-latest-xlarge\", \"macos-latest-large\", \"macos-26-intel\", \"macos-26-xlarge\", \"macos-26-large\", \"macos-26\", \"macos-15-intel\", \"macos-15-xlarge\", \"macos-15-large\", \"macos-15\", \"macos-14-xlarge\", \"macos-14-large\", \"macos-14\", \"self-hosted\", \"x64\", \"arm\", \"arm64\", \"linux\", \"macos\", \"windows\". if it is a custom label for self-hosted runner, set list of labels in actionlint.yaml config file [runner-label]",
+        "<stdin>:54:16: label \"inf\" is unknown. available labels are \"windows-latest\", \"windows-latest-8-cores\", \"windows-2025\", \"windows-2025-vs2026\", \"windows-2022\", \"windows-11-arm\", \"windows-11-vs2026-arm\", \"ubuntu-slim\", \"ubuntu-latest\", \"ubuntu-latest-4-cores\", \"ubuntu-latest-8-cores\", \"ubuntu-latest-16-cores\", \"ubuntu-26.04\", \"ubuntu-26.04-arm\", \"ubuntu-24.04\", \"ubuntu-24.04-arm\", \"ubuntu-22.04\", \"ubuntu-22.04-arm\", \"xcode-27\", \"xcode-27-xlarge\", \"macos-latest\", \"macos-latest-xlarge\", \"macos-latest-large\", \"macos-26-intel\", \"macos-26-xlarge\", \"macos-26-large\", \"macos-26\", \"macos-15-intel\", \"macos-15-xlarge\", \"macos-15-large\", \"macos-15\", \"macos-14-xlarge\", \"macos-14-large\", \"macos-14\", \"self-hosted\", \"x64\", \"arm\", \"arm64\", \"linux\", \"macos\", \"windows\". if it is a custom label for self-hosted runner, set list of labels in actionlint.yaml config file [runner-label]",
+        "<stdin>:54:21: label \"-inf\" is unknown. available labels are \"windows-latest\", \"windows-latest-8-cores\", \"windows-2025\", \"windows-2025-vs2026\", \"windows-2022\", \"windows-11-arm\", \"windows-11-vs2026-arm\", \"ubuntu-slim\", \"ubuntu-latest\", \"ubuntu-latest-4-cores\", \"ubuntu-latest-8-cores\", \"ubuntu-latest-16-cores\", \"ubuntu-26.04\", \"ubuntu-26.04-arm\", \"ubuntu-24.04\", \"ubuntu-24.04-arm\", \"ubuntu-22.04\", \"ubuntu-22.04-arm\", \"xcode-27\", \"xcode-27-xlarge\", \"macos-latest\", \"macos-latest-xlarge\", \"macos-latest-large\", \"macos-26-intel\", \"macos-26-xlarge\", \"macos-26-large\", \"macos-26\", \"macos-15-intel\", \"macos-15-xlarge\", \"macos-15-large\", \"macos-15\", \"macos-14-xlarge\", \"macos-14-large\", \"macos-14\", \"self-hosted\", \"x64\", \"arm\", \"arm64\", \"linux\", \"macos\", \"windows\". if it is a custom label for self-hosted runner, set list of labels in actionlint.yaml config file [runner-label]",
+        "<stdin>:54:27: label \"+inf\" is unknown. available labels are \"windows-latest\", \"windows-latest-8-cores\", \"windows-2025\", \"windows-2025-vs2026\", \"windows-2022\", \"windows-11-arm\", \"windows-11-vs2026-arm\", \"ubuntu-slim\", \"ubuntu-latest\", \"ubuntu-latest-4-cores\", \"ubuntu-latest-8-cores\", \"ubuntu-latest-16-cores\", \"ubuntu-26.04\", \"ubuntu-26.04-arm\", \"ubuntu-24.04\", \"ubuntu-24.04-arm\", \"ubuntu-22.04\", \"ubuntu-22.04-arm\", \"xcode-27\", \"xcode-27-xlarge\", \"macos-latest\", \"macos-latest-xlarge\", \"macos-latest-large\", \"macos-26-intel\", \"macos-26-xlarge\", \"macos-26-large\", \"macos-26\", \"macos-15-intel\", \"macos-15-xlarge\", \"macos-15-large\", \"macos-15\", \"macos-14-xlarge\", \"macos-14-large\", \"macos-14\", \"self-hosted\", \"x64\", \"arm\", \"arm64\", \"linux\", \"macos\", \"windows\". if it is a custom label for self-hosted runner, set list of labels in actionlint.yaml config file [runner-label]",
+        "<stdin>:54:33: label \"infinity\" is unknown. available labels are \"windows-latest\", \"windows-latest-8-cores\", \"windows-2025\", \"windows-2025-vs2026\", \"windows-2022\", \"windows-11-arm\", \"windows-11-vs2026-arm\", \"ubuntu-slim\", \"ubuntu-latest\", \"ubuntu-latest-4-cores\", \"ubuntu-latest-8-cores\", \"ubuntu-latest-16-cores\", \"ubuntu-26.04\", \"ubuntu-26.04-arm\", \"ubuntu-24.04\", \"ubuntu-24.04-arm\", \"ubuntu-22.04\", \"ubuntu-22.04-arm\", \"xcode-27\", \"xcode-27-xlarge\", \"macos-latest\", \"macos-latest-xlarge\", \"macos-latest-large\", \"macos-26-intel\", \"macos-26-xlarge\", \"macos-26-large\", \"macos-26\", \"macos-15-intel\", \"macos-15-xlarge\", \"macos-15-large\", \"macos-15\", \"macos-14-xlarge\", \"macos-14-large\", \"macos-14\", \"self-hosted\", \"x64\", \"arm\", \"arm64\", \"linux\", \"macos\", \"windows\". if it is a custom label for self-hosted runner, set list of labels in actionlint.yaml config file [runner-label]",
+        "<stdin>:54:43: label \"NaN\" is unknown. available labels are \"windows-latest\", \"windows-latest-8-cores\", \"windows-2025\", \"windows-2025-vs2026\", \"windows-2022\", \"windows-11-arm\", \"windows-11-vs2026-arm\", \"ubuntu-slim\", \"ubuntu-latest\", \"ubuntu-latest-4-cores\", \"ubuntu-latest-8-cores\", \"ubuntu-latest-16-cores\", \"ubuntu-26.04\", \"ubuntu-26.04-arm\", \"ubuntu-24.04\", \"ubuntu-24.04-arm\", \"ubuntu-22.04\", \"ubuntu-22.04-arm\", \"xcode-27\", \"xcode-27-xlarge\", \"macos-latest\", \"macos-latest-xlarge\", \"macos-latest-large\", \"macos-26-intel\", \"macos-26-xlarge\", \"macos-26-large\", \"macos-26\", \"macos-15-intel\", \"macos-15-xlarge\", \"macos-15-large\", \"macos-15\", \"macos-14-xlarge\", \"macos-14-large\", \"macos-14\", \"self-hosted\", \"x64\", \"arm\", \"arm64\", \"linux\", \"macos\", \"windows\". if it is a custom label for self-hosted runner, set list of labels in actionlint.yaml config file [runner-label]",
+        "<stdin>:54:48: label \"nan\" is unknown. available labels are \"windows-latest\", \"windows-latest-8-cores\", \"windows-2025\", \"windows-2025-vs2026\", \"windows-2022\", \"windows-11-arm\", \"windows-11-vs2026-arm\", \"ubuntu-slim\", \"ubuntu-latest\", \"ubuntu-latest-4-cores\", \"ubuntu-latest-8-cores\", \"ubuntu-latest-16-cores\", \"ubuntu-26.04\", \"ubuntu-26.04-arm\", \"ubuntu-24.04\", \"ubuntu-24.04-arm\", \"ubuntu-22.04\", \"ubuntu-22.04-arm\", \"xcode-27\", \"xcode-27-xlarge\", \"macos-latest\", \"macos-latest-xlarge\", \"macos-latest-large\", \"macos-26-intel\", \"macos-26-xlarge\", \"macos-26-large\", \"macos-26\", \"macos-15-intel\", \"macos-15-xlarge\", \"macos-15-large\", \"macos-15\", \"macos-14-xlarge\", \"macos-14-large\", \"macos-14\", \"self-hosted\", \"x64\", \"arm\", \"arm64\", \"linux\", \"macos\", \"windows\". if it is a custom label for self-hosted runner, set list of labels in actionlint.yaml config file [runner-label]",
+        "<stdin>:54:53: label \"-infinity\" is unknown. available labels are \"windows-latest\", \"windows-latest-8-cores\", \"windows-2025\", \"windows-2025-vs2026\", \"windows-2022\", \"windows-11-arm\", \"windows-11-vs2026-arm\", \"ubuntu-slim\", \"ubuntu-latest\", \"ubuntu-latest-4-cores\", \"ubuntu-latest-8-cores\", \"ubuntu-latest-16-cores\", \"ubuntu-26.04\", \"ubuntu-26.04-arm\", \"ubuntu-24.04\", \"ubuntu-24.04-arm\", \"ubuntu-22.04\", \"ubuntu-22.04-arm\", \"xcode-27\", \"xcode-27-xlarge\", \"macos-latest\", \"macos-latest-xlarge\", \"macos-latest-large\", \"macos-26-intel\", \"macos-26-xlarge\", \"macos-26-large\", \"macos-26\", \"macos-15-intel\", \"macos-15-xlarge\", \"macos-15-large\", \"macos-15\", \"macos-14-xlarge\", \"macos-14-large\", \"macos-14\", \"self-hosted\", \"x64\", \"arm\", \"arm64\", \"linux\", \"macos\", \"windows\". if it is a custom label for self-hosted runner, set list of labels in actionlint.yaml config file [runner-label]"
+      ]
+    }
+  },
+  {
+    "reason": "Extra lint checks: the reader accepts incomplete jobs and string coercion in cancel-in-progress; actionlint requires steps and a boolean expression. A retired action is also reported.",
+    "cases": {
+      "languageservices/workflow-parser/testdata/reader/concurrency.yml": [
+        "<stdin>:9:15: the runtime or service used by \"actions/checkout@v3\" action is retired on GitHub.com. update the action's version to fix this issue [action]",
+        "<stdin>:15:3: \"steps\" section is missing in job \"build2\" [syntax-check]",
+        "<stdin>:18:3: \"steps\" section is missing in job \"build3\" [syntax-check]",
+        "<stdin>:21:3: \"steps\" section is missing in job \"build4\" [syntax-check]",
+        "<stdin>:25:27: type of expression must be bool but found type string [expression]",
+        "<stdin>:26:3: \"steps\" section is missing in job \"build5\" [syntax-check]"
+      ]
+    }
+  },
+  {
+    "reason": "Extra matrix check: the YAML scalar reader fixtures deliberately contain equivalent values; actionlint reports duplicate matrix entries after resolving their YAML types.",
+    "cases": {
+      "languageservices/workflow-parser/testdata/reader/yaml-schema-bool.yml": [
+        "<stdin>:11:13: duplicate value True is found in matrix \"vector-1\". the same value is at line:10,col:13 [matrix]",
+        "<stdin>:12:13: duplicate value TRUE is found in matrix \"vector-1\". the same value is at line:10,col:13 [matrix]",
+        "<stdin>:14:13: duplicate value False is found in matrix \"vector-1\". the same value is at line:13,col:13 [matrix]",
+        "<stdin>:15:13: duplicate value FALSE is found in matrix \"vector-1\". the same value is at line:13,col:13 [matrix]",
+        "<stdin>:18:13: duplicate value true is found in matrix \"vector-1\". the same value is at line:10,col:13 [matrix]",
+        "<stdin>:19:13: duplicate value FALSE is found in matrix \"vector-1\". the same value is at line:13,col:13 [matrix]",
+        "<stdin>:20:13: duplicate value true is found in matrix \"vector-1\". the same value is at line:10,col:13 [matrix]",
+        "<stdin>:21:13: duplicate value FALSE is found in matrix \"vector-1\". the same value is at line:13,col:13 [matrix]"
+      ],
+      "languageservices/workflow-parser/testdata/reader/yaml-schema-float.yml": [
+        "<stdin>:11:13: duplicate value 0.5 is found in matrix \"vector-1\". the same value is at line:10,col:13 [matrix]",
+        "<stdin>:13:13: duplicate value +.5 is found in matrix \"vector-1\". the same value is at line:10,col:13 [matrix]",
+        "<stdin>:14:13: duplicate value -0.5 is found in matrix \"vector-1\". the same value is at line:12,col:13 [matrix]",
+        "<stdin>:15:13: duplicate value +0.5 is found in matrix \"vector-1\". the same value is at line:10,col:13 [matrix]",
+        "<stdin>:19:13: duplicate value -0.0 is found in matrix \"vector-1\". the same value is at line:18,col:13 [matrix]",
+        "<stdin>:20:13: duplicate value +0.0 is found in matrix \"vector-1\". the same value is at line:18,col:13 [matrix]",
+        "<stdin>:22:13: duplicate value +123456.789 is found in matrix \"vector-1\". the same value is at line:21,col:13 [matrix]",
+        "<stdin>:26:13: duplicate value 1.2E2 is found in matrix \"vector-1\". the same value is at line:25,col:13 [matrix]",
+        "<stdin>:27:13: duplicate value 1.2e+2 is found in matrix \"vector-1\". the same value is at line:25,col:13 [matrix]",
+        "<stdin>:28:13: duplicate value 1.2E+2 is found in matrix \"vector-1\". the same value is at line:25,col:13 [matrix]",
+        "<stdin>:30:13: duplicate value 1.2E-2 is found in matrix \"vector-1\". the same value is at line:29,col:13 [matrix]",
+        "<stdin>:31:13: duplicate value +1.2e2 is found in matrix \"vector-1\". the same value is at line:25,col:13 [matrix]",
+        "<stdin>:32:13: duplicate value +1.2E2 is found in matrix \"vector-1\". the same value is at line:25,col:13 [matrix]",
+        "<stdin>:33:13: duplicate value +1.2e+2 is found in matrix \"vector-1\". the same value is at line:25,col:13 [matrix]",
+        "<stdin>:34:13: duplicate value +1.2E+2 is found in matrix \"vector-1\". the same value is at line:25,col:13 [matrix]",
+        "<stdin>:35:13: duplicate value +1.2e-2 is found in matrix \"vector-1\". the same value is at line:29,col:13 [matrix]",
+        "<stdin>:36:13: duplicate value +1.2E-2 is found in matrix \"vector-1\". the same value is at line:29,col:13 [matrix]",
+        "<stdin>:38:13: duplicate value -1.2E2 is found in matrix \"vector-1\". the same value is at line:37,col:13 [matrix]",
+        "<stdin>:39:13: duplicate value -1.2e+2 is found in matrix \"vector-1\". the same value is at line:37,col:13 [matrix]",
+        "<stdin>:40:13: duplicate value -1.2E+2 is found in matrix \"vector-1\". the same value is at line:37,col:13 [matrix]",
+        "<stdin>:42:13: duplicate value -1.2E-2 is found in matrix \"vector-1\". the same value is at line:41,col:13 [matrix]",
+        "<stdin>:44:13: duplicate value .Inf is found in matrix \"vector-1\". the same value is at line:43,col:13 [matrix]",
+        "<stdin>:45:13: duplicate value .INF is found in matrix \"vector-1\". the same value is at line:43,col:13 [matrix]",
+        "<stdin>:46:13: duplicate value +.inf is found in matrix \"vector-1\". the same value is at line:43,col:13 [matrix]",
+        "<stdin>:47:13: duplicate value +.Inf is found in matrix \"vector-1\". the same value is at line:43,col:13 [matrix]",
+        "<stdin>:48:13: duplicate value +.INF is found in matrix \"vector-1\". the same value is at line:43,col:13 [matrix]",
+        "<stdin>:50:13: duplicate value -.Inf is found in matrix \"vector-1\". the same value is at line:49,col:13 [matrix]",
+        "<stdin>:51:13: duplicate value -.INF is found in matrix \"vector-1\". the same value is at line:49,col:13 [matrix]",
+        "<stdin>:53:13: duplicate value .NaN is found in matrix \"vector-1\". the same value is at line:52,col:13 [matrix]",
+        "<stdin>:54:13: duplicate value .NAN is found in matrix \"vector-1\". the same value is at line:52,col:13 [matrix]",
+        "<stdin>:58:13: duplicate value 2 is found in matrix \"vector-1\". the same value is at line:17,col:13 [matrix]",
+        "<stdin>:60:13: duplicate value +1 is found in matrix \"vector-1\". the same value is at line:57,col:13 [matrix]",
+        "<stdin>:61:13: duplicate value 0 is found in matrix \"vector-1\". the same value is at line:18,col:13 [matrix]",
+        "<stdin>:62:13: duplicate value -0 is found in matrix \"vector-1\". the same value is at line:18,col:13 [matrix]",
+        "<stdin>:63:13: duplicate value +0 is found in matrix \"vector-1\". the same value is at line:18,col:13 [matrix]",
+        "<stdin>:64:13: duplicate value .Inf is found in matrix \"vector-1\". the same value is at line:43,col:13 [matrix]",
+        "<stdin>:65:13: duplicate value .NaN is found in matrix \"vector-1\". the same value is at line:52,col:13 [matrix]",
+        "<stdin>:66:13: duplicate value 1 is found in matrix \"vector-1\". the same value is at line:57,col:13 [matrix]",
+        "<stdin>:67:13: duplicate value 2 is found in matrix \"vector-1\". the same value is at line:17,col:13 [matrix]",
+        "<stdin>:68:13: duplicate value -1 is found in matrix \"vector-1\". the same value is at line:59,col:13 [matrix]",
+        "<stdin>:69:13: duplicate value +1 is found in matrix \"vector-1\". the same value is at line:57,col:13 [matrix]",
+        "<stdin>:70:13: duplicate value 0 is found in matrix \"vector-1\". the same value is at line:18,col:13 [matrix]",
+        "<stdin>:71:13: duplicate value -0 is found in matrix \"vector-1\". the same value is at line:18,col:13 [matrix]",
+        "<stdin>:72:13: duplicate value +0 is found in matrix \"vector-1\". the same value is at line:18,col:13 [matrix]",
+        "<stdin>:73:13: duplicate value .Inf is found in matrix \"vector-1\". the same value is at line:43,col:13 [matrix]",
+        "<stdin>:74:13: duplicate value .NaN is found in matrix \"vector-1\". the same value is at line:52,col:13 [matrix]"
+      ],
+      "languageservices/workflow-parser/testdata/reader/yaml-schema-int.yml": [
+        "<stdin>:13:13: duplicate value +1 is found in matrix \"vector-1\". the same value is at line:10,col:13 [matrix]",
+        "<stdin>:15:13: duplicate value -0 is found in matrix \"vector-1\". the same value is at line:14,col:13 [matrix]",
+        "<stdin>:16:13: duplicate value +0 is found in matrix \"vector-1\". the same value is at line:14,col:13 [matrix]",
+        "<stdin>:17:13: duplicate value 0000 is found in matrix \"vector-1\". the same value is at line:14,col:13 [matrix]",
+        "<stdin>:18:13: duplicate value -0000 is found in matrix \"vector-1\". the same value is at line:14,col:13 [matrix]",
+        "<stdin>:20:13: duplicate value 0xFF is found in matrix \"vector-1\". the same value is at line:19,col:13 [matrix]",
+        "<stdin>:23:13: duplicate value 00755 is found in matrix \"vector-1\". the same value is at line:22,col:13 [matrix]",
+        "<stdin>:24:13: duplicate value +00755 is found in matrix \"vector-1\". the same value is at line:22,col:13 [matrix]",
+        "<stdin>:28:13: duplicate value 1 is found in matrix \"vector-1\". the same value is at line:10,col:13 [matrix]",
+        "<stdin>:29:13: duplicate value -1 is found in matrix \"vector-1\". the same value is at line:12,col:13 [matrix]",
+        "<stdin>:30:13: duplicate value +1 is found in matrix \"vector-1\". the same value is at line:10,col:13 [matrix]",
+        "<stdin>:31:13: duplicate value 0xff is found in matrix \"vector-1\". the same value is at line:19,col:13 [matrix]",
+        "<stdin>:32:13: duplicate value 0o10 is found in matrix \"vector-1\". the same value is at line:21,col:13 [matrix]",
+        "<stdin>:33:13: duplicate value 1 is found in matrix \"vector-1\". the same value is at line:10,col:13 [matrix]",
+        "<stdin>:34:13: duplicate value -1 is found in matrix \"vector-1\". the same value is at line:12,col:13 [matrix]",
+        "<stdin>:35:13: duplicate value +1 is found in matrix \"vector-1\". the same value is at line:10,col:13 [matrix]",
+        "<stdin>:36:13: duplicate value 0xff is found in matrix \"vector-1\". the same value is at line:19,col:13 [matrix]",
+        "<stdin>:37:13: duplicate value 0o10 is found in matrix \"vector-1\". the same value is at line:21,col:13 [matrix]"
+      ],
+      "languageservices/workflow-parser/testdata/reader/yaml-schema-null.yml": [
+        "<stdin>:11:13: duplicate value Null is found in matrix \"vector-1\". the same value is at line:10,col:13 [matrix]",
+        "<stdin>:12:13: duplicate value NULL is found in matrix \"vector-1\". the same value is at line:10,col:13 [matrix]",
+        "<stdin>:13:13: duplicate value ~ is found in matrix \"vector-1\". the same value is at line:10,col:13 [matrix]",
+        "<stdin>:16:13: duplicate value null is found in matrix \"vector-1\". the same value is at line:10,col:13 [matrix]",
+        "<stdin>:17:13: duplicate value null is found in matrix \"vector-1\". the same value is at line:10,col:13 [matrix]",
+        "<stdin>:18:13: duplicate value ~ is found in matrix \"vector-1\". the same value is at line:10,col:13 [matrix]",
+        "<stdin>:19:13: duplicate value null is found in matrix \"vector-1\". the same value is at line:10,col:13 [matrix]",
+        "<stdin>:20:13: duplicate value null is found in matrix \"vector-1\". the same value is at line:10,col:13 [matrix]",
+        "<stdin>:21:13: duplicate value ~ is found in matrix \"vector-1\". the same value is at line:10,col:13 [matrix]"
+      ],
+      "languageservices/workflow-parser/testdata/reader/yaml-schema-str-block-styles.yml": [
+        "<stdin>:55:13: duplicate value \"Line 1\\nLine 2\\n\\nLine 4\\n  Line 5\\nLine 6\\nLine 7\\n\" is found in matrix \"vector-1\". the same value is at line:22,col:13 [matrix]",
+        "<stdin>:66:13: duplicate value \"Line 1\\nLine 2\\n\\nLine 4\\n  Line 5\\nLine 6\\nLine 7\" is found in matrix \"vector-1\". the same value is at line:33,col:13 [matrix]",
+        "<stdin>:77:13: duplicate value \"Line 1\\nLine 2\\n\\nLine 4\\n  Line 5\\nLine 6\\nLine 7\\n\\n\\n\" is found in matrix \"vector-1\". the same value is at line:44,col:13 [matrix]",
+        "<stdin>:121:13: duplicate value \"Line 1 Line 2\\nLine 4\\n  Line 5\\nLine 6 Line 7\\n\" is found in matrix \"vector-1\". the same value is at line:88,col:13 [matrix]",
+        "<stdin>:132:13: duplicate value \"Line 1 Line 2\\nLine 4\\n  Line 5\\nLine 6 Line 7\" is found in matrix \"vector-1\". the same value is at line:99,col:13 [matrix]",
+        "<stdin>:143:13: duplicate value \"Line 1 Line 2\\nLine 4\\n  Line 5\\nLine 6 Line 7\\n\\n\\n\" is found in matrix \"vector-1\". the same value is at line:110,col:13 [matrix]",
+        "<stdin>:157:13: duplicate value \"hello\\nworld\\n\" is found in matrix \"vector-1\". the same value is at line:154,col:13 [matrix]",
+        "<stdin>:173:13: duplicate value \"\\nhello\\n\" is found in matrix \"vector-1\". the same value is at line:165,col:13 [matrix]"
+      ],
+      "languageservices/workflow-parser/testdata/reader/yaml-schema-str-flow-styles.yml": [
+        "<stdin>:14:13: duplicate value \"foo bar\" is found in matrix \"vector-1\". the same value is at line:13,col:13 [matrix]",
+        "<stdin>:15:13: duplicate value \"foo bar\" is found in matrix \"vector-1\". the same value is at line:13,col:13 [matrix]",
+        "<stdin>:21:13: duplicate value \"foo bar\" is found in matrix \"vector-1\". the same value is at line:13,col:13 [matrix]",
+        "<stdin>:23:13: duplicate value \"foo bar\" is found in matrix \"vector-1\". the same value is at line:13,col:13 [matrix]",
+        "<stdin>:24:13: duplicate value \"null\" is found in matrix \"vector-1\". the same value is at line:18,col:13 [matrix]",
+        "<stdin>:25:13: duplicate value \"true\" is found in matrix \"vector-1\". the same value is at line:19,col:13 [matrix]",
+        "<stdin>:26:13: duplicate value \"0\" is found in matrix \"vector-1\". the same value is at line:20,col:13 [matrix]",
+        "<stdin>:27:13: duplicate value \"foo bar\" is found in matrix \"vector-1\". the same value is at line:13,col:13 [matrix]",
+        "<stdin>:28:13: duplicate value \"\\\\\\\"foo bar\\\\\\\"\" is found in matrix \"vector-1\". the same value is at line:22,col:13 [matrix]",
+        "<stdin>:29:13: duplicate value \"foo bar\" is found in matrix \"vector-1\". the same value is at line:13,col:13 [matrix]"
+      ]
+    }
+  },
+  {
+    "reason": "Extra typo check: the reader ignores unknown workflow_dispatch keys; actionlint reports them.",
+    "cases": {
+      "languageservices/workflow-parser/testdata/reader/on-workflow_dispatch-unknown-keys-ignored.yml": [
+        "<stdin>:3:5: expected \"inputs\" key for \"workflow_dispatch\" section but got \"unknown-key\" [syntax-check]"
+      ]
+    }
+  },
+  {
+    "reason": "Fixture reference differs from documented workflow-call syntax: the owner begins with a dot. actionlint rejects that uses reference.",
+    "cases": {
+      "languageservices/workflow-parser/testdata/reader/is-partial-rerun.yml": [
+        "<stdin>:9:11: reusable workflow call \".contoso/templates/.github/workflows/deploy.yml@v1\" at \"uses\" is not following the format \"owner/repo/path/to/workflow.yml@ref\", \"./path/to/workflow.yml\", nor \"$/path/to/workflow.yml\". see https://docs.github.com/en/actions/learn-github-actions/reusing-workflows for more details [workflow-call]"
+      ]
+    }
+  },
+  {
+    "reason": "Function arity difference: actionlint requires a replacement argument for format(); the upstream parser accepts a format string alone.",
+    "cases": {
+      "languageservices/expressions/testdata/format.json/format/0": [
+        "1:1:0: number of arguments is wrong. function \"format(string, any...) -> string\" takes at least 2 parameters but 1 arguments are given"
+      ],
+      "languageservices/expressions/testdata/format.json/format/2": [
+        "1:1:0: number of arguments is wrong. function \"format(string, any...) -> string\" takes at least 2 parameters but 1 arguments are given"
+      ],
+      "languageservices/expressions/testdata/format.json/format/21": [
+        "1:1:0: number of arguments is wrong. function \"format(string, any...) -> string\" takes at least 2 parameters but 1 arguments are given"
+      ],
+      "languageservices/expressions/testdata/format.json/format/25": [
+        "1:1:0: number of arguments is wrong. function \"format(string, any...) -> string\" takes at least 2 parameters but 1 arguments are given"
+      ],
+      "languageservices/expressions/testdata/format.json/format/27": [
+        "1:1:0: number of arguments is wrong. function \"format(string, any...) -> string\" takes at least 2 parameters but 1 arguments are given"
+      ],
+      "languageservices/expressions/testdata/format.json/format/29": [
+        "1:1:0: number of arguments is wrong. function \"format(string, any...) -> string\" takes at least 2 parameters but 1 arguments are given"
+      ],
+      "languageservices/expressions/testdata/format.json/format/31": [
+        "1:1:0: number of arguments is wrong. function \"format(string, any...) -> string\" takes at least 2 parameters but 1 arguments are given"
+      ],
+      "languageservices/expressions/testdata/format.json/format/33": [
+        "1:1:0: number of arguments is wrong. function \"format(string, any...) -> string\" takes at least 2 parameters but 1 arguments are given"
+      ],
+      "languageservices/expressions/testdata/format.json/format/36": [
+        "1:1:0: number of arguments is wrong. function \"format(string, any...) -> string\" takes at least 2 parameters but 1 arguments are given"
+      ],
+      "languageservices/expressions/testdata/syntax-errors.json/depth-errors/13": [
+        "1:1:0: number of arguments is wrong. function \"format(string, any...) -> string\" takes at least 2 parameters but 1 arguments are given",
+        "1:18:17: number of arguments is wrong. function \"format(string, any...) -> string\" takes at least 2 parameters but 1 arguments are given",
+        "1:35:34: number of arguments is wrong. function \"format(string, any...) -> string\" takes at least 2 parameters but 1 arguments are given",
+        "1:52:51: number of arguments is wrong. function \"format(string, any...) -> string\" takes at least 2 parameters but 1 arguments are given",
+        "1:69:68: number of arguments is wrong. function \"format(string, any...) -> string\" takes at least 2 parameters but 1 arguments are given",
+        "1:87:86: number of arguments is wrong. function \"format(string, any...) -> string\" takes at least 2 parameters but 1 arguments are given",
+        "1:105:104: number of arguments is wrong. function \"format(string, any...) -> string\" takes at least 2 parameters but 1 arguments are given",
+        "1:123:122: number of arguments is wrong. function \"format(string, any...) -> string\" takes at least 2 parameters but 1 arguments are given",
+        "1:141:140: number of arguments is wrong. function \"format(string, any...) -> string\" takes at least 2 parameters but 1 arguments are given",
+        "1:159:158: number of arguments is wrong. function \"format(string, any...) -> string\" takes at least 2 parameters but 1 arguments are given",
+        "1:177:176: number of arguments is wrong. function \"format(string, any...) -> string\" takes at least 2 parameters but 1 arguments are given",
+        "1:195:194: number of arguments is wrong. function \"format(string, any...) -> string\" takes at least 2 parameters but 1 arguments are given",
+        "1:213:212: number of arguments is wrong. function \"format(string, any...) -> string\" takes at least 2 parameters but 1 arguments are given",
+        "1:231:230: number of arguments is wrong. function \"format(string, any...) -> string\" takes at least 2 parameters but 1 arguments are given",
+        "1:249:248: number of arguments is wrong. function \"format(string, any...) -> string\" takes at least 2 parameters but 1 arguments are given",
+        "1:267:266: number of arguments is wrong. function \"format(string, any...) -> string\" takes at least 2 parameters but 1 arguments are given",
+        "1:285:284: number of arguments is wrong. function \"format(string, any...) -> string\" takes at least 2 parameters but 1 arguments are given",
+        "1:303:302: number of arguments is wrong. function \"format(string, any...) -> string\" takes at least 2 parameters but 1 arguments are given",
+        "1:321:320: number of arguments is wrong. function \"format(string, any...) -> string\" takes at least 2 parameters but 1 arguments are given",
+        "1:339:338: number of arguments is wrong. function \"format(string, any...) -> string\" takes at least 2 parameters but 1 arguments are given",
+        "1:357:356: number of arguments is wrong. function \"format(string, any...) -> string\" takes at least 2 parameters but 1 arguments are given",
+        "1:375:374: number of arguments is wrong. function \"format(string, any...) -> string\" takes at least 2 parameters but 1 arguments are given",
+        "1:393:392: number of arguments is wrong. function \"format(string, any...) -> string\" takes at least 2 parameters but 1 arguments are given",
+        "1:411:410: number of arguments is wrong. function \"format(string, any...) -> string\" takes at least 2 parameters but 1 arguments are given",
+        "1:429:428: number of arguments is wrong. function \"format(string, any...) -> string\" takes at least 2 parameters but 1 arguments are given"
+      ],
+      "languageservices/expressions/testdata/syntax-errors.json/depth-errors/15": [
+        "1:1:0: number of arguments is wrong. function \"format(string, any...) -> string\" takes at least 2 parameters but 1 arguments are given",
+        "1:18:17: number of arguments is wrong. function \"format(string, any...) -> string\" takes at least 2 parameters but 1 arguments are given",
+        "1:35:34: number of arguments is wrong. function \"format(string, any...) -> string\" takes at least 2 parameters but 1 arguments are given",
+        "1:52:51: number of arguments is wrong. function \"format(string, any...) -> string\" takes at least 2 parameters but 1 arguments are given",
+        "1:69:68: number of arguments is wrong. function \"format(string, any...) -> string\" takes at least 2 parameters but 1 arguments are given",
+        "1:87:86: number of arguments is wrong. function \"format(string, any...) -> string\" takes at least 2 parameters but 1 arguments are given",
+        "1:105:104: number of arguments is wrong. function \"format(string, any...) -> string\" takes at least 2 parameters but 1 arguments are given",
+        "1:123:122: number of arguments is wrong. function \"format(string, any...) -> string\" takes at least 2 parameters but 1 arguments are given",
+        "1:141:140: number of arguments is wrong. function \"format(string, any...) -> string\" takes at least 2 parameters but 1 arguments are given",
+        "1:159:158: number of arguments is wrong. function \"format(string, any...) -> string\" takes at least 2 parameters but 1 arguments are given",
+        "1:177:176: number of arguments is wrong. function \"format(string, any...) -> string\" takes at least 2 parameters but 1 arguments are given",
+        "1:195:194: number of arguments is wrong. function \"format(string, any...) -> string\" takes at least 2 parameters but 1 arguments are given",
+        "1:213:212: number of arguments is wrong. function \"format(string, any...) -> string\" takes at least 2 parameters but 1 arguments are given",
+        "1:231:230: number of arguments is wrong. function \"format(string, any...) -> string\" takes at least 2 parameters but 1 arguments are given",
+        "1:249:248: number of arguments is wrong. function \"format(string, any...) -> string\" takes at least 2 parameters but 1 arguments are given",
+        "1:267:266: number of arguments is wrong. function \"format(string, any...) -> string\" takes at least 2 parameters but 1 arguments are given",
+        "1:285:284: number of arguments is wrong. function \"format(string, any...) -> string\" takes at least 2 parameters but 1 arguments are given",
+        "1:303:302: number of arguments is wrong. function \"format(string, any...) -> string\" takes at least 2 parameters but 1 arguments are given",
+        "1:321:320: number of arguments is wrong. function \"format(string, any...) -> string\" takes at least 2 parameters but 1 arguments are given",
+        "1:339:338: number of arguments is wrong. function \"format(string, any...) -> string\" takes at least 2 parameters but 1 arguments are given",
+        "1:357:356: number of arguments is wrong. function \"format(string, any...) -> string\" takes at least 2 parameters but 1 arguments are given",
+        "1:375:374: number of arguments is wrong. function \"format(string, any...) -> string\" takes at least 2 parameters but 1 arguments are given",
+        "1:393:392: number of arguments is wrong. function \"format(string, any...) -> string\" takes at least 2 parameters but 1 arguments are given",
+        "1:411:410: number of arguments is wrong. function \"format(string, any...) -> string\" takes at least 2 parameters but 1 arguments are given",
+        "1:429:428: number of arguments is wrong. function \"format(string, any...) -> string\" takes at least 2 parameters but 1 arguments are given"
+      ]
+    }
+  },
+  {
+    "reason": "Mixed reader differences: missing steps, undefined matrix and step properties, numeric coercion, and the unsupported cancel-timeout-minutes field.",
+    "cases": {
+      "languageservices/workflow-parser/testdata/reader/misc-jobs.yml": [
+        "<stdin>:3:3: \"steps\" section is missing in job \"build\" [syntax-check]",
+        "<stdin>:4:18: property \"os\" is not defined in object type {} [expression]",
+        "<stdin>:5:28: property \"experimental\" is not defined in object type {} [expression]",
+        "<stdin>:7:22: type of expression at \"float number value\" must be number but found type string [expression]",
+        "<stdin>:8:5: unexpected key \"cancel-timeout-minutes\" for \"job\" section. expected one of \"concurrency\", \"container\", \"continue-on-error\", \"defaults\", \"env\", \"environment\", \"if\", \"name\", \"needs\", \"outputs\", \"permissions\", \"runs-on\", \"secrets\", \"services\", \"snapshot\", \"steps\", \"strategy\", \"timeout-minutes\", \"uses\", \"with\" [syntax-check]",
+        "<stdin>:15:17: property \"step_id\" is not defined in object type {} [expression]",
+        "<stdin>:18:20: property \"step1\" is not defined in object type {} [expression]",
+        "<stdin>:19:20: property \"step2\" is not defined in object type {} [expression]",
+        "<stdin>:24:3: \"steps\" section is missing in job \"build2\" [syntax-check]",
+        "<stdin>:29:5: unexpected key \"cancel-timeout-minutes\" for \"job\" section. expected one of \"concurrency\", \"container\", \"continue-on-error\", \"defaults\", \"env\", \"environment\", \"if\", \"name\", \"needs\", \"outputs\", \"permissions\", \"runs-on\", \"secrets\", \"services\", \"snapshot\", \"steps\", \"strategy\", \"timeout-minutes\", \"uses\", \"with\" [syntax-check]"
+      ]
+    }
+  },
+  {
+    "reason": "Numeric parsing gap: the fixture exercises overflow, infinity, and NaN values that actionlint does not accept in these numeric fields.",
+    "cases": {
+      "languageservices/workflow-parser/testdata/reader/round-to-infinity.yml": [
+        "<stdin>:5:22: expecting a single ${{...}} expression or float number literal, but found plain text node [syntax-check]",
+        "<stdin>:10:22: expecting a single ${{...}} expression or float number literal, but found plain text node [syntax-check]",
+        "<stdin>:15:22: expecting a single ${{...}} expression or float number literal, but found plain text node [syntax-check]",
+        "<stdin>:20:26: undefined variable \"NaN\". available variables are \"env\", \"github\", \"inputs\", \"job\", \"matrix\", \"needs\", \"runner\", \"secrets\", \"steps\", \"strategy\", \"vars\" [expression]",
+        "<stdin>:33:26: expecting a single ${{...}} expression or float number literal, but found plain text node [syntax-check]",
+        "<stdin>:39:26: expecting a single ${{...}} expression or float number literal, but found plain text node [syntax-check]"
+      ]
+    }
+  },
+  {
+    "reason": "Parser gap: the reader rejects the explicit timestamp tag, which actionlint currently accepts.",
+    "cases": {
+      "languageservices/workflow-parser/testdata/reader/errors-yaml-tags-explicit-unsupported.yml": []
+    }
+  },
+  {
+    "reason": "Reader field gap: cancel-timeout-minutes is not accepted by actionlint.",
+    "cases": {
+      "languageservices/workflow-parser/testdata/reader/job-cancel-timeout-minutes.yml": [
+        "<stdin>:5:5: unexpected key \"cancel-timeout-minutes\" for \"job\" section. expected one of \"concurrency\", \"container\", \"continue-on-error\", \"defaults\", \"env\", \"environment\", \"if\", \"name\", \"needs\", \"outputs\", \"permissions\", \"runs-on\", \"secrets\", \"services\", \"snapshot\", \"steps\", \"strategy\", \"timeout-minutes\", \"uses\", \"with\" [syntax-check]",
+        "<stdin>:17:5: unexpected key \"cancel-timeout-minutes\" for \"job\" section. expected one of \"concurrency\", \"container\", \"continue-on-error\", \"defaults\", \"env\", \"environment\", \"if\", \"name\", \"needs\", \"outputs\", \"permissions\", \"runs-on\", \"secrets\", \"services\", \"snapshot\", \"steps\", \"strategy\", \"timeout-minutes\", \"uses\", \"with\" [syntax-check]"
+      ],
+      "languageservices/workflow-parser/testdata/reader/job-concurrency.yml": [
+        "<stdin>:17:5: unexpected key \"cancel-timeout-minutes\" for \"job\" section. expected one of \"concurrency\", \"container\", \"continue-on-error\", \"defaults\", \"env\", \"environment\", \"if\", \"name\", \"needs\", \"outputs\", \"permissions\", \"runs-on\", \"secrets\", \"services\", \"snapshot\", \"steps\", \"strategy\", \"timeout-minutes\", \"uses\", \"with\" [syntax-check]"
+      ]
+    }
+  },
+  {
+    "reason": "Reader field gap: cancel-timeout-minutes is not accepted by actionlint. This fixture also uses the retired windows-2019 label.",
+    "cases": {
+      "languageservices/workflow-parser/testdata/reader/job-basic.yml": [
+        "<stdin>:4:14: label \"windows-2019\" is unknown. available labels are \"windows-latest\", \"windows-latest-8-cores\", \"windows-2025\", \"windows-2025-vs2026\", \"windows-2022\", \"windows-11-arm\", \"windows-11-vs2026-arm\", \"ubuntu-slim\", \"ubuntu-latest\", \"ubuntu-latest-4-cores\", \"ubuntu-latest-8-cores\", \"ubuntu-latest-16-cores\", \"ubuntu-26.04\", \"ubuntu-26.04-arm\", \"ubuntu-24.04\", \"ubuntu-24.04-arm\", \"ubuntu-22.04\", \"ubuntu-22.04-arm\", \"xcode-27\", \"xcode-27-xlarge\", \"macos-latest\", \"macos-latest-xlarge\", \"macos-latest-large\", \"macos-26-intel\", \"macos-26-xlarge\", \"macos-26-large\", \"macos-26\", \"macos-15-intel\", \"macos-15-xlarge\", \"macos-15-large\", \"macos-15\", \"macos-14-xlarge\", \"macos-14-large\", \"macos-14\", \"self-hosted\", \"x64\", \"arm\", \"arm64\", \"linux\", \"macos\", \"windows\". if it is a custom label for self-hosted runner, set list of labels in actionlint.yaml config file [runner-label]",
+        "<stdin>:8:14: label \"windows-2019\" is unknown. available labels are \"windows-latest\", \"windows-latest-8-cores\", \"windows-2025\", \"windows-2025-vs2026\", \"windows-2022\", \"windows-11-arm\", \"windows-11-vs2026-arm\", \"ubuntu-slim\", \"ubuntu-latest\", \"ubuntu-latest-4-cores\", \"ubuntu-latest-8-cores\", \"ubuntu-latest-16-cores\", \"ubuntu-26.04\", \"ubuntu-26.04-arm\", \"ubuntu-24.04\", \"ubuntu-24.04-arm\", \"ubuntu-22.04\", \"ubuntu-22.04-arm\", \"xcode-27\", \"xcode-27-xlarge\", \"macos-latest\", \"macos-latest-xlarge\", \"macos-latest-large\", \"macos-26-intel\", \"macos-26-xlarge\", \"macos-26-large\", \"macos-26\", \"macos-15-intel\", \"macos-15-xlarge\", \"macos-15-large\", \"macos-15\", \"macos-14-xlarge\", \"macos-14-large\", \"macos-14\", \"self-hosted\", \"x64\", \"arm\", \"arm64\", \"linux\", \"macos\", \"windows\". if it is a custom label for self-hosted runner, set list of labels in actionlint.yaml config file [runner-label]",
+        "<stdin>:9:5: unexpected key \"cancel-timeout-minutes\" for \"job\" section. expected one of \"concurrency\", \"container\", \"continue-on-error\", \"defaults\", \"env\", \"environment\", \"if\", \"name\", \"needs\", \"outputs\", \"permissions\", \"runs-on\", \"secrets\", \"services\", \"snapshot\", \"steps\", \"strategy\", \"timeout-minutes\", \"uses\", \"with\" [syntax-check]"
+      ]
+    }
+  },
+  {
+    "reason": "Reader field gap: the reader accepts a workflow-level description field; actionlint currently rejects it.",
+    "cases": {
+      "languageservices/workflow-parser/testdata/reader/workflow-description.yml": [
+        "<stdin>:1:1: unexpected key \"description\" for \"workflow\" section. expected one of \"concurrency\", \"defaults\", \"env\", \"jobs\", \"name\", \"on\", \"permissions\", \"run-name\" [syntax-check]"
+      ]
+    }
+  },
+  {
+    "reason": "Reader fixture versus lint checks: combined include/exclude filters, retired events, stacked activity types, one-minute schedules, and required inputs with defaults produce additional diagnostics.",
+    "cases": {
+      "languageservices/workflow-parser/testdata/reader/events-mapping-all.yml": [
+        "<stdin>:76:5: both \"branches\" and \"branches-ignore\" filters cannot be used for the same event \"merge_group\". note: use '!' to negate patterns [events]",
+        "<stdin>:88:3: unknown Webhook event \"project\". see https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#webhook-events for list of all Webhook event names [events]",
+        "<stdin>:95:3: unknown Webhook event \"project_card\". see https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#webhook-events for list of all Webhook event names [events]",
+        "<stdin>:102:3: unknown Webhook event \"project_column\". see https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#webhook-events for list of all Webhook event names [events]",
+        "<stdin>:113:5: both \"branches\" and \"branches-ignore\" filters cannot be used for the same event \"pull_request\". note: use '!' to negate patterns [events]",
+        "<stdin>:115:5: both \"paths\" and \"paths-ignore\" filters cannot be used for the same event \"pull_request\". note: use '!' to negate patterns [events]",
+        "<stdin>:138:9: invalid activity type \"stacked\" for \"pull_request\" Webhook event. available types are \"assigned\", \"auto_merge_disabled\", \"auto_merge_enabled\", \"closed\", \"converted_to_draft\", \"demilestoned\", \"dequeued\", \"edited\", \"enqueued\", \"labeled\", \"locked\", \"milestoned\", \"opened\", \"ready_for_review\", \"reopened\", \"review_request_removed\", \"review_requested\", \"synchronize\", \"unassigned\", \"unlabeled\", \"unlocked\" [events]",
+        "<stdin>:139:3: unknown Webhook event \"pull_request_comment\". see https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#webhook-events for list of all Webhook event names [events]",
+        "<stdin>:158:5: both \"branches\" and \"branches-ignore\" filters cannot be used for the same event \"pull_request_target\". note: use '!' to negate patterns [events]",
+        "<stdin>:160:5: both \"paths\" and \"paths-ignore\" filters cannot be used for the same event \"pull_request_target\". note: use '!' to negate patterns [events]",
+        "<stdin>:183:9: invalid activity type \"stacked\" for \"pull_request_target\" Webhook event. available types are \"assigned\", \"auto_merge_disabled\", \"auto_merge_enabled\", \"closed\", \"converted_to_draft\", \"demilestoned\", \"dequeued\", \"edited\", \"enqueued\", \"labeled\", \"locked\", \"milestoned\", \"opened\", \"ready_for_review\", \"reopened\", \"review_request_removed\", \"review_requested\", \"synchronize\", \"unassigned\", \"unlabeled\", \"unlocked\" [events]",
+        "<stdin>:188:5: both \"branches\" and \"branches-ignore\" filters cannot be used for the same event \"push\". note: use '!' to negate patterns [events]",
+        "<stdin>:192:5: both \"tags\" and \"tags-ignore\" filters cannot be used for the same event \"push\". note: use '!' to negate patterns [events]",
+        "<stdin>:194:5: both \"paths\" and \"paths-ignore\" filters cannot be used for the same event \"push\". note: use '!' to negate patterns [events]",
+        "<stdin>:209:13: scheduled job runs too frequently. it runs once per 60 seconds. the shortest interval is once every 5 minutes [events]",
+        "<stdin>:210:13: scheduled job runs too frequently. it runs once per 60 seconds. the shortest interval is once every 5 minutes [events]",
+        "<stdin>:220:18: input \"foo\" of workflow_call event has the default value \"bar\", but it is also required. if an input is marked as required, its default value will never be used [events]",
+        "<stdin>:234:5: both \"branches\" and \"branches-ignore\" filters cannot be used for the same event \"workflow_run\". note: use '!' to negate patterns [events]",
+        "<stdin>:239:15: the runtime or service used by \"actions/checkout@v3\" action is retired on GitHub.com. update the action's version to fix this issue [action]"
+      ]
+    }
+  },
+  {
+    "reason": "Reader versus lint checks: empty and constant conditions, unknown context properties, and arguments to success() produce diagnostics.",
+    "cases": {
+      "languageservices/workflow-parser/testdata/reader/job-if.yml": [
+        "<stdin>:6:9: constant expression \"true\" in condition. remove the if: section [if-cond]",
+        "<stdin>:11:9: string should not be empty [syntax-check]",
+        "<stdin>:11:9: unexpected end of input while parsing variable access, function call, null, bool, int, float or string. expecting \"IDENT\", \"(\", \"INTEGER\", \"FLOAT\", \"STRING\" [expression]",
+        "<stdin>:16:13: property \"foo\" is not defined in object type {action: string; action_path: string; action_ref: string; action_repository: string; action_status: string; actor: string; actor_id: string; api_url: string; artifact_cache_size_limit: number; artifacts: string; artifacts_list: string; base_ref: string; env: string; event: object; event_name: string; event_path: string; graphql_url: string; head_ref: string; job: string; output: string; path: string; ref: string; ref_name: string; ref_protected: bool; ref_type: string; repository: string; repository_id: string; repository_owner: string; repository_owner_id: string; repository_visibility: string; repositoryurl: string; retention_days: string; run_attempt: string; run_id: string; run_number: string; secret_source: string; server_url: string; sha: string; state: string; step_summary: string; token: string; triggering_actor: string; workflow: string; workflow_ref: string; workflow_sha: string; workspace: string} [expression]",
+        "<stdin>:24:13: number of arguments is wrong. function \"success() -> bool\" takes 0 parameters but 2 arguments are given [expression]",
+        "<stdin>:29:9: property \"foo\" is not defined in object type {action: string; action_path: string; action_ref: string; action_repository: string; action_status: string; actor: string; actor_id: string; api_url: string; artifact_cache_size_limit: number; artifacts: string; artifacts_list: string; base_ref: string; env: string; event: object; event_name: string; event_path: string; graphql_url: string; head_ref: string; job: string; output: string; path: string; ref: string; ref_name: string; ref_protected: bool; ref_type: string; repository: string; repository_id: string; repository_owner: string; repository_owner_id: string; repository_visibility: string; repositoryurl: string; retention_days: string; run_attempt: string; run_id: string; run_number: string; secret_source: string; server_url: string; sha: string; state: string; step_summary: string; token: string; triggering_actor: string; workflow: string; workflow_ref: string; workflow_sha: string; workspace: string} [expression]",
+        "<stdin>:34:9: constant expression \"null\" in condition. remove the if: section [if-cond]",
+        "<stdin>:44:9: constant expression \"false || (true && true)\" in condition. remove the if: section [if-cond]"
+      ]
+    }
+  },
+  {
+    "reason": "Resolution boundary: the upstream fixture supplies remote reusable workflows to a mock file provider. actionlint analyzes the caller offline and does not resolve those remote bodies, permissions, or nested calls.",
+    "cases": {
+      "languageservices/workflow-parser/testdata/reader/errors-reusable-workflow-job-inputs-required.yml": [],
+      "languageservices/workflow-parser/testdata/reader/errors-reusable-workflow-job-inputs-type-mismatch.yml": [],
+      "languageservices/workflow-parser/testdata/reader/errors-reusable-workflow-job-inputs-undefined.yml": [],
+      "languageservices/workflow-parser/testdata/reader/errors-reusable-workflow-job-nested-depth-exceeded.yml": [],
+      "languageservices/workflow-parser/testdata/reader/errors-reusable-workflow-job-nested-permissions-not-allowed-job-level-from-caller-job-level.yml": [],
+      "languageservices/workflow-parser/testdata/reader/errors-reusable-workflow-job-nested-permissions-not-allowed-job-level-from-caller-workflow-level.yml": [],
+      "languageservices/workflow-parser/testdata/reader/errors-reusable-workflow-job-nested-permissions-not-allowed-workflow-level-from-caller-job-level.yml": [],
+      "languageservices/workflow-parser/testdata/reader/errors-reusable-workflow-job-nested-permissions-not-allowed-workflow-level-from-caller-workflow-level.yml": [],
+      "languageservices/workflow-parser/testdata/reader/errors-reusable-workflow-job-secrets-required.yml": [],
+      "languageservices/workflow-parser/testdata/reader/errors-reusable-workflow-job-secrets-undefined.yml": [],
+      "languageservices/workflow-parser/testdata/reader/errors-reusable-workflow-max-result-size.yml": [],
+      "languageservices/workflow-parser/testdata/reader/errors-reusable-workflow-permissions-not-allowed-job-level-from-caller-default.yml": [],
+      "languageservices/workflow-parser/testdata/reader/errors-reusable-workflow-permissions-not-allowed-job-level-from-caller-job-level.yml": [],
+      "languageservices/workflow-parser/testdata/reader/errors-reusable-workflow-permissions-not-allowed-job-level-from-caller-workflow-level.yml": [],
+      "languageservices/workflow-parser/testdata/reader/errors-reusable-workflow-permissions-not-allowed-request-actions-write.yml": [],
+      "languageservices/workflow-parser/testdata/reader/errors-reusable-workflow-permissions-not-allowed-request-checks-write.yml": [],
+      "languageservices/workflow-parser/testdata/reader/errors-reusable-workflow-permissions-not-allowed-request-contents-write.yml": [],
+      "languageservices/workflow-parser/testdata/reader/errors-reusable-workflow-permissions-not-allowed-request-deployments-write.yml": [],
+      "languageservices/workflow-parser/testdata/reader/errors-reusable-workflow-permissions-not-allowed-request-discussions-write.yml": [],
+      "languageservices/workflow-parser/testdata/reader/errors-reusable-workflow-permissions-not-allowed-request-id-token-write.yml": [],
+      "languageservices/workflow-parser/testdata/reader/errors-reusable-workflow-permissions-not-allowed-request-issues-write.yml": [],
+      "languageservices/workflow-parser/testdata/reader/errors-reusable-workflow-permissions-not-allowed-request-packages-write.yml": [],
+      "languageservices/workflow-parser/testdata/reader/errors-reusable-workflow-permissions-not-allowed-request-pages-write.yml": [],
+      "languageservices/workflow-parser/testdata/reader/errors-reusable-workflow-permissions-not-allowed-request-pull-requests-write.yml": [],
+      "languageservices/workflow-parser/testdata/reader/errors-reusable-workflow-permissions-not-allowed-request-read-all-allowed-none.yml": [],
+      "languageservices/workflow-parser/testdata/reader/errors-reusable-workflow-permissions-not-allowed-request-repository-projects-write.yml": [],
+      "languageservices/workflow-parser/testdata/reader/errors-reusable-workflow-permissions-not-allowed-request-security-events-write.yml": [],
+      "languageservices/workflow-parser/testdata/reader/errors-reusable-workflow-permissions-not-allowed-request-statuses-write.yml": [],
+      "languageservices/workflow-parser/testdata/reader/errors-reusable-workflow-permissions-not-allowed-request-write-all-allowed-none.yml": [],
+      "languageservices/workflow-parser/testdata/reader/errors-reusable-workflow-permissions-not-allowed-request-write-all-allowed-read-all.yml": [],
+      "languageservices/workflow-parser/testdata/reader/errors-reusable-workflow-permissions-not-allowed-workflow-level-from-caller-default.yml": [],
+      "languageservices/workflow-parser/testdata/reader/errors-reusable-workflow-permissions-not-allowed-workflow-level-from-caller-job-level.yml": [],
+      "languageservices/workflow-parser/testdata/reader/errors-reusable-workflow-permissions-not-allowed-workflow-level-from-caller-workflow-level.yml": []
+    }
+  },
+  {
+    "reason": "Runner limit gap: actionlint does not enforce the expansion, object-size, or expression-length limit configured by this reader fixture.",
+    "cases": {
+      "languageservices/workflow-parser/testdata/reader/errors-max-job-limit-with-reusable-workflow.yml": [],
+      "languageservices/workflow-parser/testdata/reader/errors-max-result-size.yml": [],
+      "languageservices/workflow-parser/testdata/reader/errors-step-run-exceeds-length.yml": []
+    }
+  },
+  {
+    "reason": "Runner-internal contract: plugin actions omit runs.using; actionlint validates public action metadata and requires it.",
+    "cases": {
+      "runner/src/Test/TestData/pluginaction.yml": [
+        ":1:1: \"runs.using\" is missing in local action \"Hello World\" defined at \"<action>\" [action]"
+      ]
+    }
+  },
+  {
+    "reason": "Schema versus lint contract: this JavaScript action fixture omits description and uses node12; actionlint requires a description and reports the retired runtime.",
+    "cases": {
+      "schemastore/src/test/github-action/javascript.json": [
+        ":1:1: description is required in metadata of \"Test JavaScript action\" action at \"<action>/action.yml\" [action]",
+        ":1:1: runtime \"node12\" is no longer bundled with current GitHub Actions runners. update runs.using in local action \"Test JavaScript action\" to a current runtime [action]"
+      ]
+    }
+  },
+  {
+    "reason": "Schema versus lint contract: this schema-valid example triggers additional actionlint checks (action, deprecated-commands, runner-label). The exact diagnostics are retained for review; schema acceptance alone does not establish runtime validity.",
+    "cases": {
+      "schemastore/src/test/github-workflow/issue_2463_file_2.yaml": [
+        "<stdin>:91:15: the runtime or service used by \"actions/setup-python@v2\" action is retired on GitHub.com. update the action's version to fix this issue [action]",
+        "<stdin>:105:14: workflow command \"set-output\" was deprecated. use `echo \"{name}={value}\" >> $GITHUB_OUTPUT` instead: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions [deprecated-commands]",
+        "<stdin>:110:14: workflow command \"set-output\" was deprecated. use `echo \"{name}={value}\" >> $GITHUB_OUTPUT` instead: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions [deprecated-commands]",
+        "<stdin>:115:15: the runtime or service used by \"actions/checkout@v2\" action is retired on GitHub.com. update the action's version to fix this issue [action]",
+        "<stdin>:125:14: workflow command \"set-output\" was deprecated. use `echo \"{name}={value}\" >> $GITHUB_OUTPUT` instead: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions [deprecated-commands]",
+        "<stdin>:136:14: workflow command \"set-output\" was deprecated. use `echo \"{name}={value}\" >> $GITHUB_OUTPUT` instead: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions [deprecated-commands]",
+        "<stdin>:149:14: workflow command \"set-output\" was deprecated. use `echo \"{name}={value}\" >> $GITHUB_OUTPUT` instead: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions [deprecated-commands]",
+        "<stdin>:188:14: workflow command \"set-output\" was deprecated. use `echo \"{name}={value}\" >> $GITHUB_OUTPUT` instead: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions [deprecated-commands]",
+        "<stdin>:199:14: workflow command \"set-output\" was deprecated. use `echo \"{name}={value}\" >> $GITHUB_OUTPUT` instead: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions [deprecated-commands]",
+        "<stdin>:207:14: workflow command \"set-output\" was deprecated. use `echo \"{name}={value}\" >> $GITHUB_OUTPUT` instead: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions [deprecated-commands]",
+        "<stdin>:246:15: the runtime or service used by \"actions/setup-python@v4\" action is retired on GitHub.com. update the action's version to fix this issue [action]",
+        "<stdin>:254:14: workflow command \"set-output\" was deprecated. use `echo \"{name}={value}\" >> $GITHUB_OUTPUT` instead: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions [deprecated-commands]",
+        "<stdin>:263:14: workflow command \"set-output\" was deprecated. use `echo \"{name}={value}\" >> $GITHUB_OUTPUT` instead: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions [deprecated-commands]",
+        "<stdin>:286:15: the runtime or service used by \"actions/checkout@v2\" action is retired on GitHub.com. update the action's version to fix this issue [action]",
+        "<stdin>:337:15: the runtime or service used by \"actions/upload-artifact@v2\" action is retired on GitHub.com. update the action's version to fix this issue [action]",
+        "<stdin>:385:13: label \"ubuntu-20.04\" is unknown. available labels are \"windows-latest\", \"windows-latest-8-cores\", \"windows-2025\", \"windows-2025-vs2026\", \"windows-2022\", \"windows-11-arm\", \"windows-11-vs2026-arm\", \"ubuntu-slim\", \"ubuntu-latest\", \"ubuntu-latest-4-cores\", \"ubuntu-latest-8-cores\", \"ubuntu-latest-16-cores\", \"ubuntu-26.04\", \"ubuntu-26.04-arm\", \"ubuntu-24.04\", \"ubuntu-24.04-arm\", \"ubuntu-22.04\", \"ubuntu-22.04-arm\", \"xcode-27\", \"xcode-27-xlarge\", \"macos-latest\", \"macos-latest-xlarge\", \"macos-latest-large\", \"macos-26-intel\", \"macos-26-xlarge\", \"macos-26-large\", \"macos-26\", \"macos-15-intel\", \"macos-15-xlarge\", \"macos-15-large\", \"macos-15\", \"macos-14-xlarge\", \"macos-14-large\", \"macos-14\", \"self-hosted\", \"x64\", \"arm\", \"arm64\", \"linux\", \"macos\", \"windows\". if it is a custom label for self-hosted runner, set list of labels in actionlint.yaml config file [runner-label]",
+        "<stdin>:386:13: label \"macos-12\" is unknown. available labels are \"windows-latest\", \"windows-latest-8-cores\", \"windows-2025\", \"windows-2025-vs2026\", \"windows-2022\", \"windows-11-arm\", \"windows-11-vs2026-arm\", \"ubuntu-slim\", \"ubuntu-latest\", \"ubuntu-latest-4-cores\", \"ubuntu-latest-8-cores\", \"ubuntu-latest-16-cores\", \"ubuntu-26.04\", \"ubuntu-26.04-arm\", \"ubuntu-24.04\", \"ubuntu-24.04-arm\", \"ubuntu-22.04\", \"ubuntu-22.04-arm\", \"xcode-27\", \"xcode-27-xlarge\", \"macos-latest\", \"macos-latest-xlarge\", \"macos-latest-large\", \"macos-26-intel\", \"macos-26-xlarge\", \"macos-26-large\", \"macos-26\", \"macos-15-intel\", \"macos-15-xlarge\", \"macos-15-large\", \"macos-15\", \"macos-14-xlarge\", \"macos-14-large\", \"macos-14\", \"self-hosted\", \"x64\", \"arm\", \"arm64\", \"linux\", \"macos\", \"windows\". if it is a custom label for self-hosted runner, set list of labels in actionlint.yaml config file [runner-label]",
+        "<stdin>:387:13: label \"macos-11\" is unknown. available labels are \"windows-latest\", \"windows-latest-8-cores\", \"windows-2025\", \"windows-2025-vs2026\", \"windows-2022\", \"windows-11-arm\", \"windows-11-vs2026-arm\", \"ubuntu-slim\", \"ubuntu-latest\", \"ubuntu-latest-4-cores\", \"ubuntu-latest-8-cores\", \"ubuntu-latest-16-cores\", \"ubuntu-26.04\", \"ubuntu-26.04-arm\", \"ubuntu-24.04\", \"ubuntu-24.04-arm\", \"ubuntu-22.04\", \"ubuntu-22.04-arm\", \"xcode-27\", \"xcode-27-xlarge\", \"macos-latest\", \"macos-latest-xlarge\", \"macos-latest-large\", \"macos-26-intel\", \"macos-26-xlarge\", \"macos-26-large\", \"macos-26\", \"macos-15-intel\", \"macos-15-xlarge\", \"macos-15-large\", \"macos-15\", \"macos-14-xlarge\", \"macos-14-large\", \"macos-14\", \"self-hosted\", \"x64\", \"arm\", \"arm64\", \"linux\", \"macos\", \"windows\". if it is a custom label for self-hosted runner, set list of labels in actionlint.yaml config file [runner-label]",
+        "<stdin>:410:15: the runtime or service used by \"actions/checkout@v2\" action is retired on GitHub.com. update the action's version to fix this issue [action]",
+        "<stdin>:415:15: the runtime or service used by \"actions/download-artifact@v2\" action is retired on GitHub.com. update the action's version to fix this issue [action]",
+        "<stdin>:422:15: the runtime or service used by \"actions/setup-python@v4\" action is retired on GitHub.com. update the action's version to fix this issue [action]",
+        "<stdin>:429:14: workflow command \"set-output\" was deprecated. use `echo \"{name}={value}\" >> $GITHUB_OUTPUT` instead: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions [deprecated-commands]",
+        "<stdin>:436:15: the runtime or service used by \"actions/cache@v2\" action is retired on GitHub.com. update the action's version to fix this issue [action]",
+        "<stdin>:478:15: the runtime or service used by \"codecov/codecov-action@v3\" action is retired on GitHub.com. update the action's version to fix this issue [action]",
+        "<stdin>:523:15: the runtime or service used by \"actions/download-artifact@v2\" action is retired on GitHub.com. update the action's version to fix this issue [action]",
+        "<stdin>:551:15: the runtime or service used by \"actions/download-artifact@v2\" action is retired on GitHub.com. update the action's version to fix this issue [action]",
+        "<stdin>:560:11: avoid using deprecated input \"repository_url\" in action \"pypa/gh-action-pypi-publish@release/v1\": The inputs have been normalized to use kebab-case. Use `repository-url` instead [action]",
+        "<stdin>:573:15: the runtime or service used by \"actions/checkout@v2\" action is retired on GitHub.com. update the action's version to fix this issue [action]",
+        "<stdin>:610:15: the runtime or service used by \"actions/download-artifact@v2\" action is retired on GitHub.com. update the action's version to fix this issue [action]"
+      ]
+    }
+  },
+  {
+    "reason": "Schema versus lint contract: this schema-valid example triggers additional actionlint checks (action, events). The exact diagnostics are retained for review; schema acceptance alone does not establish runtime validity.",
+    "cases": {
+      "schemastore/src/test/github-workflow/918.yaml": [
+        "<stdin>:5:5: \"tags\" filter is not available for create event. it is only for push event [events]",
+        "<stdin>:11:15: the runtime or service used by \"actions/checkout@v1\" action is retired on GitHub.com. update the action's version to fix this issue [action]",
+        "<stdin>:12:15: the runtime or service used by \"actions/setup-node@v1\" action is retired on GitHub.com. update the action's version to fix this issue [action]",
+        "<stdin>:21:15: the runtime or service used by \"actions/checkout@v1\" action is retired on GitHub.com. update the action's version to fix this issue [action]",
+        "<stdin>:22:15: the runtime or service used by \"actions/setup-node@v1\" action is retired on GitHub.com. update the action's version to fix this issue [action]"
+      ],
+      "schemastore/src/test/github-workflow/event-trigger.yaml": [
+        "<stdin>:11:13: scheduled job runs too frequently. it runs once per 60 seconds. the shortest interval is once every 5 minutes [events]",
+        "<stdin>:12:13: scheduled job runs too frequently. it runs once per 60 seconds. the shortest interval is once every 5 minutes [events]",
+        "<stdin>:13:13: scheduled job runs too frequently. it runs once per 60 seconds. the shortest interval is once every 5 minutes [events]",
+        "<stdin>:14:13: scheduled job runs too frequently. it runs once per 60 seconds. the shortest interval is once every 5 minutes [events]",
+        "<stdin>:21:15: the runtime or service used by \"actions/checkout@v1\" action is retired on GitHub.com. update the action's version to fix this issue [action]",
+        "<stdin>:22:15: the runtime or service used by \"actions/setup-node@v1\" action is retired on GitHub.com. update the action's version to fix this issue [action]"
+      ]
+    }
+  },
+  {
+    "reason": "Schema versus lint contract: this schema-valid example triggers additional actionlint checks (action, expression). The exact diagnostics are retained for review; schema acceptance alone does not establish runtime validity.",
+    "cases": {
+      "schemastore/src/test/github-workflow/matrix_from_json.yaml": [
+        "<stdin>:11:27: property \"job1\" is not defined in object type {} [expression]",
+        "<stdin>:13:15: the runtime or service used by \"actions/checkout@v1\" action is retired on GitHub.com. update the action's version to fix this issue [action]",
+        "<stdin>:14:15: the runtime or service used by \"actions/setup-node@v1\" action is retired on GitHub.com. update the action's version to fix this issue [action]"
+      ],
+      "schemastore/src/test/github-workflow/matrix_include.yaml": [
+        "<stdin>:25:15: the runtime or service used by \"actions/checkout@v1\" action is retired on GitHub.com. update the action's version to fix this issue [action]",
+        "<stdin>:26:15: the runtime or service used by \"actions/setup-node@v1\" action is retired on GitHub.com. update the action's version to fix this issue [action]",
+        "<stdin>:28:29: property \"node-version\" is not defined in object type {experimental: bool; node: number; os: string} [expression]"
+      ],
+      "schemastore/src/test/github-workflow/matrix_include_expression.yaml": [
+        "<stdin>:12:32: property \"job1\" is not defined in object type {} [expression]",
+        "<stdin>:15:15: the runtime or service used by \"actions/checkout@v1\" action is retired on GitHub.com. update the action's version to fix this issue [action]",
+        "<stdin>:16:15: the runtime or service used by \"actions/setup-node@v1\" action is retired on GitHub.com. update the action's version to fix this issue [action]"
+      ],
+      "schemastore/src/test/github-workflow/workflow_call_input_issue_2501.yaml": [
+        "<stdin>:33:15: the runtime or service used by \"actions/labeler@v4\" action is retired on GitHub.com. update the action's version to fix this issue [action]",
+        "<stdin>:36:35: property \"config-path\" is not defined in object type {aws_env: string; aws_region: string; terraform_command: string; terraform_version: string; working_directory: string} [expression]"
+      ]
+    }
+  },
+  {
+    "reason": "Schema versus lint contract: this schema-valid example triggers additional actionlint checks (action, if-cond). The exact diagnostics are retained for review; schema acceptance alone does not establish runtime validity.",
+    "cases": {
+      "schemastore/src/test/github-workflow/conditions.yaml": [
+        "<stdin>:8:9: constant expression \"false\" in condition. remove the if: section [if-cond]",
+        "<stdin>:10:15: the runtime or service used by \"actions/checkout@v2\" action is retired on GitHub.com. update the action's version to fix this issue [action]",
+        "<stdin>:11:13: constant expression \"false\" in condition. remove the if: section [if-cond]",
+        "<stdin>:14:9: constant expression \"0\" in condition. remove the if: section [if-cond]",
+        "<stdin>:16:15: the runtime or service used by \"actions/checkout@v2\" action is retired on GitHub.com. update the action's version to fix this issue [action]",
+        "<stdin>:17:13: constant expression \"0\" in condition. remove the if: section [if-cond]",
+        "<stdin>:22:15: the runtime or service used by \"actions/checkout@v2\" action is retired on GitHub.com. update the action's version to fix this issue [action]",
+        "<stdin>:26:9: constant expression \"false\" in condition. remove the if: section [if-cond]",
+        "<stdin>:29:9: constant expression \"0\" in condition. remove the if: section [if-cond]"
+      ]
+    }
+  },
+  {
+    "reason": "Schema versus lint contract: this schema-valid example triggers additional actionlint checks (action, runner-label). The exact diagnostics are retained for review; schema acceptance alone does not establish runtime validity.",
+    "cases": {
+      "schemastore/src/test/github-workflow/2579-1.yaml": [
+        "<stdin>:8:15: label \"ubuntu-20.04-16core\" is unknown. available labels are \"windows-latest\", \"windows-latest-8-cores\", \"windows-2025\", \"windows-2025-vs2026\", \"windows-2022\", \"windows-11-arm\", \"windows-11-vs2026-arm\", \"ubuntu-slim\", \"ubuntu-latest\", \"ubuntu-latest-4-cores\", \"ubuntu-latest-8-cores\", \"ubuntu-latest-16-cores\", \"ubuntu-26.04\", \"ubuntu-26.04-arm\", \"ubuntu-24.04\", \"ubuntu-24.04-arm\", \"ubuntu-22.04\", \"ubuntu-22.04-arm\", \"xcode-27\", \"xcode-27-xlarge\", \"macos-latest\", \"macos-latest-xlarge\", \"macos-latest-large\", \"macos-26-intel\", \"macos-26-xlarge\", \"macos-26-large\", \"macos-26\", \"macos-15-intel\", \"macos-15-xlarge\", \"macos-15-large\", \"macos-15\", \"macos-14-xlarge\", \"macos-14-large\", \"macos-14\", \"self-hosted\", \"x64\", \"arm\", \"arm64\", \"linux\", \"macos\", \"windows\". if it is a custom label for self-hosted runner, set list of labels in actionlint.yaml config file [runner-label]",
+        "<stdin>:10:15: the runtime or service used by \"actions/checkout@v3\" action is retired on GitHub.com. update the action's version to fix this issue [action]",
+        "<stdin>:11:15: the runtime or service used by \"actions/setup-node@v3\" action is retired on GitHub.com. update the action's version to fix this issue [action]"
+      ]
+    }
+  },
+  {
+    "reason": "Schema versus lint contract: this schema-valid example triggers additional actionlint checks (action, syntax-check). The exact diagnostics are retained for review; schema acceptance alone does not establish runtime validity.",
+    "cases": {
+      "schemastore/src/test/github-workflow/with-from-json.yaml": [
+        "<stdin>:11:15: the runtime or service used by \"actions/checkout@v1\" action is retired on GitHub.com. update the action's version to fix this issue [action]",
+        "<stdin>:12:15: the runtime or service used by \"actions/setup-node@v1\" action is retired on GitHub.com. update the action's version to fix this issue [action]",
+        "<stdin>:13:15: \"with\" section is scalar node but mapping node is expected [syntax-check]"
+      ]
+    }
+  },
+  {
+    "reason": "Schema versus lint contract: this schema-valid example triggers additional actionlint checks (events, runner-label). The exact diagnostics are retained for review; schema acceptance alone does not establish runtime validity.",
+    "cases": {
+      "schemastore/src/test/github-workflow/runs-on.yaml": [
+        "<stdin>:11:13: scheduled job runs too frequently. it runs once per 60 seconds. the shortest interval is once every 5 minutes [events]",
+        "<stdin>:14:13: scheduled job runs too frequently. it runs once per 60 seconds. the shortest interval is once every 5 minutes [events]",
+        "<stdin>:37:14: label \"ubuntu-20.04\" is unknown. available labels are \"windows-latest\", \"windows-latest-8-cores\", \"windows-2025\", \"windows-2025-vs2026\", \"windows-2022\", \"windows-11-arm\", \"windows-11-vs2026-arm\", \"ubuntu-slim\", \"ubuntu-latest\", \"ubuntu-latest-4-cores\", \"ubuntu-latest-8-cores\", \"ubuntu-latest-16-cores\", \"ubuntu-26.04\", \"ubuntu-26.04-arm\", \"ubuntu-24.04\", \"ubuntu-24.04-arm\", \"ubuntu-22.04\", \"ubuntu-22.04-arm\", \"xcode-27\", \"xcode-27-xlarge\", \"macos-latest\", \"macos-latest-xlarge\", \"macos-latest-large\", \"macos-26-intel\", \"macos-26-xlarge\", \"macos-26-large\", \"macos-26\", \"macos-15-intel\", \"macos-15-xlarge\", \"macos-15-large\", \"macos-15\", \"macos-14-xlarge\", \"macos-14-large\", \"macos-14\", \"self-hosted\", \"x64\", \"arm\", \"arm64\", \"linux\", \"macos\", \"windows\". if it is a custom label for self-hosted runner, set list of labels in actionlint.yaml config file [runner-label]",
+        "<stdin>:41:14: label \"ubuntu-18.04\" is unknown. available labels are \"windows-latest\", \"windows-latest-8-cores\", \"windows-2025\", \"windows-2025-vs2026\", \"windows-2022\", \"windows-11-arm\", \"windows-11-vs2026-arm\", \"ubuntu-slim\", \"ubuntu-latest\", \"ubuntu-latest-4-cores\", \"ubuntu-latest-8-cores\", \"ubuntu-latest-16-cores\", \"ubuntu-26.04\", \"ubuntu-26.04-arm\", \"ubuntu-24.04\", \"ubuntu-24.04-arm\", \"ubuntu-22.04\", \"ubuntu-22.04-arm\", \"xcode-27\", \"xcode-27-xlarge\", \"macos-latest\", \"macos-latest-xlarge\", \"macos-latest-large\", \"macos-26-intel\", \"macos-26-xlarge\", \"macos-26-large\", \"macos-26\", \"macos-15-intel\", \"macos-15-xlarge\", \"macos-15-large\", \"macos-15\", \"macos-14-xlarge\", \"macos-14-large\", \"macos-14\", \"self-hosted\", \"x64\", \"arm\", \"arm64\", \"linux\", \"macos\", \"windows\". if it is a custom label for self-hosted runner, set list of labels in actionlint.yaml config file [runner-label]",
+        "<stdin>:49:14: label \"macos-10.15\" is unknown. available labels are \"windows-latest\", \"windows-latest-8-cores\", \"windows-2025\", \"windows-2025-vs2026\", \"windows-2022\", \"windows-11-arm\", \"windows-11-vs2026-arm\", \"ubuntu-slim\", \"ubuntu-latest\", \"ubuntu-latest-4-cores\", \"ubuntu-latest-8-cores\", \"ubuntu-latest-16-cores\", \"ubuntu-26.04\", \"ubuntu-26.04-arm\", \"ubuntu-24.04\", \"ubuntu-24.04-arm\", \"ubuntu-22.04\", \"ubuntu-22.04-arm\", \"xcode-27\", \"xcode-27-xlarge\", \"macos-latest\", \"macos-latest-xlarge\", \"macos-latest-large\", \"macos-26-intel\", \"macos-26-xlarge\", \"macos-26-large\", \"macos-26\", \"macos-15-intel\", \"macos-15-xlarge\", \"macos-15-large\", \"macos-15\", \"macos-14-xlarge\", \"macos-14-large\", \"macos-14\", \"self-hosted\", \"x64\", \"arm\", \"arm64\", \"linux\", \"macos\", \"windows\". if it is a custom label for self-hosted runner, set list of labels in actionlint.yaml config file [runner-label]",
+        "<stdin>:53:14: label \"macos-11\" is unknown. available labels are \"windows-latest\", \"windows-latest-8-cores\", \"windows-2025\", \"windows-2025-vs2026\", \"windows-2022\", \"windows-11-arm\", \"windows-11-vs2026-arm\", \"ubuntu-slim\", \"ubuntu-latest\", \"ubuntu-latest-4-cores\", \"ubuntu-latest-8-cores\", \"ubuntu-latest-16-cores\", \"ubuntu-26.04\", \"ubuntu-26.04-arm\", \"ubuntu-24.04\", \"ubuntu-24.04-arm\", \"ubuntu-22.04\", \"ubuntu-22.04-arm\", \"xcode-27\", \"xcode-27-xlarge\", \"macos-latest\", \"macos-latest-xlarge\", \"macos-latest-large\", \"macos-26-intel\", \"macos-26-xlarge\", \"macos-26-large\", \"macos-26\", \"macos-15-intel\", \"macos-15-xlarge\", \"macos-15-large\", \"macos-15\", \"macos-14-xlarge\", \"macos-14-large\", \"macos-14\", \"self-hosted\", \"x64\", \"arm\", \"arm64\", \"linux\", \"macos\", \"windows\". if it is a custom label for self-hosted runner, set list of labels in actionlint.yaml config file [runner-label]",
+        "<stdin>:69:14: label \"windows-2019\" is unknown. available labels are \"windows-latest\", \"windows-latest-8-cores\", \"windows-2025\", \"windows-2025-vs2026\", \"windows-2022\", \"windows-11-arm\", \"windows-11-vs2026-arm\", \"ubuntu-slim\", \"ubuntu-latest\", \"ubuntu-latest-4-cores\", \"ubuntu-latest-8-cores\", \"ubuntu-latest-16-cores\", \"ubuntu-26.04\", \"ubuntu-26.04-arm\", \"ubuntu-24.04\", \"ubuntu-24.04-arm\", \"ubuntu-22.04\", \"ubuntu-22.04-arm\", \"xcode-27\", \"xcode-27-xlarge\", \"macos-latest\", \"macos-latest-xlarge\", \"macos-latest-large\", \"macos-26-intel\", \"macos-26-xlarge\", \"macos-26-large\", \"macos-26\", \"macos-15-intel\", \"macos-15-xlarge\", \"macos-15-large\", \"macos-15\", \"macos-14-xlarge\", \"macos-14-large\", \"macos-14\", \"self-hosted\", \"x64\", \"arm\", \"arm64\", \"linux\", \"macos\", \"windows\". if it is a custom label for self-hosted runner, set list of labels in actionlint.yaml config file [runner-label]",
+        "<stdin>:77:13: label \"ubuntu-20.04\" is unknown. available labels are \"windows-latest\", \"windows-latest-8-cores\", \"windows-2025\", \"windows-2025-vs2026\", \"windows-2022\", \"windows-11-arm\", \"windows-11-vs2026-arm\", \"ubuntu-slim\", \"ubuntu-latest\", \"ubuntu-latest-4-cores\", \"ubuntu-latest-8-cores\", \"ubuntu-latest-16-cores\", \"ubuntu-26.04\", \"ubuntu-26.04-arm\", \"ubuntu-24.04\", \"ubuntu-24.04-arm\", \"ubuntu-22.04\", \"ubuntu-22.04-arm\", \"xcode-27\", \"xcode-27-xlarge\", \"macos-latest\", \"macos-latest-xlarge\", \"macos-latest-large\", \"macos-26-intel\", \"macos-26-xlarge\", \"macos-26-large\", \"macos-26\", \"macos-15-intel\", \"macos-15-xlarge\", \"macos-15-large\", \"macos-15\", \"macos-14-xlarge\", \"macos-14-large\", \"macos-14\", \"self-hosted\", \"x64\", \"arm\", \"arm64\", \"linux\", \"macos\", \"windows\". if it is a custom label for self-hosted runner, set list of labels in actionlint.yaml config file [runner-label]",
+        "<stdin>:78:13: label \"ubuntu-18.04\" is unknown. available labels are \"windows-latest\", \"windows-latest-8-cores\", \"windows-2025\", \"windows-2025-vs2026\", \"windows-2022\", \"windows-11-arm\", \"windows-11-vs2026-arm\", \"ubuntu-slim\", \"ubuntu-latest\", \"ubuntu-latest-4-cores\", \"ubuntu-latest-8-cores\", \"ubuntu-latest-16-cores\", \"ubuntu-26.04\", \"ubuntu-26.04-arm\", \"ubuntu-24.04\", \"ubuntu-24.04-arm\", \"ubuntu-22.04\", \"ubuntu-22.04-arm\", \"xcode-27\", \"xcode-27-xlarge\", \"macos-latest\", \"macos-latest-xlarge\", \"macos-latest-large\", \"macos-26-intel\", \"macos-26-xlarge\", \"macos-26-large\", \"macos-26\", \"macos-15-intel\", \"macos-15-xlarge\", \"macos-15-large\", \"macos-15\", \"macos-14-xlarge\", \"macos-14-large\", \"macos-14\", \"self-hosted\", \"x64\", \"arm\", \"arm64\", \"linux\", \"macos\", \"windows\". if it is a custom label for self-hosted runner, set list of labels in actionlint.yaml config file [runner-label]",
+        "<stdin>:112:9: label \"x86\" is unknown. available labels are \"windows-latest\", \"windows-latest-8-cores\", \"windows-2025\", \"windows-2025-vs2026\", \"windows-2022\", \"windows-11-arm\", \"windows-11-vs2026-arm\", \"ubuntu-slim\", \"ubuntu-latest\", \"ubuntu-latest-4-cores\", \"ubuntu-latest-8-cores\", \"ubuntu-latest-16-cores\", \"ubuntu-26.04\", \"ubuntu-26.04-arm\", \"ubuntu-24.04\", \"ubuntu-24.04-arm\", \"ubuntu-22.04\", \"ubuntu-22.04-arm\", \"xcode-27\", \"xcode-27-xlarge\", \"macos-latest\", \"macos-latest-xlarge\", \"macos-latest-large\", \"macos-26-intel\", \"macos-26-xlarge\", \"macos-26-large\", \"macos-26\", \"macos-15-intel\", \"macos-15-xlarge\", \"macos-15-large\", \"macos-15\", \"macos-14-xlarge\", \"macos-14-large\", \"macos-14\", \"self-hosted\", \"x64\", \"arm\", \"arm64\", \"linux\", \"macos\", \"windows\". if it is a custom label for self-hosted runner, set list of labels in actionlint.yaml config file [runner-label]",
+        "<stdin>:114:9: label \"gpu\" is unknown. available labels are \"windows-latest\", \"windows-latest-8-cores\", \"windows-2025\", \"windows-2025-vs2026\", \"windows-2022\", \"windows-11-arm\", \"windows-11-vs2026-arm\", \"ubuntu-slim\", \"ubuntu-latest\", \"ubuntu-latest-4-cores\", \"ubuntu-latest-8-cores\", \"ubuntu-latest-16-cores\", \"ubuntu-26.04\", \"ubuntu-26.04-arm\", \"ubuntu-24.04\", \"ubuntu-24.04-arm\", \"ubuntu-22.04\", \"ubuntu-22.04-arm\", \"xcode-27\", \"xcode-27-xlarge\", \"macos-latest\", \"macos-latest-xlarge\", \"macos-latest-large\", \"macos-26-intel\", \"macos-26-xlarge\", \"macos-26-large\", \"macos-26\", \"macos-15-intel\", \"macos-15-xlarge\", \"macos-15-large\", \"macos-15\", \"macos-14-xlarge\", \"macos-14-large\", \"macos-14\", \"self-hosted\", \"x64\", \"arm\", \"arm64\", \"linux\", \"macos\", \"windows\". if it is a custom label for self-hosted runner, set list of labels in actionlint.yaml config file [runner-label]",
+        "<stdin>:115:9: label \"large\" is unknown. available labels are \"windows-latest\", \"windows-latest-8-cores\", \"windows-2025\", \"windows-2025-vs2026\", \"windows-2022\", \"windows-11-arm\", \"windows-11-vs2026-arm\", \"ubuntu-slim\", \"ubuntu-latest\", \"ubuntu-latest-4-cores\", \"ubuntu-latest-8-cores\", \"ubuntu-latest-16-cores\", \"ubuntu-26.04\", \"ubuntu-26.04-arm\", \"ubuntu-24.04\", \"ubuntu-24.04-arm\", \"ubuntu-22.04\", \"ubuntu-22.04-arm\", \"xcode-27\", \"xcode-27-xlarge\", \"macos-latest\", \"macos-latest-xlarge\", \"macos-latest-large\", \"macos-26-intel\", \"macos-26-xlarge\", \"macos-26-large\", \"macos-26\", \"macos-15-intel\", \"macos-15-xlarge\", \"macos-15-large\", \"macos-15\", \"macos-14-xlarge\", \"macos-14-large\", \"macos-14\", \"self-hosted\", \"x64\", \"arm\", \"arm64\", \"linux\", \"macos\", \"windows\". if it is a custom label for self-hosted runner, set list of labels in actionlint.yaml config file [runner-label]",
+        "<stdin>:121:9: label \"gpu\" is unknown. available labels are \"windows-latest\", \"windows-latest-8-cores\", \"windows-2025\", \"windows-2025-vs2026\", \"windows-2022\", \"windows-11-arm\", \"windows-11-vs2026-arm\", \"ubuntu-slim\", \"ubuntu-latest\", \"ubuntu-latest-4-cores\", \"ubuntu-latest-8-cores\", \"ubuntu-latest-16-cores\", \"ubuntu-26.04\", \"ubuntu-26.04-arm\", \"ubuntu-24.04\", \"ubuntu-24.04-arm\", \"ubuntu-22.04\", \"ubuntu-22.04-arm\", \"xcode-27\", \"xcode-27-xlarge\", \"macos-latest\", \"macos-latest-xlarge\", \"macos-latest-large\", \"macos-26-intel\", \"macos-26-xlarge\", \"macos-26-large\", \"macos-26\", \"macos-15-intel\", \"macos-15-xlarge\", \"macos-15-large\", \"macos-15\", \"macos-14-xlarge\", \"macos-14-large\", \"macos-14\", \"self-hosted\", \"x64\", \"arm\", \"arm64\", \"linux\", \"macos\", \"windows\". if it is a custom label for self-hosted runner, set list of labels in actionlint.yaml config file [runner-label]",
+        "<stdin>:122:9: label \"on-prem\" is unknown. available labels are \"windows-latest\", \"windows-latest-8-cores\", \"windows-2025\", \"windows-2025-vs2026\", \"windows-2022\", \"windows-11-arm\", \"windows-11-vs2026-arm\", \"ubuntu-slim\", \"ubuntu-latest\", \"ubuntu-latest-4-cores\", \"ubuntu-latest-8-cores\", \"ubuntu-latest-16-cores\", \"ubuntu-26.04\", \"ubuntu-26.04-arm\", \"ubuntu-24.04\", \"ubuntu-24.04-arm\", \"ubuntu-22.04\", \"ubuntu-22.04-arm\", \"xcode-27\", \"xcode-27-xlarge\", \"macos-latest\", \"macos-latest-xlarge\", \"macos-latest-large\", \"macos-26-intel\", \"macos-26-xlarge\", \"macos-26-large\", \"macos-26\", \"macos-15-intel\", \"macos-15-xlarge\", \"macos-15-large\", \"macos-15\", \"macos-14-xlarge\", \"macos-14-large\", \"macos-14\", \"self-hosted\", \"x64\", \"arm\", \"arm64\", \"linux\", \"macos\", \"windows\". if it is a custom label for self-hosted runner, set list of labels in actionlint.yaml config file [runner-label]"
+      ]
+    }
+  },
+  {
+    "reason": "Schema versus lint contract: this schema-valid example triggers additional actionlint checks (events, syntax-check). The exact diagnostics are retained for review; schema acceptance alone does not establish runtime validity.",
+    "cases": {
+      "schemastore/src/test/github-workflow/on-event_name-null.yaml": [
+        "<stdin>:18:3: unknown Webhook event \"project\". see https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#webhook-events for list of all Webhook event names [events]",
+        "<stdin>:19:3: unknown Webhook event \"project_card\". see https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#webhook-events for list of all Webhook event names [events]",
+        "<stdin>:20:3: unknown Webhook event \"project_column\". see https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#webhook-events for list of all Webhook event names [events]",
+        "<stdin>:33:3: no workflow is configured for \"workflow_run\" event [events]",
+        "<stdin>:39:14: string should not be empty [syntax-check]"
+      ]
+    }
+  },
+  {
+    "reason": "Schema versus lint contract: this schema-valid example triggers additional actionlint checks (expression). The exact diagnostics are retained for review; schema acceptance alone does not establish runtime validity.",
+    "cases": {
+      "schemastore/src/test/github-workflow/defaults.yaml": [
+        "<stdin>:16:20: property \"shell\" is not defined in object type {} [expression]"
+      ],
+      "schemastore/src/test/github-workflow/env-with-simple-expression.yaml": [
+        "<stdin>:15:14: type of expression at \"env\" must be object but found type string [expression]"
+      ]
+    }
+  },
+  {
+    "reason": "Schema versus lint contract: this schema-valid example triggers additional actionlint checks (runner-label, syntax-check). The exact diagnostics are retained for review; schema acceptance alone does not establish runtime validity.",
+    "cases": {
+      "schemastore/src/test/github-workflow/2579-2.yaml": [
+        "<stdin>:5:3: \"steps\" section is missing in job \"check-bats-version\" [syntax-check]",
+        "<stdin>:8:29: label \"label-1\" is unknown. available labels are \"windows-latest\", \"windows-latest-8-cores\", \"windows-2025\", \"windows-2025-vs2026\", \"windows-2022\", \"windows-11-arm\", \"windows-11-vs2026-arm\", \"ubuntu-slim\", \"ubuntu-latest\", \"ubuntu-latest-4-cores\", \"ubuntu-latest-8-cores\", \"ubuntu-latest-16-cores\", \"ubuntu-26.04\", \"ubuntu-26.04-arm\", \"ubuntu-24.04\", \"ubuntu-24.04-arm\", \"ubuntu-22.04\", \"ubuntu-22.04-arm\", \"xcode-27\", \"xcode-27-xlarge\", \"macos-latest\", \"macos-latest-xlarge\", \"macos-latest-large\", \"macos-26-intel\", \"macos-26-xlarge\", \"macos-26-large\", \"macos-26\", \"macos-15-intel\", \"macos-15-xlarge\", \"macos-15-large\", \"macos-15\", \"macos-14-xlarge\", \"macos-14-large\", \"macos-14\", \"self-hosted\", \"x64\", \"arm\", \"arm64\", \"linux\", \"macos\", \"windows\". if it is a custom label for self-hosted runner, set list of labels in actionlint.yaml config file [runner-label]"
+      ],
+      "schemastore/src/test/github-workflow/issue-3208.yaml": [
+        "<stdin>:4:3: \"steps\" section is missing in job \"ci\" [syntax-check]",
+        "<stdin>:5:14: label \"unknown\" is unknown. available labels are \"windows-latest\", \"windows-latest-8-cores\", \"windows-2025\", \"windows-2025-vs2026\", \"windows-2022\", \"windows-11-arm\", \"windows-11-vs2026-arm\", \"ubuntu-slim\", \"ubuntu-latest\", \"ubuntu-latest-4-cores\", \"ubuntu-latest-8-cores\", \"ubuntu-latest-16-cores\", \"ubuntu-26.04\", \"ubuntu-26.04-arm\", \"ubuntu-24.04\", \"ubuntu-24.04-arm\", \"ubuntu-22.04\", \"ubuntu-22.04-arm\", \"xcode-27\", \"xcode-27-xlarge\", \"macos-latest\", \"macos-latest-xlarge\", \"macos-latest-large\", \"macos-26-intel\", \"macos-26-xlarge\", \"macos-26-large\", \"macos-26\", \"macos-15-intel\", \"macos-15-xlarge\", \"macos-15-large\", \"macos-15\", \"macos-14-xlarge\", \"macos-14-large\", \"macos-14\", \"self-hosted\", \"x64\", \"arm\", \"arm64\", \"linux\", \"macos\", \"windows\". if it is a custom label for self-hosted runner, set list of labels in actionlint.yaml config file [runner-label]"
+      ]
+    }
+  },
+  {
+    "reason": "Schema versus lint contract: this schema-valid example triggers additional actionlint checks (syntax-check). The exact diagnostics are retained for review; schema acceptance alone does not establish runtime validity.",
+    "cases": {
+      "schemastore/src/test/github-workflow/1162.yaml": [
+        "<stdin>:8:3: \"steps\" section is missing in job \"check_run\" [syntax-check]"
+      ],
+      "schemastore/src/test/github-workflow/concurrency.yaml": [
+        "<stdin>:7:3: \"steps\" section is missing in job \"build\" [syntax-check]",
+        "<stdin>:10:3: \"steps\" section is missing in job \"test\" [syntax-check]",
+        "<stdin>:21:14: string should not be empty [syntax-check]"
+      ],
+      "schemastore/src/test/github-workflow/containers.yaml": [
+        "<stdin>:6:3: \"steps\" section is missing in job \"build\" [syntax-check]",
+        "<stdin>:27:3: \"steps\" section is missing in job \"test\" [syntax-check]"
+      ],
+      "schemastore/src/test/github-workflow/environments.yaml": [
+        "<stdin>:6:3: \"steps\" section is missing in job \"build\" [syntax-check]",
+        "<stdin>:11:3: \"steps\" section is missing in job \"test\" [syntax-check]"
+      ],
+      "schemastore/src/test/github-workflow/fail-fast.yaml": [
+        "<stdin>:6:3: \"steps\" section is missing in job \"boolean\" [syntax-check]",
+        "<stdin>:14:3: \"steps\" section is missing in job \"non-boolean\" [syntax-check]"
+      ]
+    }
+  },
+  {
+    "reason": "Template gap: actionlint does not implement the reader insert directive. The fixture also references an undeclared step output.",
+    "cases": {
+      "languageservices/workflow-parser/testdata/reader/insert.yml": [
+        "<stdin>:6:23: property \"set-matrix\" is not defined in object type {} [expression]",
+        "<stdin>:13:11: undefined variable \"insert\". available variables are \"env\", \"github\", \"inputs\", \"job\", \"matrix\", \"needs\", \"runner\", \"secrets\", \"steps\", \"strategy\", \"vars\" [expression]"
+      ]
+    }
+  },
+  {
+    "reason": "Validation gap: actionlint does not check the organization/enterprise prefix of runs-on group names.",
+    "cases": {
+      "languageservices/workflow-parser/testdata/reader/errors-job-runs-on-group-invalid-prefix.yml": []
+    }
+  },
+  {
+    "reason": "Validation gap: the reader reserves job IDs beginning with two underscores; actionlint currently accepts them.",
+    "cases": {
+      "languageservices/workflow-parser/testdata/reader/errors-job-id-leading-underscores.yml": []
+    }
+  },
+  {
+    "reason": "Workflow-call validation gap: actionlint accepts the non-YAML filename that SchemaStore rejects.",
+    "cases": {
+      "schemastore/src/negative_test/github-workflow/reusable-workflow-uses-has-wrong-filetype.yaml": []
+    }
+  },
+  {
+    "reason": "YAML dependency difference: go.yaml accepts invalid YAML for \"Block scalar with more spaces than first content line\" according to YAML Test Suite. This is a YAML-stream test, not a GitHub workflow verdict.",
+    "cases": {
+      "yaml-test-suite/S98Z/in.yaml": []
+    }
+  },
+  {
+    "reason": "YAML dependency difference: go.yaml accepts invalid YAML for \"Comment without whitespace after block scalar indicator\" according to YAML Test Suite. This is a YAML-stream test, not a GitHub workflow verdict.",
+    "cases": {
+      "yaml-test-suite/X4QW/in.yaml": []
+    }
+  },
+  {
+    "reason": "YAML dependency difference: go.yaml accepts invalid YAML for \"Comment without whitespace after doublequoted scalar\" according to YAML Test Suite. This is a YAML-stream test, not a GitHub workflow verdict.",
+    "cases": {
+      "yaml-test-suite/SU5Z/in.yaml": []
+    }
+  },
+  {
+    "reason": "YAML dependency difference: go.yaml accepts invalid YAML for \"Dash in flow sequence\" according to YAML Test Suite. This is a YAML-stream test, not a GitHub workflow verdict.",
+    "cases": {
+      "yaml-test-suite/YJV2/in.yaml": []
+    }
+  },
+  {
+    "reason": "YAML dependency difference: go.yaml accepts invalid YAML for \"Directive variants\" according to YAML Test Suite. This is a YAML-stream test, not a GitHub workflow verdict.",
+    "cases": {
+      "yaml-test-suite/MUS6/00/in.yaml": []
+    }
+  },
+  {
+    "reason": "YAML dependency difference: go.yaml accepts invalid YAML for \"Double quoted scalar with escaped single quote\" according to YAML Test Suite. This is a YAML-stream test, not a GitHub workflow verdict.",
+    "cases": {
+      "yaml-test-suite/HRE5/in.yaml": []
+    }
+  },
+  {
+    "reason": "YAML dependency difference: go.yaml accepts invalid YAML for \"Invalid comment after comma\" according to YAML Test Suite. This is a YAML-stream test, not a GitHub workflow verdict.",
+    "cases": {
+      "yaml-test-suite/CVW2/in.yaml": []
+    }
+  },
+  {
+    "reason": "YAML dependency difference: go.yaml accepts invalid YAML for \"Invalid comment after end of flow sequence\" according to YAML Test Suite. This is a YAML-stream test, not a GitHub workflow verdict.",
+    "cases": {
+      "yaml-test-suite/9JBA/in.yaml": []
+    }
+  },
+  {
+    "reason": "YAML dependency difference: go.yaml accepts invalid YAML for \"Need document footer before directives\" according to YAML Test Suite. This is a YAML-stream test, not a GitHub workflow verdict.",
+    "cases": {
+      "yaml-test-suite/9HCY/in.yaml": []
+    }
+  },
+  {
+    "reason": "YAML dependency difference: go.yaml accepts invalid YAML for \"Plain dashes in flow sequence\" according to YAML Test Suite. This is a YAML-stream test, not a GitHub workflow verdict.",
+    "cases": {
+      "yaml-test-suite/G5U8/in.yaml": []
+    }
+  },
+  {
+    "reason": "YAML dependency difference: go.yaml accepts invalid YAML for \"Tabs in various contexts\" according to YAML Test Suite. This is a YAML-stream test, not a GitHub workflow verdict.",
+    "cases": {
+      "yaml-test-suite/Y79Y/003/in.yaml": []
+    }
+  },
+  {
+    "reason": "YAML dependency difference: go.yaml accepts invalid YAML for \"Tabs that look like indentation\" according to YAML Test Suite. This is a YAML-stream test, not a GitHub workflow verdict.",
+    "cases": {
+      "yaml-test-suite/DK95/01/in.yaml": []
+    }
+  },
+  {
+    "reason": "YAML dependency difference: go.yaml accepts invalid YAML for \"Wrong indented flow sequence\" according to YAML Test Suite. This is a YAML-stream test, not a GitHub workflow verdict.",
+    "cases": {
+      "yaml-test-suite/9C9N/in.yaml": []
+    }
+  },
+  {
+    "reason": "YAML dependency difference: go.yaml accepts invalid YAML for \"Wrong indented multiline quoted scalar\" according to YAML Test Suite. This is a YAML-stream test, not a GitHub workflow verdict.",
+    "cases": {
+      "yaml-test-suite/QB6E/in.yaml": []
+    }
+  },
+  {
+    "reason": "YAML dependency difference: go.yaml rejects valid YAML for \"Aliases in Explicit Block Mapping\" according to YAML Test Suite. This is a YAML-stream test, not a GitHub workflow verdict.",
+    "cases": {
+      "yaml-test-suite/6M2F/in.yaml": [
+        "go-yaml load error in parser (while parsing a block mapping) at L1.C1-L3.C1: did not find expected key"
+      ]
+    }
+  },
+  {
+    "reason": "YAML dependency difference: go.yaml rejects valid YAML for \"Allowed characters in alias\" according to YAML Test Suite. This is a YAML-stream test, not a GitHub workflow verdict.",
+    "cases": {
+      "yaml-test-suite/W5VH/in.yaml": [
+        "go-yaml load error in scanner (while scanning an anchor) at L1.C4-C5: did not find expected alphabetic or numeric character"
+      ]
+    }
+  },
+  {
+    "reason": "YAML dependency difference: go.yaml rejects valid YAML for \"Anchor with unicode character\" according to YAML Test Suite. This is a YAML-stream test, not a GitHub workflow verdict.",
+    "cases": {
+      "yaml-test-suite/8XYN/in.yaml": [
+        "go-yaml load error in scanner (while scanning an anchor) at L2.C3-C4: did not find expected alphabetic or numeric character"
+      ]
+    }
+  },
+  {
+    "reason": "YAML dependency difference: go.yaml rejects valid YAML for \"Anchors With Colon in Name\" according to YAML Test Suite. This is a YAML-stream test, not a GitHub workflow verdict.",
+    "cases": {
+      "yaml-test-suite/2SXE/in.yaml": [
+        "go-yaml load error in scanner at L1.C8: mapping values are not allowed in this context"
+      ]
+    }
+  },
+  {
+    "reason": "YAML dependency difference: go.yaml rejects valid YAML for \"Bare document after document end marker\" according to YAML Test Suite. This is a YAML-stream test, not a GitHub workflow verdict.",
+    "cases": {
+      "yaml-test-suite/7Z25/in.yaml": [
+        "go-yaml load error in parser at L4.C1: did not find expected <document start>"
+      ]
+    }
+  },
+  {
+    "reason": "YAML dependency difference: go.yaml rejects valid YAML for \"Block Mapping with Missing Keys\" according to YAML Test Suite. This is a YAML-stream test, not a GitHub workflow verdict.",
+    "cases": {
+      "yaml-test-suite/2JQS/in.yaml": [
+        "go-yaml load error in parser (while parsing a block mapping) at L1.C1: did not find expected key"
+      ]
+    }
+  },
+  {
+    "reason": "YAML dependency difference: go.yaml rejects valid YAML for \"Colon and adjacent value after comment on next line\" according to YAML Test Suite. This is a YAML-stream test, not a GitHub workflow verdict.",
+    "cases": {
+      "yaml-test-suite/K3WX/in.yaml": [
+        "go-yaml load error in parser (while parsing a flow mapping) at L2.C1-L3.C3: did not find expected ',' or '}'"
+      ]
+    }
+  },
+  {
+    "reason": "YAML dependency difference: go.yaml rejects valid YAML for \"Colon and adjacent value on next line\" according to YAML Test Suite. This is a YAML-stream test, not a GitHub workflow verdict.",
+    "cases": {
+      "yaml-test-suite/5MUD/in.yaml": [
+        "go-yaml load error in parser (while parsing a flow mapping) at L2.C1-L3.C3: did not find expected ',' or '}'"
+      ]
+    }
+  },
+  {
+    "reason": "YAML dependency difference: go.yaml rejects valid YAML for \"Colon at the beginning of adjacent flow scalar\" according to YAML Test Suite. This is a YAML-stream test, not a GitHub workflow verdict.",
+    "cases": {
+      "yaml-test-suite/5T43/in.yaml": [
+        "go-yaml load error in parser (while parsing a flow node) at L2.C11: did not find expected node content"
+      ]
+    }
+  },
+  {
+    "reason": "YAML dependency difference: go.yaml rejects valid YAML for \"Directive variants\" according to YAML Test Suite. This is a YAML-stream test, not a GitHub workflow verdict.",
+    "cases": {
+      "yaml-test-suite/MUS6/05/in.yaml": [
+        "go-yaml load error in scanner (while scanning a directive) at L1.C1-C5: found unknown directive name"
+      ],
+      "yaml-test-suite/MUS6/06/in.yaml": [
+        "go-yaml load error in scanner (while scanning a directive) at L1.C1-C7: found unknown directive name"
+      ]
+    }
+  },
+  {
+    "reason": "YAML dependency difference: go.yaml rejects valid YAML for \"Empty Lines at End of Document\" according to YAML Test Suite. This is a YAML-stream test, not a GitHub workflow verdict.",
+    "cases": {
+      "yaml-test-suite/NHX8/in.yaml": [
+        "go-yaml load error in parser (while parsing a block mapping) at L1.C1: did not find expected key"
+      ]
+    }
+  },
+  {
+    "reason": "YAML dependency difference: go.yaml rejects valid YAML for \"Empty implicit key in single pair flow sequences\" according to YAML Test Suite. This is a YAML-stream test, not a GitHub workflow verdict.",
+    "cases": {
+      "yaml-test-suite/CFD4/in.yaml": [
+        "go-yaml load error in parser (while parsing a flow node) at L1.C5: did not find expected node content"
+      ]
+    }
+  },
+  {
+    "reason": "YAML dependency difference: go.yaml rejects valid YAML for \"Empty keys in block and flow mapping\" according to YAML Test Suite. This is a YAML-stream test, not a GitHub workflow verdict.",
+    "cases": {
+      "yaml-test-suite/NKF9/in.yaml": [
+        "go-yaml load error in parser (while parsing a block mapping) at L2.C1-L3.C1: did not find expected key"
+      ]
+    }
+  },
+  {
+    "reason": "YAML dependency difference: go.yaml rejects valid YAML for \"Escaped slash in double quotes\" according to YAML Test Suite. This is a YAML-stream test, not a GitHub workflow verdict.",
+    "cases": {
+      "yaml-test-suite/3UYS/in.yaml": [
+        "go-yaml load error in scanner (while scanning a quoted scalar) at L1.C16-C18: found unknown escape character"
+      ]
+    }
+  },
+  {
+    "reason": "YAML dependency difference: go.yaml rejects valid YAML for \"Flow collections over many lines\" according to YAML Test Suite. This is a YAML-stream test, not a GitHub workflow verdict.",
+    "cases": {
+      "yaml-test-suite/VJP3/01/in.yaml": [
+        "go-yaml load error in parser (while parsing a flow mapping) at L1.C4-L3.C2: did not find expected ',' or '}'"
+      ]
+    }
+  },
+  {
+    "reason": "YAML dependency difference: go.yaml rejects valid YAML for \"Flow mapping colon on line after key\" according to YAML Test Suite. This is a YAML-stream test, not a GitHub workflow verdict.",
+    "cases": {
+      "yaml-test-suite/4MUZ/00/in.yaml": [
+        "go-yaml load error in parser (while parsing a flow mapping) at L1.C1-L2.C1: did not find expected ',' or '}'"
+      ],
+      "yaml-test-suite/4MUZ/01/in.yaml": [
+        "go-yaml load error in parser (while parsing a flow mapping) at L1.C1-L2.C1: did not find expected ',' or '}'"
+      ],
+      "yaml-test-suite/4MUZ/02/in.yaml": [
+        "go-yaml load error in parser (while parsing a flow mapping) at L1.C1-L2.C1: did not find expected ',' or '}'"
+      ]
+    }
+  },
+  {
+    "reason": "YAML dependency difference: go.yaml rejects valid YAML for \"Flow mapping edge cases\" according to YAML Test Suite. This is a YAML-stream test, not a GitHub workflow verdict.",
+    "cases": {
+      "yaml-test-suite/58MP/in.yaml": [
+        "go-yaml load error in parser (while parsing a flow node) at L1.C5: did not find expected node content"
+      ]
+    }
+  },
+  {
+    "reason": "YAML dependency difference: go.yaml rejects valid YAML for \"Leading tab content in literals\" according to YAML Test Suite. This is a YAML-stream test, not a GitHub workflow verdict.",
+    "cases": {
+      "yaml-test-suite/96NN/00/in.yaml": [
+        "go-yaml load error in scanner (while scanning a block scalar) at L1.C6-L2.C2: found a tab character where an indentation space is expected"
+      ],
+      "yaml-test-suite/96NN/01/in.yaml": [
+        "go-yaml load error in scanner (while scanning a block scalar) at L1.C6-L2.C2: found a tab character where an indentation space is expected"
+      ]
+    }
+  },
+  {
+    "reason": "YAML dependency difference: go.yaml rejects valid YAML for \"Multiline double quoted flow mapping key\" according to YAML Test Suite. This is a YAML-stream test, not a GitHub workflow verdict.",
+    "cases": {
+      "yaml-test-suite/9SA2/in.yaml": [
+        "go-yaml load error in parser (while parsing a flow mapping) at L3.C3-L4.C8: did not find expected ',' or '}'"
+      ]
+    }
+  },
+  {
+    "reason": "YAML dependency difference: go.yaml rejects valid YAML for \"Multiline plain flow mapping key\" according to YAML Test Suite. This is a YAML-stream test, not a GitHub workflow verdict.",
+    "cases": {
+      "yaml-test-suite/NJ66/in.yaml": [
+        "go-yaml load error in parser (while parsing a flow mapping) at L3.C3-L4.C7: did not find expected ',' or '}'"
+      ]
+    }
+  },
+  {
+    "reason": "YAML dependency difference: go.yaml rejects valid YAML for \"Question mark edge cases\" according to YAML Test Suite. This is a YAML-stream test, not a GitHub workflow verdict.",
+    "cases": {
+      "yaml-test-suite/M2N8/00/in.yaml": [
+        "go-yaml load error in parser (while parsing a block mapping) at L1.C5: did not find expected key"
+      ]
+    }
+  },
+  {
+    "reason": "YAML dependency difference: go.yaml rejects valid YAML for \"Question marks in scalars\" according to YAML Test Suite. This is a YAML-stream test, not a GitHub workflow verdict.",
+    "cases": {
+      "yaml-test-suite/JR7V/in.yaml": [
+        "go-yaml load error in parser (while parsing a flow sequence) at L5.C3-C12: did not find expected ',' or ']'"
+      ]
+    }
+  },
+  {
+    "reason": "YAML dependency difference: go.yaml rejects valid YAML for \"Single character streams\" according to YAML Test Suite. This is a YAML-stream test, not a GitHub workflow verdict.",
+    "cases": {
+      "yaml-test-suite/SM9W/01/in.yaml": [
+        "go-yaml load error in parser (while parsing a block mapping) at L1.C1: did not find expected key"
+      ]
+    }
+  },
+  {
+    "reason": "YAML dependency difference: go.yaml rejects valid YAML for \"Spec Example 5.9. Directive Indicator\" according to YAML Test Suite. This is a YAML-stream test, not a GitHub workflow verdict.",
+    "cases": {
+      "yaml-test-suite/27NA/in.yaml": [
+        "go-yaml load error in parser at L1.C1: found incompatible YAML document"
+      ]
+    }
+  },
+  {
+    "reason": "YAML dependency difference: go.yaml rejects valid YAML for \"Spec Example 6.13. Reserved Directives [1.3]\" according to YAML Test Suite. This is a YAML-stream test, not a GitHub workflow verdict.",
+    "cases": {
+      "yaml-test-suite/2LFX/in.yaml": [
+        "go-yaml load error in scanner (while scanning a directive) at L1.C1-C5: found unknown directive name"
+      ]
+    }
+  },
+  {
+    "reason": "YAML dependency difference: go.yaml rejects valid YAML for \"Spec Example 6.13. Reserved Directives\" according to YAML Test Suite. This is a YAML-stream test, not a GitHub workflow verdict.",
+    "cases": {
+      "yaml-test-suite/6LVF/in.yaml": [
+        "go-yaml load error in scanner (while scanning a directive) at L1.C1-C5: found unknown directive name"
+      ]
+    }
+  },
+  {
+    "reason": "YAML dependency difference: go.yaml rejects valid YAML for \"Spec Example 6.14. “YAML” directive\" according to YAML Test Suite. This is a YAML-stream test, not a GitHub workflow verdict.",
+    "cases": {
+      "yaml-test-suite/BEC7/in.yaml": [
+        "go-yaml load error in parser at L1.C1: found incompatible YAML document"
+      ]
+    }
+  },
+  {
+    "reason": "YAML dependency difference: go.yaml rejects valid YAML for \"Spec Example 6.2. Indentation Indicators\" according to YAML Test Suite. This is a YAML-stream test, not a GitHub workflow verdict.",
+    "cases": {
+      "yaml-test-suite/A2M4/in.yaml": [
+        "go-yaml load error in scanner (while scanning for the next token) at L2.C4: found character that cannot start any token"
+      ]
+    }
+  },
+  {
+    "reason": "YAML dependency difference: go.yaml rejects valid YAML for \"Spec Example 6.3. Separation Spaces\" according to YAML Test Suite. This is a YAML-stream test, not a GitHub workflow verdict.",
+    "cases": {
+      "yaml-test-suite/6BCT/in.yaml": [
+        "go-yaml load error in scanner (while scanning for the next token) at L3.C4: found character that cannot start any token"
+      ]
+    }
+  },
+  {
+    "reason": "YAML dependency difference: go.yaml rejects valid YAML for \"Spec Example 7.2. Empty Content\" according to YAML Test Suite. This is a YAML-stream test, not a GitHub workflow verdict.",
+    "cases": {
+      "yaml-test-suite/WZ62/in.yaml": [
+        "go-yaml load error in scanner (while parsing a tag) at L2.C9-C14: found character ',' that is not allowed in a YAML tag"
+      ]
+    }
+  },
+  {
+    "reason": "YAML dependency difference: go.yaml rejects valid YAML for \"Spec Example 7.3. Completely Empty Flow Nodes\" according to YAML Test Suite. This is a YAML-stream test, not a GitHub workflow verdict.",
+    "cases": {
+      "yaml-test-suite/FRK4/in.yaml": [
+        "go-yaml load error in parser (while parsing a flow node) at L3.C3: did not find expected node content"
+      ]
+    }
+  },
+  {
+    "reason": "YAML dependency difference: go.yaml rejects valid YAML for \"Spec Example 8.18. Implicit Block Mapping Entries\" according to YAML Test Suite. This is a YAML-stream test, not a GitHub workflow verdict.",
+    "cases": {
+      "yaml-test-suite/S3PD/in.yaml": [
+        "go-yaml load error in parser (while parsing a block mapping) at L1.C1-L2.C1: did not find expected key"
+      ]
+    }
+  },
+  {
+    "reason": "YAML dependency difference: go.yaml rejects valid YAML for \"Spec Example 8.2. Block Indentation Indicator\" according to YAML Test Suite. This is a YAML-stream test, not a GitHub workflow verdict.",
+    "cases": {
+      "yaml-test-suite/R4YG/in.yaml": [
+        "go-yaml load error in scanner (while scanning a block scalar) at L9.C3-L10.C2: found a tab character where an indentation space is expected"
+      ]
+    }
+  },
+  {
+    "reason": "YAML dependency difference: go.yaml rejects valid YAML for \"Spec Example 9.2. Document Markers\" according to YAML Test Suite. This is a YAML-stream test, not a GitHub workflow verdict.",
+    "cases": {
+      "yaml-test-suite/RTP8/in.yaml": [
+        "go-yaml load error in parser at L1.C1: found incompatible YAML document"
+      ]
+    }
+  },
+  {
+    "reason": "YAML dependency difference: go.yaml rejects valid YAML for \"Spec Example 9.3. Bare Documents\" according to YAML Test Suite. This is a YAML-stream test, not a GitHub workflow verdict.",
+    "cases": {
+      "yaml-test-suite/M7A3/in.yaml": [
+        "go-yaml load error in parser at L6.C1: did not find expected <document start>"
+      ]
+    }
+  },
+  {
+    "reason": "YAML dependency difference: go.yaml rejects valid YAML for \"Spec Example 9.4. Explicit Documents\" according to YAML Test Suite. This is a YAML-stream test, not a GitHub workflow verdict.",
+    "cases": {
+      "yaml-test-suite/UT92/in.yaml": [
+        "go-yaml load error in parser (while parsing a flow mapping) at L2.C1-L3.C3: did not find expected ',' or '}'"
+      ]
+    }
+  },
+  {
+    "reason": "YAML dependency difference: go.yaml rejects valid YAML for \"Spec Example 9.5. Directives Documents\" according to YAML Test Suite. This is a YAML-stream test, not a GitHub workflow verdict.",
+    "cases": {
+      "yaml-test-suite/W4TN/in.yaml": [
+        "go-yaml load error in parser at L1.C1: found incompatible YAML document"
+      ]
+    }
+  },
+  {
+    "reason": "YAML dependency difference: go.yaml rejects valid YAML for \"Spec Example 9.6. Stream [1.3]\" according to YAML Test Suite. This is a YAML-stream test, not a GitHub workflow verdict.",
+    "cases": {
+      "yaml-test-suite/9DXL/in.yaml": [
+        "go-yaml load error in parser at L5.C1: found incompatible YAML document"
+      ]
+    }
+  },
+  {
+    "reason": "YAML dependency difference: go.yaml rejects valid YAML for \"Spec Example 9.6. Stream\" according to YAML Test Suite. This is a YAML-stream test, not a GitHub workflow verdict.",
+    "cases": {
+      "yaml-test-suite/6ZKB/in.yaml": [
+        "go-yaml load error in parser at L5.C1: found incompatible YAML document"
+      ]
+    }
+  },
+  {
+    "reason": "YAML dependency difference: go.yaml rejects valid YAML for \"Syntax character edge cases\" according to YAML Test Suite. This is a YAML-stream test, not a GitHub workflow verdict.",
+    "cases": {
+      "yaml-test-suite/UKK6/00/in.yaml": [
+        "go-yaml load error in parser (while parsing a block mapping) at L1.C3: did not find expected key"
+      ]
+    }
+  },
+  {
+    "reason": "YAML dependency difference: go.yaml rejects valid YAML for \"Tab at beginning of line followed by a flow mapping\" according to YAML Test Suite. This is a YAML-stream test, not a GitHub workflow verdict.",
+    "cases": {
+      "yaml-test-suite/Q5MG/in.yaml": [
+        "go-yaml load error in scanner (while scanning for the next token) at L1.C1: found character that cannot start any token"
+      ]
+    }
+  },
+  {
+    "reason": "YAML dependency difference: go.yaml rejects valid YAML for \"Tab indented top flow\" according to YAML Test Suite. This is a YAML-stream test, not a GitHub workflow verdict.",
+    "cases": {
+      "yaml-test-suite/6CA3/in.yaml": [
+        "go-yaml load error in scanner (while scanning for the next token) at L1.C1: found character that cannot start any token"
+      ]
+    }
+  },
+  {
+    "reason": "YAML dependency difference: go.yaml rejects valid YAML for \"Tabs in various contexts\" according to YAML Test Suite. This is a YAML-stream test, not a GitHub workflow verdict.",
+    "cases": {
+      "yaml-test-suite/Y79Y/001/in.yaml": [
+        "go-yaml load error in scanner (while scanning a block scalar) at L1.C6-L2.C2: found a tab character where an indentation space is expected"
+      ],
+      "yaml-test-suite/Y79Y/010/in.yaml": [
+        "go-yaml load error in scanner (while scanning for the next token) at L1.C2: found character that cannot start any token"
+      ]
+    }
+  },
+  {
+    "reason": "YAML dependency difference: go.yaml rejects valid YAML for \"Tabs that look like indentation\" according to YAML Test Suite. This is a YAML-stream test, not a GitHub workflow verdict.",
+    "cases": {
+      "yaml-test-suite/DK95/00/in.yaml": [
+        "go-yaml load error in scanner (while scanning for the next token) at L2.C2: found character that cannot start any token"
+      ],
+      "yaml-test-suite/DK95/03/in.yaml": [
+        "go-yaml load error in scanner (while scanning for the next token) at L1.C2: found character that cannot start any token"
+      ],
+      "yaml-test-suite/DK95/04/in.yaml": [
+        "go-yaml load error in scanner (while scanning a plain scalar) at L1.C6-L2.C1: found a tab character that violates indentation"
+      ],
+      "yaml-test-suite/DK95/07/in.yaml": [
+        "go-yaml load error in parser at L1.C1: found incompatible YAML document"
+      ]
+    }
+  }
+]

--- a/upstream_conformance_adapters_test.go
+++ b/upstream_conformance_adapters_test.go
@@ -1,0 +1,118 @@
+//go:build conformance
+
+package actionlint
+
+import (
+	"encoding/json"
+	"io/fs"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+type upstreamBlock struct{ Name, Body string }
+
+func TestUpstreamConformanceControls(t *testing.T) {
+	for _, c := range []upstreamCase{
+		{ID: "parser accepts runtime coercion", Kind: "expression", Input: "1 == false"},
+		{ID: "parser does not evaluate format", Kind: "expression", Input: "format('{2}', 'only one argument')"},
+		{ID: "unknown context", Kind: "expression", Input: "secrets.TOKEN", Reject: true},
+		{ID: "unknown function", Kind: "expression", Input: "unknown('value')", Reject: true},
+		{ID: "function arity", Kind: "expression", Input: "contains('value')", Reject: true},
+		{ID: "case argument parity", Kind: "expression", Input: "case(true, 'first', false, 'second')", Reject: true},
+		{ID: "unterminated expression", Kind: "expression", Input: "inputs[", Reject: true},
+		{ID: "expression terminator is not end of input", Kind: "expression", Input: "true }} ignored", Reject: true},
+		{ID: "quoted expression terminator", Kind: "expression", Input: "'text }} still quoted'"},
+		{ID: "invalid action runtime", Kind: "action", Input: "name: Test\ndescription: Test\nruns: {using: nonexistent, main: main.js}", Reject: true},
+		{ID: "invalid workflow key", Kind: "workflow", Input: "on: push\njobs:\n  test:\n    runs-on: ubuntu-latest\n    stepz: []", Reject: true},
+	} {
+		t.Run(c.ID, func(t *testing.T) {
+			got := checkUpstreamCase(t, c)
+			if c.Reject != (len(got) > 0) {
+				t.Fatalf("want reject=%t, got %q", c.Reject, got)
+			}
+		})
+	}
+}
+
+func upstreamBlocks(t *testing.T, input, pattern string, count int) []upstreamBlock {
+	t.Helper()
+	matches := regexp.MustCompile(pattern).FindAllStringSubmatchIndex(input, -1)
+	if len(matches) != count {
+		t.Fatalf("upstream test structure changed: expected %d blocks, found %d", count, len(matches))
+	}
+	blocks := make([]upstreamBlock, 0, len(matches))
+	for i, match := range matches {
+		end := len(input)
+		if i+1 < len(matches) {
+			end = matches[i+1][0]
+		}
+		blocks = append(blocks, upstreamBlock{input[match[2]:match[3]], input[match[1]:end]})
+	}
+	return blocks
+}
+
+func loadLanguageServiceCases(t *testing.T, root fs.FS) []upstreamCase {
+	t.Helper()
+	var cases []upstreamCase
+	for _, suite := range []struct {
+		File  string
+		Count int
+	}{
+		{"validate.service-container-command.test.ts", 5},
+		{"validate.yaml-anchors.test.ts", 8},
+	} {
+		file := "languageservice/src/" + suite.File
+		input := readUpstream(t, root, file)
+		blocks := upstreamBlocks(t, input, `(?m)^  it\("([^"]+)", async \(\) => \{`, suite.Count)
+		for _, block := range blocks {
+			templates := regexp.MustCompile("(?s)`([^`]+)`").FindAllStringSubmatch(block.Body, -1)
+			if len(templates) != 1 || strings.ContainsAny(templates[0][1], "\\") || strings.Contains(templates[0][1], "${") {
+				t.Fatalf("%s/%s: expected one literal template without interpolation or escapes", file, block.Name)
+			}
+			c := upstreamCase{ID: file + "/" + block.Name, Kind: "workflow", Input: templates[0][1]}
+			c.Reject = strings.Contains(block.Body, ".toBeGreaterThan(0)")
+			if !c.Reject && !strings.Contains(block.Body, ".toEqual([])") {
+				if !strings.Contains(block.Body, "expect(result).toBeDefined()") {
+					t.Fatalf("%s: unrecognized upstream assertion", c.ID)
+				}
+				c.CompletionOnly = true
+			}
+			for _, filter := range regexp.MustCompile(`d.message.includes\("([^"]+)"\)`).FindAllStringSubmatch(block.Body, -1) {
+				c.Filter = append(c.Filter, filter[1])
+			}
+			cases = append(cases, c)
+		}
+	}
+	return cases
+}
+
+func loadRunnerExpressions(t *testing.T, root fs.FS) []upstreamCase {
+	t.Helper()
+	const file = "src/Test/L0/Sdk/ExpressionParserL0.cs"
+	input := readUpstream(t, root, file)
+	blocks := upstreamBlocks(t, input, `public void (CreateTree_\w+)\(\)`, 4)
+	var cases []upstreamCase
+	for _, block := range blocks {
+		calls := regexp.MustCompile(`parser.CreateTree\(("[^"\\]*"), null, namedValues, null\)`).FindAllStringSubmatch(block.Body, -1)
+		names := regexp.MustCompile(`new NamedValueInfo<ContextValueNode>\("([^"\\]+)"\)`).FindAllStringSubmatch(block.Body, -1)
+		if len(calls) != 1 || len(names) == 0 {
+			t.Fatalf("%s/%s: unsupported upstream expression fixture", file, block.Name)
+		}
+		expr, err := strconv.Unquote(calls[0][1])
+		if err != nil {
+			t.Fatal(err)
+		}
+		c := upstreamCase{ID: file + "/" + block.Name, Input: expr, Kind: "expression", Contexts: map[string]json.RawMessage{}}
+		c.Reject = strings.Contains(block.Body, "Assert.Throws<ParseException>")
+		if !c.Reject && !strings.Contains(block.Body, "Assert.NotNull(node)") {
+			t.Fatalf("%s: unrecognized upstream assertion", c.ID)
+		}
+		for _, name := range names {
+			c.Contexts[name[1]] = json.RawMessage(`{}`)
+		}
+		cases = append(cases, c)
+	}
+	return cases
+}

--- a/upstream_conformance_test.go
+++ b/upstream_conformance_test.go
@@ -1,0 +1,458 @@
+//go:build conformance
+
+package actionlint
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"maps"
+	"os"
+	"path"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strconv"
+	"strings"
+	"testing"
+
+	"actionlint.kjanat.dev/internal/conformance"
+	"github.com/google/go-cmp/cmp"
+	"go.yaml.in/yaml/v4"
+)
+
+type upstreamCase struct {
+	ID             string
+	Input          string
+	Reject         bool
+	ExpectedErrors []string
+	Contexts       map[string]json.RawMessage
+	Kind           string
+	Filter         []string
+	CompletionOnly bool
+}
+
+type upstreamResult struct {
+	ID              string   `json:"id"`
+	ExpectedReject  bool     `json:"expected_reject"`
+	ExpectedErrors  []string `json:"expected_errors,omitempty"`
+	Actual          []string `json:"actual"`
+	Difference      bool     `json:"difference"`
+	Contract        string   `json:"contract"`
+	KnownDifference string   `json:"known_difference,omitempty"`
+}
+
+type upstreamDifference struct {
+	Reason string   `json:"reason"`
+	Actual []string `json:"actual"`
+}
+
+type upstreamDifferenceGroup struct {
+	Reason string              `json:"reason"`
+	Cases  map[string][]string `json:"cases"`
+}
+
+func TestUpstreamConformance(t *testing.T) {
+	dir := os.Getenv("ACTIONLINT_CONFORMANCE_DIR")
+	if dir == "" {
+		dir = ".cache/conformance"
+	}
+	sources, err := conformance.Sources()
+	if err != nil {
+		t.Fatal(err)
+	}
+	baseline := map[string]upstreamDifference{}
+	data, err := os.ReadFile("testdata/conformance/differences.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var groups []upstreamDifferenceGroup
+	if err := json.Unmarshal(data, &groups); err != nil {
+		t.Fatal(err)
+	}
+	for _, group := range groups {
+		if strings.TrimSpace(group.Reason) == "" || len(group.Cases) == 0 {
+			t.Fatal("difference group must have a reason and at least one case")
+		}
+		for id, actual := range group.Cases {
+			if _, ok := baseline[id]; ok {
+				t.Fatalf("duplicate known difference %q", id)
+			}
+			baseline[id] = upstreamDifference{group.Reason, actual}
+		}
+	}
+	seen := map[string]bool{}
+	var results []upstreamResult
+	for _, source := range sources {
+		root, closeSource, err := source.Open(dir)
+		if err != nil {
+			t.Fatalf("%v; run go run ./scripts/fetch-conformance first", err)
+		}
+		t.Cleanup(func() { _ = closeSource() })
+		cases := loadUpstreamCases(t, source.Name, root)
+		counts := map[string]int{"languageservices": 1228, "runner": 24, "schemastore": 67, "yaml-test-suite": 402}
+		if len(cases) != counts[source.Name] {
+			t.Fatalf("source inventory changed: want %d cases, got %d", counts[source.Name], len(cases))
+		}
+		for i := range cases {
+			cases[i].ID = source.Name + "/" + cases[i].ID
+			if seen[cases[i].ID] {
+				t.Fatalf("duplicate test case %q", cases[i].ID)
+			}
+			seen[cases[i].ID] = true
+		}
+		t.Run(source.Name, func(t *testing.T) {
+			for _, c := range cases {
+				t.Run(strings.TrimPrefix(c.ID, source.Name+"/"), func(t *testing.T) {
+					actual := checkUpstreamCase(t, c)
+					if len(c.Filter) > 0 {
+						actual = slices.DeleteFunc(actual, func(message string) bool {
+							return !slices.ContainsFunc(c.Filter, func(word string) bool { return strings.Contains(message, word) })
+						})
+					}
+					contract := "acceptance"
+					if len(c.Filter) > 0 {
+						contract = "diagnostics containing: " + strings.Join(c.Filter, ", ")
+					}
+					if c.CompletionOnly {
+						contract = "completes without panic or hang"
+					}
+					known, ok := baseline[c.ID]
+					result := upstreamResult{c.ID, c.Reject, c.ExpectedErrors, actual, !c.CompletionOnly && c.Reject != (len(actual) > 0), contract, known.Reason}
+					results = append(results, result)
+					if !result.Difference {
+						if ok {
+							t.Error("now agrees with upstream; remove the resolved entry from differences.json")
+						}
+						return
+					}
+					if !ok {
+						t.Errorf("upstream reject=%t; actionlint diagnostics=%q; upstream diagnostics=%q", c.Reject, actual, c.ExpectedErrors)
+						return
+					}
+					if os.Getenv("ACTIONLINT_CONFORMANCE_STRICT") == "1" {
+						t.Errorf("upstream difference: %s", known.Reason)
+					}
+					if diff := cmp.Diff(known.Actual, actual); diff != "" {
+						t.Errorf("known difference changed (-want +got):\n%s", diff)
+					}
+					t.Logf("UPSTREAM DIFFERENCE: %s", known.Reason)
+				})
+			}
+		})
+	}
+	for id := range baseline {
+		if !seen[id] {
+			t.Errorf("known difference refers to a missing case: %s", id)
+		}
+	}
+	counts := map[string]int{}
+	for _, result := range results {
+		if result.Difference {
+			counts["differences"]++
+		} else {
+			counts["agreements"]++
+		}
+	}
+	t.Logf("Upstream comparison: %d cases, %d agreements, %d differences", len(results), counts["agreements"], counts["differences"])
+	if summary := os.Getenv("GITHUB_STEP_SUMMARY"); summary != "" {
+		writeUpstreamSummary(t, summary, sources, results)
+	}
+	if report := os.Getenv("ACTIONLINT_CONFORMANCE_REPORT"); report != "" {
+		data, err := json.MarshalIndent(struct {
+			Sources []conformance.Source `json:"sources"`
+			Results []upstreamResult     `json:"results"`
+		}{sources, results}, "", "  ")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(report, append(data, '\n'), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func writeUpstreamSummary(t *testing.T, filename string, sources []conformance.Source, results []upstreamResult) {
+	t.Helper()
+	var text strings.Builder
+	text.WriteString("## Upstream conformance\n\nAgreement means matching acceptance for the stated contract, not full runtime compatibility. Known differences are executed and checked against their recorded diagnostics.\n\n")
+	text.WriteString("| Source | Cases | Agreements | Known differences | New differences |\n| --- | ---: | ---: | ---: | ---: |\n")
+	for _, source := range sources {
+		var total, agree, known, unknown int
+		for _, result := range results {
+			if !strings.HasPrefix(result.ID, source.Name+"/") {
+				continue
+			}
+			total++
+			switch {
+			case !result.Difference:
+				agree++
+			case result.KnownDifference != "":
+				known++
+			default:
+				unknown++
+			}
+		}
+		fmt.Fprintf(&text, "| [%s](https://github.com/%s/tree/%s) | %d | %d | %d | %d |\n", source.Name, source.Repository, source.Revision, total, agree, known, unknown)
+	}
+	text.WriteString("\nThe JSON artifact includes each case ID, upstream expectation, actionlint diagnostics, and explanation for known differences. A changed or resolved known difference also fails the test.\n")
+	f, err := os.OpenFile(filename, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, writeErr := f.WriteString(text.String())
+	closeErr := f.Close()
+	if writeErr != nil {
+		t.Fatal(writeErr)
+	}
+	if closeErr != nil {
+		t.Fatal(closeErr)
+	}
+}
+
+func loadUpstreamCases(t *testing.T, source string, root fs.FS) []upstreamCase {
+	t.Helper()
+	switch source {
+	case "languageservices":
+		return slices.Concat(loadUpstreamExpressions(t, root), loadUpstreamWorkflows(t, root), loadLanguageServiceCases(t, root))
+	case "runner":
+		var cases []upstreamCase
+		// These are the fixture-backed Load_* assertions in ActionManifestManagerL0.cs.
+		for _, name := range []string{
+			"dockerfileaction", "dockerfileaction_init", "dockerfileaction_cleanup", "dockerfileaction_init_default",
+			"dockerfileaction_cleanup_default", "dockerfileaction_noargs_noenv_noentrypoint", "dockerfileaction_arg_env_expression",
+			"dockerhubaction", "nodeaction", "node16action", "node20action", "node24action", "nodeaction_init",
+			"nodeaction_init_default", "nodeaction_cleanup", "nodeaction_cleanup_default", "pluginaction",
+			"conditional_composite_action", "composite_action_without_using_token", "dockerfileaction_env_invalid_context",
+		} {
+			file := "src/Test/TestData/" + name + ".yml"
+			reject := name == "composite_action_without_using_token" || name == "dockerfileaction_env_invalid_context"
+			cases = append(cases, upstreamCase{ID: file, Input: readUpstream(t, root, file), Kind: "action", Reject: reject})
+		}
+		return append(cases, loadRunnerExpressions(t, root)...)
+	case "schemastore":
+		var cases []upstreamCase
+		for _, kind := range []string{"action", "workflow"} {
+			for _, suite := range []string{"test", "negative_test"} {
+				pattern := "src/" + suite + "/github-" + kind + "/*"
+				for _, file := range upstreamFiles(t, root, pattern) {
+					cases = append(cases, upstreamCase{ID: file, Input: readUpstream(t, root, file), Kind: kind, Reject: suite == "negative_test"})
+				}
+			}
+		}
+		return cases
+	case "yaml-test-suite":
+		var cases []upstreamCase
+		if err := fs.WalkDir(root, ".", func(file string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if !d.IsDir() && path.Base(file) == "in.yaml" {
+				_, err := fs.Stat(root, path.Join(path.Dir(file), "error"))
+				if err != nil && !errors.Is(err, fs.ErrNotExist) {
+					return err
+				}
+				cases = append(cases, upstreamCase{ID: file, Input: readUpstream(t, root, file), Kind: "yaml", Reject: err == nil})
+			}
+			return nil
+		}); err != nil {
+			t.Fatal(err)
+		}
+		return cases
+	default:
+		t.Fatalf("no adapter for source %q", source)
+		return nil
+	}
+}
+
+func readUpstream(t *testing.T, root fs.FS, file string) string {
+	t.Helper()
+	b, err := fs.ReadFile(root, file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(b)
+}
+
+func upstreamFiles(t *testing.T, root fs.FS, pattern string) []string {
+	t.Helper()
+	files, err := fs.Glob(root, pattern)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) == 0 {
+		t.Fatalf("no upstream files match %q", pattern)
+	}
+	return files
+}
+
+func loadUpstreamExpressions(t *testing.T, root fs.FS) []upstreamCase {
+	t.Helper()
+	var cases []upstreamCase
+	for _, file := range upstreamFiles(t, root, "expressions/testdata/*.json") {
+		var groups map[string][]struct {
+			Expr     string
+			Contexts map[string]json.RawMessage
+			Err      *struct{ Kind, Value string }
+		}
+		if err := json.Unmarshal([]byte(readUpstream(t, root, file)), &groups); err != nil {
+			t.Fatalf("%s: %v", file, err)
+		}
+		for _, group := range slices.Sorted(maps.Keys(groups)) {
+			for i, entry := range groups[group] {
+				c := upstreamCase{ID: fmt.Sprintf("%s/%s/%d", file, group, i), Input: entry.Expr, Kind: "expression", Contexts: entry.Contexts}
+				if entry.Err != nil && entry.Err.Kind != "evaluation" {
+					c.Reject = true
+					c.ExpectedErrors = []string{entry.Err.Value}
+				}
+				cases = append(cases, c)
+			}
+		}
+	}
+	return cases
+}
+
+var upstreamDocumentBoundary = regexp.MustCompile(`\r?\n---\r?\n`)
+
+func loadUpstreamWorkflows(t *testing.T, root fs.FS) []upstreamCase {
+	t.Helper()
+	var cases []upstreamCase
+	for _, file := range upstreamFiles(t, root, "workflow-parser/testdata/reader/*.yml") {
+		docs := upstreamDocumentBoundary.Split(readUpstream(t, root, file), -1)
+		if len(docs) < 3 {
+			t.Fatalf("%s has fewer than three fixture documents", file)
+		}
+		var expected struct{ Errors []struct{ Message string } }
+		if err := json.Unmarshal([]byte(docs[len(docs)-1]), &expected); err != nil {
+			t.Fatalf("%s: %v", file, err)
+		}
+		c := upstreamCase{ID: file, Input: docs[1], Kind: "workflow", Reject: len(expected.Errors) > 0}
+		for _, e := range expected.Errors {
+			c.ExpectedErrors = append(c.ExpectedErrors, e.Message)
+		}
+		cases = append(cases, c)
+	}
+	return cases
+}
+
+func checkUpstreamCase(t *testing.T, c upstreamCase) []string {
+	t.Helper()
+	switch c.Kind {
+	case "expression":
+		parser := ExprParser{}
+		lexer := NewExprLexer(c.Input + "}}")
+		node, err := parser.Parse(lexer)
+		if err != nil {
+			return []string{err.Error()}
+		}
+		if lexer.Offset() != len(c.Input)+2 {
+			return []string{fmt.Sprintf("unexpected expression terminator at byte %d in standalone expression", lexer.Offset()-2)}
+		}
+		checker := NewExprSemanticsChecker(false, nil)
+		checker.vars = map[string]ExprType{}
+		for name := range c.Contexts {
+			checker.vars[strings.ToLower(name)] = AnyType{}
+		}
+		checker.SetContextAvailability(slices.Sorted(maps.Keys(checker.vars)))
+		// GitHub's parser checks symbols and arity, but leaves coercion and evaluation to its evaluator.
+		VisitExprNode(node, func(n, _ ExprNode, entering bool) {
+			if !entering {
+				return
+			}
+			switch n := n.(type) {
+			case *VariableNode:
+				checker.checkVariable(n)
+			case *FuncCallNode:
+				callChecker := NewExprSemanticsChecker(false, nil)
+				callChecker.vars = map[string]ExprType{"argument": AnyType{}}
+				callChecker.SetContextAvailability([]string{"argument"})
+				callChecker.SetSpecialFunctionAvailability([]string{"always", "cancelled", "failure", "success", "hashfiles"})
+				args := make([]ExprNode, len(n.Args))
+				for i := range args {
+					args[i] = &VariableNode{Name: "argument", tok: n.Args[i].Token()}
+				}
+				_, errs := callChecker.Check(&FuncCallNode{Callee: n.Callee, Args: args, tok: n.tok})
+				checker.errs = append(checker.errs, errs...)
+			}
+		})
+		out := []string{}
+		for _, err := range checker.errs {
+			out = append(out, err.Error())
+		}
+		return out
+	case "workflow":
+		linter, err := NewLinter(io.Discard, &LinterOptions{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		linter.defaultConfig = &Config{}
+		errs, err := linter.Lint("<stdin>", []byte(c.Input), nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return upstreamDiagnostics(errs)
+	case "action":
+		var meta ActionMetadata
+		if err := yaml.Unmarshal([]byte(c.Input), &meta); err != nil {
+			return []string{err.Error()}
+		}
+		meta.file, meta.src = "action.yml", []byte(c.Input)
+		meta.dir = t.TempDir()
+		// Manifest-parser fixtures assume companion files exist; their contents are never executed.
+		files := []string{meta.Runs.Main, meta.Runs.Pre, meta.Runs.Post, meta.Runs.PreEntrypoint, meta.Runs.Entrypoint, meta.Runs.PostEntrypoint}
+		if !strings.HasPrefix(meta.Runs.Image, "docker://") {
+			files = append(files, meta.Runs.Image)
+		}
+		for _, file := range files {
+			if file == "" {
+				continue
+			}
+			if !filepath.IsLocal(file) {
+				t.Fatalf("fixture references non-local companion file %q", file)
+			}
+			file = filepath.Join(meta.dir, filepath.FromSlash(file))
+			if err := os.MkdirAll(filepath.Dir(file), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(file, nil, 0o644); err != nil {
+				t.Fatal(err)
+			}
+		}
+		rule := NewRuleAction(nil)
+		rule.checkLocalActionMetadata(&meta, &ExecAction{Uses: &String{Value: "./action", Pos: &Pos{Line: 1, Col: 1}}})
+		out := upstreamDiagnostics(rule.Errs())
+		quotedDir := strings.TrimSuffix(strings.TrimPrefix(strconv.Quote(meta.dir), `"`), `"`)
+		for i := range out {
+			out[i] = strings.ReplaceAll(out[i], quotedDir, "<action>")
+			out[i] = strings.ReplaceAll(out[i], `<action>\\action.yml`, "<action>/action.yml")
+		}
+		return out
+	case "yaml":
+		decoder := yaml.NewDecoder(bytes.NewBufferString(c.Input))
+		for {
+			var document yaml.Node
+			err := decoder.Decode(&document)
+			if errors.Is(err, io.EOF) {
+				return []string{}
+			}
+			if err != nil {
+				return []string{err.Error()}
+			}
+		}
+	default:
+		t.Fatalf("unknown conformance case kind %q", c.Kind)
+		return nil
+	}
+}
+
+func upstreamDiagnostics(errs []*Error) []string {
+	out := make([]string, 0, len(errs))
+	for _, err := range errs {
+		err.Filepath = filepath.ToSlash(err.Filepath)
+		out = append(out, err.Error())
+	}
+	return out
+}


### PR DESCRIPTION
Add independently maintained test inputs and expectations before changing actionlint's implementation. The harness runs upstream fixtures through the existing Go parser and validators.

| Source | Cases |
| --- | ---: |
| `actions/languageservices`: expressions, workflow reader, and selected language-service validation tests | 1,228 |
| `actions/runner`: action manifests and expression context/function tests | 24 |
| SchemaStore: positive and negative workflow/action fixtures | 67 |
| YAML Test Suite: stream acceptance | 402 |

The initial comparison has **1,721 cases, 1,368 agreements, and 353 recorded differences**. Every case runs. The difference file records exact case IDs, diagnostics, and explanations; new differences, changed diagnostics, obsolete exceptions, and missing cases fail the job. Strict mode fails on all differences.

The remaining differences include bracket wildcards, numeric expression spellings, Docker action conditions and contexts, action outputs, and reserved job IDs. Others come from extra lint checks, runner-internal behavior, or remote workflow resolution. This does not claim full compatibility with GitHub's runtime.

Archives are pinned by commit and SHA-256, cached outside Git, and read without extracting or executing upstream code. Tests run offline after fetching. Linux, macOS, and Windows CI jobs publish a summary and the complete JSON comparison.

The [conformance guide](https://github.com/kjanat/actionlint/blob/ba53188/docs/conformance.md) documents the selected contracts, their limits, how to run the tests, and how to update sources. Expression evaluation, editor protocol behavior, and runner execution are outside this harness; workflow comparisons check acceptance rather than expanded workflow objects or diagnostic equivalence.

Validation:

- All imported cases passed the regression gate on Windows and Ubuntu WSL.
- The Windows conformance run passed with module networking disabled and cached dependencies.
- Strict mode failed on all 11 recorded runner differences as expected.
- `go test ./...` passed on Windows.
- Archive verification and adapter control tests passed; the fetch command downloaded and verified all four archives into an empty cache.
- `golangci-lint` 2.13.1 with the `conformance` build tag, dprint, workflow linting, and `git diff --check` passed.
