### PR TITLE
Restrict Pages builds and deployment permissions

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -5,7 +5,7 @@ on:
   workflow_run: { workflows: [Release], types: [completed] }
   workflow_dispatch: null
 
-permissions: { contents: read, pages: write, id-token: write }
+permissions: { contents: read }
 
 concurrency:
   group: pages
@@ -13,7 +13,10 @@ concurrency:
 
 jobs:
   build:
-    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
+    if: >-
+      github.event_name != 'workflow_run' ||
+      (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.head_repository.full_name == github.repository)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -30,18 +33,19 @@ jobs:
         run: run make:man
       - name: Build and test playground
         run: run --dir playground -s make:build make:test
-      - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6
       - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
         with: { path: playground/dist }
 
   deploy:
     needs: build
     runs-on: ubuntu-latest
+    permissions: { pages: write, id-token: write }
     environment: {
       name: github-pages,
       url: "${{ steps.deployment.outputs.page_url }}",
     }
     steps: [
+      { uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d }, # v6
       {
         name: Deploy to GitHub Pages,
         id: deployment,

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -45,7 +45,6 @@ jobs:
       url: "${{ steps.deployment.outputs.page_url }}",
     }
     steps: [
-      { uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d }, # v6
       {
         name: Deploy to GitHub Pages,
         id: deployment,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # Unreleased
 
+- Restrict release-triggered Pages builds to successful push runs from this repository and grant Pages write and OIDC permissions only to the deployment job.
+
 - Add upstream conformance tests using GitHub's language-services and runner fixtures, with SchemaStore and YAML Test Suite comparisons. Run them across Linux, macOS, and Windows and report known differences separately from agreements.
 
 <a id="v1.16.0"></a>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -275,10 +275,13 @@ Visit [`playground/README.md`](./playground/README.md).
 
 ## How to deploy playground
 
-The [Pages workflow](./.github/workflows/pages.yml) deploys on pushes to `master` and after successful Release runs.
-Release-triggered builds check out that release's commit. It builds the bundle with
+The [Pages workflow](./.github/workflows/pages.yml) deploys on pushes to `master` and after successful Release runs
+triggered by pushes within this repository. Release-triggered builds check out that release's commit. The build job has
+read-only repository access and builds the bundle with
 `make -C playground build`, packages `playground/dist` together with the manual, and uploads it through
 `actions/upload-pages-artifact`.
+
+Only the separate deployment job receives Pages write and OIDC permissions.
 
 To check a build locally before pushing:
 

--- a/scripts/bump-version/targets.go
+++ b/scripts/bump-version/targets.go
@@ -83,6 +83,7 @@ var targets = []*target{
 			mustRule("download script example description", `example installs v(\d+\.\d+\.\d+)`, 1),
 			mustRule("download script argument", `download-actionlint\.bash\) (\d+\.\d+\.\d+)`, 1),
 		},
+		unrelated: []string{"has proposed switching the package to this fork at v1.16.0"},
 	},
 	{
 		path: "README.md",


### PR DESCRIPTION
Address [code-scanning alert #32](https://github.com/kjanat/actionlint/security/code-scanning/32) by checking the source of release completion events before Pages checks out their commit. Only successful push runs from this repository qualify. The build job receives read-only repository access; deployment runs in the separate job with Pages write and OIDC permissions.

Release builds continue using the release commit, and the existing protected-branch deployment policy stays in effect. Pushes to `master` and manual dispatch remain supported.

Validation:

- Evaluated the workflow's actual condition with `@actions/expressions`: all 13 cases passed, covering successful releases, rejected run sources and conclusions, missing event fields, master pushes, and manual dispatch.
- Checked job permissions and separation locally.
- `actionlint -shellcheck= -pyflakes= .github/workflows/pages.yml`, dprint, Comment Cop, and `git diff --check` passed.
- CodeQL and CI results will be available on this PR. No production Pages deployment was triggered for this test.