### PR TITLE
Report YAML alias errors at their use sites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # Unreleased
 
+- Report YAML alias type errors at each invalid alias use, with the anchor location included in the message. Preserve source locations inside anchored content and avoid missing-ref errors for malformed `uses` values. (kjanat/actionlint#149)
+
 - Keep project-discovery test repositories in temporary directories so running tests does not add fake repositories to editors' repository lists.
 
 - Add a Nix flake with source builds, packaged external linters, completions, the manpage and configuration schema, a development shell, and package integration checks. Update its version during release preparation and require Nix checks before tagging and publishing. (NixOS/nixpkgs#561437; thanks @voidlily for the initial packaging proposal.)

--- a/ast.go
+++ b/ast.go
@@ -590,6 +590,7 @@ type Input struct {
 // https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#jobsjob_idstepsuses
 type ExecAction struct {
 	// https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#jobsjob_idstepsuses
+	// Uses is nil when its value could not be parsed as a nonempty string.
 	Uses *String
 	// Inputs represents inputs to the action to execute in 'with' section. Keys are in lower case since they are case-insensitive.
 	Inputs map[string]*Input

--- a/docs/checks.md
+++ b/docs/checks.md
@@ -3333,6 +3333,10 @@ workflows.
 
 Anchor and alias names containing `+`, such as `&git+opts` and `*git+opts`, are rejected by GitHub Actions and reported as errors.
 
+If an alias supplies the wrong value type, actionlint reports the error at that alias use and includes the anchor's location.
+For example, `- &Runner { uses: example/action@v1 }` defines a complete step mapping. Reusing it as `- *Runner` is valid, but
+`- uses: *Runner` is a type error because `uses` requires a scalar string. Each incorrect use gets its own diagnostic.
+
 actionlint detects errors under YAML anchors. When an alias node references an erroneous anchor, actionlint checks them as if the
 alias node is replaced with the anchor node. This means that one anchor node may be checked multiple times and actionlint may
 report multiple similar errors at the same source location.
@@ -3432,9 +3436,7 @@ test.yaml:22:14: recursive alias "recursive" is found. anchor was declared at li
 
 [Playground](https://kjanat.github.io/actionlint/#eNpsj8FqwzAQRO/+ijkUHwp27/qZothLomKvxI7kFEL+vYjGwiE5mRm/p92N6pAKL133E090HZCFuX4Bim1hEv4nQM9Bf/cAhNWfxT3axVev/ZtMZtEc/EKH/pAaARSKqV/F4eN2A2UyyRxri/v9wCVPXqPNz9ze7qwV5VCvKaeiuQyHhZgltSOGSjqMX3O86hL9PPLSholuDp+v6zappLdK/07pTaZiDJs0+PEK4yrfnCyk/Dq9WX8BAAD//wHceU8=)
 
-actionlint checks dangling aliases as syntax error. Note that the error position is currently incorrect as the below output
-indicates. This issue is due to go-yaml library and the [fix](https://github.com/yaml/go-yaml/pull/191) will be included at the
-next release of the library.
+actionlint reports dangling aliases at the alias use when no matching anchor has been defined.
 
 Example input:
 

--- a/parse.go
+++ b/parse.go
@@ -80,6 +80,7 @@ func (l *delayedSprintf) String() string {
 type parser struct {
 	errors      []*Error
 	sourceLines []string
+	aliases     map[*yaml.Node]*yaml.Node
 }
 
 func splitSourceLines(b []byte) []string {
@@ -220,8 +221,17 @@ func (p *parser) errorf(n *yaml.Node, format string, args ...any) {
 	p.error(n, m)
 }
 
+func (p *parser) typeErrorf(n *yaml.Node, format string, args ...any) {
+	m := fmt.Sprintf(format, args...)
+	if alias, ok := p.aliases[n]; ok {
+		m += fmt.Sprintf(". alias %q refers to the anchor at line:%d, column:%d", alias.Value, n.Line, n.Column)
+		n = alias
+	}
+	p.error(n, m)
+}
+
 func (p *parser) resolveAliases(root *yaml.Node) {
-	resolveYAMLAliases(root, func(n *yaml.Node, d yamlAliasDiagnostic, m string) {
+	p.aliases = resolveYAMLAliases(root, func(n *yaml.Node, d yamlAliasDiagnostic, m string) {
 		p.error(n, m)
 	})
 }
@@ -237,13 +247,14 @@ const (
 	yamlAliasDiagnosticInvalidName
 )
 
-func resolveYAMLAliases(root *yaml.Node, report func(n *yaml.Node, d yamlAliasDiagnostic, m string)) {
+func resolveYAMLAliases(root *yaml.Node, report func(n *yaml.Node, d yamlAliasDiagnostic, m string)) map[*yaml.Node]*yaml.Node {
 	type usage struct {
 		used    bool
 		defined bool
 	}
 
 	anchors := map[*yaml.Node]*usage{}
+	var aliases map[*yaml.Node]*yaml.Node
 
 	var resolve func(*yaml.Node) // For recursive call
 	resolve = func(n *yaml.Node) {
@@ -267,7 +278,13 @@ func resolveYAMLAliases(root *yaml.Node, report func(n *yaml.Node, d yamlAliasDi
 			if u, ok := anchors[c.Alias]; ok {
 				u.used = true
 				if u.defined {
-					n.Content[i] = c.Alias // Resolved
+					// Keep each alias use distinct without relocating the anchored content.
+					resolved := *c.Alias
+					n.Content[i] = &resolved
+					if aliases == nil {
+						aliases = map[*yaml.Node]*yaml.Node{}
+					}
+					aliases[&resolved] = c
 				} else {
 					// Don't resolve the recursive alias because it causes stack overflow on parsing the tree as
 					// `RawYAMLValue`. (#610)
@@ -286,6 +303,7 @@ func resolveYAMLAliases(root *yaml.Node, report func(n *yaml.Node, d yamlAliasDi
 			report(n, yamlAliasDiagnosticUnusedAnchor, fmt.Sprintf("anchor %q is defined but not used", n.Anchor))
 		}
 	}
+	return aliases
 }
 
 func (p *parser) unexpectedKey(s *String, sec string, expected []string) {
@@ -314,7 +332,7 @@ func (p *parser) checkNotEmpty(sec string, count int, n *yaml.Node) bool {
 
 func (p *parser) checkSequence(sec string, n *yaml.Node, allowEmpty bool) bool {
 	if n.Kind != yaml.SequenceNode {
-		p.errorf(n, "%q section must be sequence node but got %s node with %q tag", sec, nodeKindName(n.Kind), n.Tag)
+		p.typeErrorf(n, "%q section must be sequence node but got %s node with %q tag", sec, nodeKindName(n.Kind), n.Tag)
 		return false
 	}
 	return allowEmpty || p.checkNotEmpty(sec, len(n.Content), n)
@@ -324,7 +342,7 @@ func (p *parser) checkString(n *yaml.Node, allowEmpty bool) bool {
 	// Do not check n.Tag is !!str because we don't need to check the node is string strictly.
 	// In almost all cases, other nodes (like 42) are handled as string with its string representation.
 	if n.Kind != yaml.ScalarNode {
-		p.errorf(n, "expected scalar node for string value but found %s node with %q tag", nodeKindName(n.Kind), n.Tag)
+		p.typeErrorf(n, "expected scalar node for string value but found %s node with %q tag", nodeKindName(n.Kind), n.Tag)
 		return false
 	}
 	if !allowEmpty && n.Value == "" {
@@ -335,7 +353,7 @@ func (p *parser) checkString(n *yaml.Node, allowEmpty bool) bool {
 }
 
 func (p *parser) missingExpression(n *yaml.Node, expecting string) {
-	p.errorf(n, "expecting a single ${{...}} expression or %s, but found plain text node", expecting)
+	p.typeErrorf(n, "expecting a single ${{...}} expression or %s, but found plain text node", expecting)
 }
 
 func (p *parser) parseExpression(n *yaml.Node, expecting string) *String {
@@ -389,7 +407,7 @@ func (p *parser) parseStringOrStringSequence(sec string, n *yaml.Node) []*String
 
 func (p *parser) parseBool(n *yaml.Node) *Bool {
 	if n.Kind != yaml.ScalarNode || (n.Tag != yamlTagBool && n.Tag != yamlTagStr) {
-		p.errorf(n, "expected bool value but found %s node with %q tag", nodeKindName(n.Kind), n.Tag)
+		p.typeErrorf(n, "expected bool value but found %s node with %q tag", nodeKindName(n.Kind), n.Tag)
 		return nil
 	}
 
@@ -409,7 +427,7 @@ func (p *parser) parseBool(n *yaml.Node) *Bool {
 
 func (p *parser) parseInt(n *yaml.Node) *Int {
 	if n.Kind != yaml.ScalarNode || (n.Tag != yamlTagInt && n.Tag != yamlTagStr) {
-		p.errorf(n, "expected scalar node for integer value but found %s node with %q tag", nodeKindName(n.Kind), n.Tag)
+		p.typeErrorf(n, "expected scalar node for integer value but found %s node with %q tag", nodeKindName(n.Kind), n.Tag)
 		return nil
 	}
 
@@ -438,7 +456,7 @@ func (p *parser) parseInt(n *yaml.Node) *Int {
 
 func (p *parser) parseFloat(n *yaml.Node) *Float {
 	if n.Kind != yaml.ScalarNode || (n.Tag != yamlTagFloat && n.Tag != yamlTagInt && n.Tag != yamlTagStr) {
-		p.errorf(n, "expected scalar node for float value but found %s node with %q tag", nodeKindName(n.Kind), n.Tag)
+		p.typeErrorf(n, "expected scalar node for float value but found %s node with %q tag", nodeKindName(n.Kind), n.Tag)
 		return nil
 	}
 
@@ -475,7 +493,7 @@ func (p *parser) parseMapping(where delayedSprintf, n *yaml.Node, allowEmpty, ca
 		}
 
 		if n.Kind != yaml.MappingNode {
-			p.errorf(n, "%s is %s node but mapping node is expected", where.String(), nodeKindName(n.Kind))
+			p.typeErrorf(n, "%s is %s node but mapping node is expected", where.String(), nodeKindName(n.Kind))
 			return
 		}
 
@@ -882,7 +900,7 @@ func (p *parser) parseEvents(n *yaml.Node) []Event {
 
 		return ret
 	default:
-		p.errorf(n, "\"on\" section value is expected to be mapping or sequence but found %s node", nodeKindName(n.Kind))
+		p.typeErrorf(n, "\"on\" section value is expected to be mapping or sequence but found %s node", nodeKindName(n.Kind))
 		return nil
 	}
 }
@@ -1093,7 +1111,7 @@ func (p *parser) parseRawYAMLValue(n *yaml.Node) RawYAMLValue {
 		}
 		return &RawYAMLObject{m, posAt(n)}
 	default:
-		p.errorf(n, "unexpected %s node on parsing value in matrix row", nodeKindName(n.Kind))
+		p.typeErrorf(n, "unexpected %s node on parsing value in matrix row", nodeKindName(n.Kind))
 		return nil
 	}
 }
@@ -1327,7 +1345,9 @@ func (p *parser) parseStepExecAction(entries []workflowMappingEntry, isDocker bo
 	for _, e := range entries {
 		switch e.id {
 		case "uses":
-			ret.Uses = p.parseString(e.val, false)
+			if p.checkString(e.val, false) {
+				ret.Uses = newString(e.val)
+			}
 		case "with":
 			ret.Inputs = map[string]*Input{}
 			with := p.parseSectionMapping("with", e.val, false, false)
@@ -1366,7 +1386,6 @@ func (p *parser) parseStepExecAction(entries []workflowMappingEntry, isDocker bo
 		}
 	}
 
-	// Note: `ret.Uses` is never `nil` because `parseStep` checks `uses` key in advance
 	return ret
 }
 
@@ -1631,7 +1650,7 @@ func (p *parser) parseSnapshot(pos *Pos, n *yaml.Node) *Snapshot {
 		}
 		return ret
 	default:
-		p.errorf(n, "\"snapshot\" section value must be string or mapping but found %s node", nodeKindName(n.Kind))
+		p.typeErrorf(n, "\"snapshot\" section value must be string or mapping but found %s node", nodeKindName(n.Kind))
 		return nil
 	}
 }

--- a/parse_test.go
+++ b/parse_test.go
@@ -33,6 +33,49 @@ func TestParserAnchorNames(t *testing.T) {
 	}
 }
 
+func TestParserAliasTypeLocations(t *testing.T) {
+	tests := []struct {
+		name, value, message string
+		check                func(*parser, *yaml.Node)
+	}{
+		{"string", "{}", "expected scalar node for string value", func(p *parser, n *yaml.Node) { p.parseString(n, false) }},
+		{"sequence", "{}", "must be sequence node", func(p *parser, n *yaml.Node) { p.checkSequence("steps", n, false) }},
+		{"mapping", "[]", "mapping node is expected", func(p *parser, n *yaml.Node) {
+			for range p.parseSectionMapping("env", n, false, false) {
+			}
+		}},
+		{"bool", "{}", "expected bool value", func(p *parser, n *yaml.Node) { p.parseBool(n) }},
+		{"integer", "{}", "expected scalar node for integer value", func(p *parser, n *yaml.Node) { p.parseInt(n) }},
+		{"float", "{}", "expected scalar node for float value", func(p *parser, n *yaml.Node) { p.parseFloat(n) }},
+		{"expression", "plain", "expecting a single ${{...}} expression", func(p *parser, n *yaml.Node) { p.parseBool(n) }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var doc yaml.Node
+			src := "anchor: &value " + tt.value + "\nfirst: *value\nsecond: *value\n"
+			if err := yaml.Unmarshal([]byte(src), &doc); err != nil {
+				t.Fatal(err)
+			}
+			p := &parser{}
+			p.resolveAliases(&doc)
+			for _, n := range []*yaml.Node{doc.Content[0].Content[3], doc.Content[0].Content[5]} {
+				tt.check(p, n)
+			}
+			if len(p.errors) != 2 {
+				t.Fatalf("wanted one error per alias use, got %v", p.errors)
+			}
+			for i, err := range p.errors {
+				if err.Line != i+2 || err.Column != i+8 {
+					t.Errorf("error points to %d:%d, want %d:%d", err.Line, err.Column, i+2, i+8)
+				}
+				if !strings.Contains(err.Message, tt.message) || !strings.Contains(err.Message, `alias "value" refers to the anchor at line:1, column:9`) {
+					t.Errorf("error lost the type mismatch or anchor location: %s", err.Message)
+				}
+			}
+		})
+	}
+}
+
 func TestParserScriptSource(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -187,6 +230,29 @@ func TestParserScriptSource(t *testing.T) {
 		}
 		if want := (Pos{Line: 2, Col: 12}); *end != want {
 			t.Fatalf("mapped end position is %v but wanted %v", end, want)
+		}
+	})
+
+	t.Run("aliased literal block", func(t *testing.T) {
+		input := "script: &script |\n  echo $foo\nrun: *script\n"
+		var root yaml.Node
+		if err := yaml.Unmarshal([]byte(input), &root); err != nil {
+			t.Fatal(err)
+		}
+		p := &parser{sourceLines: splitSourceLines([]byte(input))}
+		p.resolveAliases(&root)
+		if len(p.errors) != 0 {
+			t.Fatal(p.errors)
+		}
+		for _, n := range []*yaml.Node{root.Content[0].Content[1], root.Content[0].Content[3]} {
+			source := p.scriptSource(n)
+			if source == nil {
+				t.Fatal("literal script lost its source mapping")
+			}
+			pos, ok := source.pos(1, 6)
+			if want := (Pos{Line: 2, Col: 8}); !ok || *pos != want {
+				t.Fatalf("script position is %v (mapped=%v), want %v", pos, ok, want)
+			}
 		}
 	})
 

--- a/testdata/err/alias_content_errors.out
+++ b/testdata/err/alias_content_errors.out
@@ -1,0 +1,1 @@
+/test\.yaml:7:19: undefined variable "missing"\. available variables are .+ \[expression\]/

--- a/testdata/err/alias_content_errors.yaml
+++ b/testdata/err/alias_content_errors.yaml
@@ -1,0 +1,9 @@
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - &Step
+        name: ${{ missing.value }}
+        run: echo ok
+      - *Step

--- a/testdata/err/alias_type_errors.out
+++ b/testdata/err/alias_type_errors.out
@@ -1,0 +1,5 @@
+test.yaml:7:15: expected scalar node for string value but found mapping node with "!!map" tag. alias "Runner" refers to the anchor at line:6, column:9 [syntax-check]
+test.yaml:8:15: expected scalar node for string value but found mapping node with "!!map" tag. alias "Runner" refers to the anchor at line:6, column:9 [syntax-check]
+test.yaml:13:15: expected scalar node for string value but found mapping node with "!!map" tag. alias "Runner" refers to the anchor at line:6, column:9 [syntax-check]
+test.yaml:15:15: expected scalar node for string value but found mapping node with "!!map" tag. alias "Wrapper" refers to the anchor at line:12, column:9 [syntax-check]
+test.yaml:16:22: specifying action "example/action" in invalid format because ref is missing. available formats are "{owner}/{repo}@{ref}", "{owner}/{repo}/{path}@{ref}", "./{path}", or "$/{path}" [action]

--- a/testdata/err/alias_type_errors.yaml
+++ b/testdata/err/alias_type_errors.yaml
@@ -1,0 +1,17 @@
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - &Runner { uses: example/action@v1 }
+      - uses: *Runner
+      - uses: *Runner
+      - *Runner
+      - uses: &Action example/action@v1
+      - uses: *Action
+      - &Wrapper
+        uses: *Runner
+      - *Wrapper
+      - uses: *Wrapper
+      - &Bad { uses: example/action }
+      - *Bad

--- a/testdata/ok/alias_source_locations.yaml
+++ b/testdata/ok/alias_source_locations.yaml
@@ -1,0 +1,12 @@
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - &Runner { uses: example/action@v1 }
+      - *Runner
+      - uses: &Action example/action@v1
+      - uses: *Action
+      - run: &Script |
+          echo "${{ github.ref }}"
+      - run: *Script


### PR DESCRIPTION
Fixes #149.

A mapping alias used as `uses: *Runner` now reports the type mismatch at each incorrect alias use and includes the anchor location. Rejected `uses` values no longer produce a second error about an empty action reference.

Valid whole-step and scalar aliases still work. Errors inside anchored content retain their source locations. Regression tests cover repeated and nested aliases, scalar/sequence/mapping type checks, and literal-script source mappings. The checks documentation and changelog describe the behavior.

Validation:

- `go test ./...` on Windows with Go 1.26.5, ShellCheck 0.11.0 and Pyflakes 3.4.0.
- All 1,721 cached upstream conformance cases pass.
- `golangci-lint` 2.13.1, dprint, Comment Cop and `git diff --check` pass.
- Replayed the original reproduction: only the type errors at `7:15` and `8:15` remain.
- Checks documentation validated in NixOS WSL with Go 1.26.7.
