### PR TITLE
Keep test repositories outside the checkout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # Unreleased
 
+- Keep project-discovery test repositories in temporary directories so running tests does not add fake repositories to editors' repository lists.
+
 - Restrict release-triggered Pages builds to successful push runs from this repository and grant Pages write and OIDC permissions only to the deployment job.
 
 - Add upstream conformance tests using GitHub's language-services and runner fixtures, with SchemaStore and YAML Test Suite comparisons. Run them across Linux, macOS, and Windows and report known differences separately from agreements.

--- a/linter_test.go
+++ b/linter_test.go
@@ -270,14 +270,12 @@ CheckFiles:
 }
 
 func TestLintFindProjectFromPath(t *testing.T) {
-	d := filepath.Join("testdata", "find_project")
+	d := testProjectDir(t, filepath.Join("testdata", "find_project"))
 	f := filepath.Join(d, ".github", "workflows", "test.yaml")
 	b, err := os.ReadFile(f)
 	if err != nil {
 		panic(err)
 	}
-
-	testEnsureDotGitDir(d)
 
 	lint := func(path string) []*Error {
 		l, err := NewLinter(io.Discard, &LinterOptions{})
@@ -677,8 +675,7 @@ func TestLinterGenerateDefaultConfigAlreadyExists(t *testing.T) {
 	}
 
 	for _, n := range []string{"ok", "yml"} {
-		d := filepath.Join("testdata", "config", "projects", n)
-		testEnsureDotGitDir(d)
+		d := testProjectDir(t, filepath.Join("testdata", "config", "projects", n))
 
 		err := l.GenerateDefaultConfig(d)
 		if err == nil {

--- a/project_test.go
+++ b/project_test.go
@@ -7,25 +7,26 @@ import (
 	"testing"
 )
 
-// Create `.git` directory since actionlint finds the directory to detect the repository root.
-// Without creating this directory, this test case will fail when `actionlint/.git` directory
-// doesn't exist. When cloning actionlint repository with Git, it never happens. However, when
-// downloading sources tarball from github.com, it doesn't contain `.git` directory so it
-// happens. Please see #307 for more details.
-func testEnsureDotGitDir(dir string) {
-	d := filepath.Join(dir, ".git")
-	if err := os.MkdirAll(d, 0750); err != nil {
-		panic(err)
+// Project discovery needs a .git marker. Keep it in a temporary fixture copy so
+// tests also work without a checkout and editors do not discover fake repositories.
+func testProjectDir(t *testing.T, fixture string) string {
+	t.Helper()
+	d := t.TempDir()
+	if err := os.CopyFS(d, os.DirFS(fixture)); err != nil {
+		t.Fatal(err)
 	}
+	if err := os.MkdirAll(filepath.Join(d, ".git"), 0750); err != nil {
+		t.Fatal(err)
+	}
+	return d
 }
 
 func TestProjectsFindProjectFromPath(t *testing.T) {
-	d := filepath.Join("testdata", "find_project")
+	d := testProjectDir(t, filepath.Join("testdata", "find_project"))
 	abs, err := filepath.Abs(d)
 	if err != nil {
 		panic(err)
 	}
-	testEnsureDotGitDir(d)
 
 	ps := NewProjects()
 	for _, tc := range []struct {
@@ -81,12 +82,11 @@ func TestProjectsFindProjectFromPath(t *testing.T) {
 }
 
 func TestProjectsDoesNotFindProjectFromOutside(t *testing.T) {
-	d := filepath.Join("testdata", "find_project")
+	d := testProjectDir(t, filepath.Join("testdata", "find_project"))
 	abs, err := filepath.Abs(d)
 	if err != nil {
 		panic(err)
 	}
-	testEnsureDotGitDir(d)
 
 	outside := filepath.Join(d, "..")
 	ps := NewProjects()
@@ -101,8 +101,7 @@ func TestProjectsDoesNotFindProjectFromOutside(t *testing.T) {
 
 func TestProjectsLoadProjectConfig(t *testing.T) {
 	for _, n := range []string{"ok", "yml"} {
-		d := filepath.Join("testdata", "config", "projects", n)
-		testEnsureDotGitDir(d)
+		d := testProjectDir(t, filepath.Join("testdata", "config", "projects", n))
 		ps := NewProjects()
 		p, err := ps.At(d)
 		if err != nil {
@@ -118,8 +117,7 @@ func TestProjectsLoadProjectConfig(t *testing.T) {
 }
 
 func TestProjectsLoadingNoProjectConfig(t *testing.T) {
-	d := filepath.Join("testdata", "config", "projects", "none")
-	testEnsureDotGitDir(d)
+	d := testProjectDir(t, filepath.Join("testdata", "config", "projects", "none"))
 	ps := NewProjects()
 	p, err := ps.At(d)
 	if err != nil {
@@ -135,8 +133,7 @@ func TestProjectsLoadingNoProjectConfig(t *testing.T) {
 
 func TestProjectsLoadingBrokenProjectConfig(t *testing.T) {
 	want := "could not parse config file"
-	d := filepath.Join("testdata", "config", "projects", "err")
-	testEnsureDotGitDir(d)
+	d := testProjectDir(t, filepath.Join("testdata", "config", "projects", "err"))
 	ps := NewProjects()
 	p, err := ps.At(d)
 	if err == nil {

--- a/testdata/find_project/README.md
+++ b/testdata/find_project/README.md
@@ -3,4 +3,5 @@ This directory is used for testing that actionlint can detect a repository root.
 - `TestLintFindProjectFromPath` in `linter_test.go`
 - `project_test.go`
 
-`.git` directory is dynamically created when the test case is run because Git doesn't allow committing `.git` directory.
+Tests copy these files into a temporary directory and create a `.git` marker there for project discovery.
+Go removes the temporary directory after the test, leaving the checked-in fixtures unchanged.


### PR DESCRIPTION
Running the project-discovery tests left empty `.git` directories in `testdata`, causing editors to list `find_project`, `err`, `none`, `ok`, and `yml` as additional repositories.

Copy the fixtures into `t.TempDir()` before adding the repository markers. Go cleans up each temporary directory after its test, and the checked-in fixtures remain unchanged. Update the fixture documentation and changelog.

Related: kjanat/zed-editor#77, and kjanat/zed-editor#78, which track the editor's behavior when the old markers were removed.

Validation:

- All seven affected tests passed on Windows with Go 1.26.5, including a rerun after moving the fix onto `master`. No `.git` markers remained in the fixture directories afterward.
- `golangci-lint run .` passed with v2.13.1.
- `dprint check CHANGELOG.md testdata/find_project/README.md` and `git diff --check` passed.
